### PR TITLE
Enable Maven quality profile for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
-script: mvn verify -Plinux
+script: mvn verify -Pquality,linux
 jdk:
  - oraclejdk8

--- a/components/api/src/main/java/com/hotels/styx/api/HttpInterceptor.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpInterceptor.java
@@ -50,8 +50,8 @@ public interface HttpInterceptor {
         @Deprecated
         <T> T get(String key, Class<T> clazz);
 
-        default <T> Optional<T> getIfAvailable(String key, Class<T> clazz){
-            return Optional.ofNullable(get(key,clazz));
+        default <T> Optional<T> getIfAvailable(String key, Class<T> clazz) {
+            return Optional.ofNullable(get(key, clazz));
         }
 
         Context EMPTY = new Context() {

--- a/components/api/src/main/java/com/hotels/styx/api/http/handlers/CachedBodyHttpHandler.java
+++ b/components/api/src/main/java/com/hotels/styx/api/http/handlers/CachedBodyHttpHandler.java
@@ -79,6 +79,9 @@ public class CachedBodyHttpHandler extends BaseHttpHandler {
         }
     }
 
+    /**
+     * A builder for CachedBodyHttpHandler class.
+     */
     public static final class Builder {
         private final Supplier<String> contentSupplier;
 

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/sets/NettyAllocatorMetricSet.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/sets/NettyAllocatorMetricSet.java
@@ -23,10 +23,9 @@ import io.netty.buffer.ByteBufAllocatorMetric;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.codahale.metrics.SharedMetricRegistries.names;
 import static com.google.common.collect.ImmutableMap.copyOf;
 import static com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry.name;
-import static java.util.Objects.*;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Creates a set of gauges that monitor metrics of netty {#ByteBufAllocatorMetric} instance.

--- a/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/sets/NettyAllocatorMetricSetTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/sets/NettyAllocatorMetricSetTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2013-2017 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hotels.styx.metrics.reporting.sets;
 
 import com.codahale.metrics.Gauge;


### PR DESCRIPTION
Enable Maven quality profile for Travis builds, and fix the CheckStyle issues that were introduced due to missing profile.
