### PR TITLE
Add .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+script: mvn verify -Plinux
+jdk:
+ - oraclejdk8


### PR DESCRIPTION
Build Travis-CI for oracle JDK 8 only.