### PR TITLE
Don't try to parse the inbound request paths

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/Url.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Url.java
@@ -157,15 +157,7 @@ public final class Url implements Comparable<Url> {
      */
     public URI toURI() {
         try {
-            String auth = authority.map(Authority::toString).orElse(null);
-
-            String query = query()
-                    .map(q -> q.parameters().stream()
-                            .map(UrlQuery.Parameter::toString)
-                            .collect(joining("&")))
-                    .orElse(null);
-
-            return new URI(scheme, auth, path, query, fragment);
+            return new URI(toString());
         } catch (URISyntaxException e) {
             throw propagate(e);
         }
@@ -236,36 +228,7 @@ public final class Url implements Comparable<Url> {
      * @return the encoded url string
      */
     public String encodedUri() {
-        StringBuilder url = new StringBuilder();
-        if (authority.isPresent()) {
-            if (!isNullOrEmpty(scheme)) {
-                url.append(scheme).append("://");
-            }
-            url.append(authority.get());
-        }
-        url.append(encodePathAndQuery());
-        if (!isNullOrEmpty(fragment)) {
-            url.append("#").append(fragment);
-        }
-
-        return url.toString();
-    }
-
-    private String encodePathAndQuery() {
-        return encodePath(path()) + query.map(query -> "?" + query.encodedQuery()).orElse("");
-    }
-
-    private static String encodePath(String path) {
-        Iterable<String> pathElements = Splitter.on(PATH_DELIMITER).omitEmptyStrings().split(path);
-        StringBuilder encodedPath = new StringBuilder();
-        for (String pathElement : pathElements) {
-            encodedPath.append(PATH_DELIMITER);
-            encodedPath.append(encodePathElement(pathElement));
-        }
-        if (path.endsWith(PATH_DELIMITER)) {
-            encodedPath.append(PATH_DELIMITER);
-        }
-        return encodedPath.toString();
+        return toString();
     }
 
     private static CharSequence encodePathElement(String pathElement) {
@@ -490,7 +453,7 @@ public final class Url implements Comparable<Url> {
             return new Builder()
                     .scheme(uri.getScheme())
                     .authority(uri.getAuthority())
-                    .path(uri.getPath())
+                    .path(uri.getRawPath())
                     .rawQuery(uri.getRawQuery())
                     .fragment(uri.getFragment());
         }

--- a/components/api/src/test/java/com/hotels/styx/api/UrlTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/UrlTest.java
@@ -149,7 +149,7 @@ public class UrlTest {
     public void handlesPathSegmentEncodedInUTF8() {
         Url url = url("http://example.com/foo/\u2603")
                 .build();
-        assertThat(url.encodedUri(), is("http://example.com/foo/%E2%98%83"));
+        assertThat(url.encodedUri(), is("http://example.com/foo/\u2603"));
     }
 
     @Test
@@ -248,6 +248,15 @@ public class UrlTest {
         String path = "/customercare/subscribe.html" + character + "sessid=nXF5jQ8rTW3bAbh6djb2hYJE3D.web-app-02";
         assertThat(url(path).build().encodedUri(), is(path));
     }
+    @Test
+    public void spaceIsAlsoPlusIsAlsoHex20() {
+        String ENCODED_SPACE = "/customercare/subscribe.html%20sessid=nXF5jQ8rTW3bAbh6djb2hYJE3D.web-app-02";
+
+        String path = "/customercare/subscribe.html+sessid=nXF5jQ8rTW3bAbh6djb2hYJE3D.web-app-02";
+        assertThat(url(path).build().encodedUri(), is(path));
+
+        assertThat(url(ENCODED_SPACE).build().encodedUri(), is(ENCODED_SPACE));
+    }
 
     @Test
     public void shouldCreateAValidUrlIfAuthorityIsMissing() {
@@ -265,6 +274,18 @@ public class UrlTest {
 
         assertThat(url.encodedUri(), is("/webapp/assets/images/icons.eot?"));
         assertThat(url.queryParams().isEmpty(), is(true));
+    }
+
+    @Test
+    public void exposesDecodedPath() throws Exception {
+        Url url = Url.Builder.url("http://localhost/foo%20bar").build();
+        assertThat(url.toURI().getPath(), is("/foo bar"));
+    }
+
+    @Test
+    public void exposesRawPath() throws Exception {
+        Url url = Url.Builder.url("http://localhost/foo%20bar").build();
+        assertThat(url.toURI().getRawPath(), is("/foo%20bar"));
     }
 
     @DataProvider(name = "pathSegmentAllowedChars")

--- a/components/client/src/main/java/com/hotels/styx/client/netty/HttpRequestOperation.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/HttpRequestOperation.java
@@ -109,7 +109,7 @@ public class HttpRequestOperation implements Operation<NettyConnection, HttpResp
 
     @VisibleForTesting
     static DefaultHttpRequest toNettyRequest(HttpRequest request) {
-        DefaultHttpRequest nettyRequest = new DefaultHttpRequest(request.version(), request.method(), request.url().encodedUri(), false);
+        DefaultHttpRequest nettyRequest = new DefaultHttpRequest(request.version(), request.method(), request.url().toString(), false);
 
         request.headers().forEach((name, value) ->
                 nettyRequest.headers().add(name, value));

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/HttpRequestOperationTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/HttpRequestOperationTest.java
@@ -31,12 +31,12 @@ public class HttpRequestOperationTest {
                 .header("X-Forwarded-Proto", "https")
                 .addCookie("HASESSION_V3", "asdasdasd")
                 .addCookie("has", "123456789")
-                .uri("https://www.example.com/foo")
+                .uri("https://www.example.com/foo%2Cbar?foo,baf=2")
                 .build();
 
         DefaultHttpRequest nettyRequest = HttpRequestOperation.toNettyRequest(request);
         assertThat(nettyRequest.getMethod(), is(GET));
-        assertThat(nettyRequest.getUri(), is("https://www.example.com/foo"));
+        assertThat(nettyRequest.getUri(), is("https://www.example.com/foo%2Cbar?foo%2Cbaf=2"));
         assertThat(nettyRequest.headers().get("X-Forwarded-Proto"), is("https"));
         assertThat(nettyRequest.headers().getAll("Cookie"), contains("HASESSION_V3=asdasdasd; has=123456789"));
     }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/UnwiseCharactersSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/UnwiseCharactersSpec.scala
@@ -66,7 +66,7 @@ class UnwiseCharactersSpec extends FunSpec with StyxProxySpec {
 
       decodedRequest(req)
 
-      recordingBackend.verify(receivedRewrittenUrl("/url/unwiseQQblah"))
+      recordingBackend.verify(receivedRewrittenUrl("/url/unwise%51%51blah"))
       assertThat(logger.log(), hasItem(loggingEvent(WARN, "Value contains unwise chars. you should fix this. raw=/url/unwiseQQblah, escaped=/url/unwise%51%51blah.*")))
     }
   }


### PR DESCRIPTION
The test updatae in HttpRequestOperationTest is the validation of our bug.
/foo%2Cbar is the same as /foo,bar

Without this patch, styx converts the URL to the comma variant when it passes to the backend.
But the backend was expecting the %2C version and issues a redirect back to the %2C. This causes a redirect loop.