### PR TITLE
Map OutOfDirectMemoryError to 500 Internal Server Error status code.

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/StyxClientError.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxClientError.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2013-2017 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.styx.client;
+
+/**
+ * Signifies an unexpected error from StyxClient.
+ *
+ * A root cause for the error is stored in the `cause` field.
+ * This could be thrown for example if StyxClient runs out of
+ * direct memory.
+ *
+ */
+public class StyxClientError extends RuntimeException {
+    public StyxClientError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/components/client/src/main/java/com/hotels/styx/client/StyxClientException.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxClientException.java
@@ -16,15 +16,15 @@
 package com.hotels.styx.client;
 
 /**
- * Signifies an unexpected error from StyxClient.
+ * Signifies an unexpected exception from StyxClient.
  *
  * A root cause for the error is stored in the `cause` field.
  * This could be thrown for example if StyxClient runs out of
  * direct memory.
  *
  */
-public class StyxClientError extends RuntimeException {
-    public StyxClientError(String message, Throwable cause) {
+public class StyxClientException extends RuntimeException {
+    public StyxClientException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/components/client/src/main/java/com/hotels/styx/client/netty/NettyToStyxResponsePropagator.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/NettyToStyxResponsePropagator.java
@@ -24,6 +24,7 @@ import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.api.netty.exceptions.ResponseTimeoutException;
 import com.hotels.styx.api.netty.exceptions.TransportLostException;
 import com.hotels.styx.client.BadHttpResponseException;
+import com.hotels.styx.client.StyxClientError;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.ChannelHandlerContext;
@@ -104,7 +105,15 @@ final class NettyToStyxResponsePropagator extends SimpleChannelInboundHandler {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         ensureContentProducerIsCreated(ctx);
-        contentProducer.ifPresent(producer -> producer.channelException(new BadHttpResponseException(origin, cause)));
+        contentProducer.ifPresent(producer -> producer.channelException(toStyxException(cause)));
+    }
+
+    private RuntimeException toStyxException(Throwable cause) {
+        if (cause instanceof OutOfMemoryError) {
+            return new StyxClientError("Styx Client: Not enough memory.", cause);
+        } else {
+            return new BadHttpResponseException(origin, cause);
+        }
     }
 
     @Override

--- a/components/client/src/main/java/com/hotels/styx/client/netty/NettyToStyxResponsePropagator.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/NettyToStyxResponsePropagator.java
@@ -24,7 +24,7 @@ import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.api.netty.exceptions.ResponseTimeoutException;
 import com.hotels.styx.api.netty.exceptions.TransportLostException;
 import com.hotels.styx.client.BadHttpResponseException;
-import com.hotels.styx.client.StyxClientError;
+import com.hotels.styx.client.StyxClientException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.ChannelHandlerContext;
@@ -110,7 +110,7 @@ final class NettyToStyxResponsePropagator extends SimpleChannelInboundHandler {
 
     private RuntimeException toStyxException(Throwable cause) {
         if (cause instanceof OutOfMemoryError) {
-            return new StyxClientError("Styx Client: Not enough memory.", cause);
+            return new StyxClientException("Styx Client out of memory. " + cause.getMessage(), cause);
         } else {
             return new BadHttpResponseException(origin, cause);
         }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/NettyToStyxResponsePropagatorTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/NettyToStyxResponsePropagatorTest.java
@@ -15,17 +15,20 @@
  */
 package com.hotels.styx.client.netty;
 
+import com.google.common.base.Throwables;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.api.netty.exceptions.ResponseTimeoutException;
 import com.hotels.styx.api.netty.exceptions.TransportLostException;
 import com.hotels.styx.client.BadHttpResponseException;
+import com.hotels.styx.client.StyxClientError;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.util.internal.OutOfDirectMemoryError;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -34,6 +37,7 @@ import rx.observers.TestSubscriber;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Optional;
 
@@ -265,6 +269,27 @@ public class NettyToStyxResponsePropagatorTest {
         channel.pipeline().fireExceptionCaught(new RuntimeException("Some Error"));
 
         assertThat(httpContentOne.refCnt(), is(0));
+    }
+
+    @Test
+    public void mapsOutOfDirectMemoryExceptionsToResourceExhaustedException() throws Exception {
+        EmbeddedChannel channel = new EmbeddedChannel(new NettyToStyxResponsePropagator(responseSubscriber, SOME_ORIGIN));
+        channel.writeInbound(new DefaultHttpResponse(HTTP_1_1, OK));
+
+        channel.pipeline().fireExceptionCaught(newOutOfDirectMemoryError("Simulated out of direct memory error in a test."));
+
+        assertThat(responseSubscriber.getOnErrorEvents().get(0), is(instanceOf(StyxClientError.class)));
+    }
+
+    private OutOfDirectMemoryError newOutOfDirectMemoryError(String message) throws InstantiationException, IllegalAccessException, java.lang.reflect.InvocationTargetException {
+        Constructor<OutOfDirectMemoryError> constructor = null;
+        try {
+            constructor = OutOfDirectMemoryError.class.getDeclaredConstructor(String.class);
+        } catch (NoSuchMethodException e) {
+            Throwables.propagate(e);
+        }
+        constructor.setAccessible(true);
+        return constructor.newInstance("message");
     }
 
     @Test

--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -32,7 +32,7 @@ import com.hotels.styx.api.netty.exceptions.ResponseTimeoutException;
 import com.hotels.styx.api.netty.exceptions.TransportLostException;
 import com.hotels.styx.api.plugins.spi.PluginException;
 import com.hotels.styx.client.BadHttpResponseException;
-import com.hotels.styx.client.StyxClientError;
+import com.hotels.styx.client.StyxClientException;
 import com.hotels.styx.client.connectionpool.ResourceExhaustedException;
 import com.hotels.styx.client.netty.ConsumerDisconnectedException;
 import com.hotels.styx.common.QueueDrainingEventProcessor;
@@ -95,7 +95,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
             )
             .add(SERVICE_UNAVAILABLE, ResourceExhaustedException.class)
             .add(GATEWAY_TIMEOUT, ResponseTimeoutException.class)
-            .add(INTERNAL_SERVER_ERROR, StyxClientError.class)
+            .add(INTERNAL_SERVER_ERROR, StyxClientException.class)
             .build();
 
     private final HttpHandler2 httpPipeline;

--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -32,6 +32,7 @@ import com.hotels.styx.api.netty.exceptions.ResponseTimeoutException;
 import com.hotels.styx.api.netty.exceptions.TransportLostException;
 import com.hotels.styx.api.plugins.spi.PluginException;
 import com.hotels.styx.client.BadHttpResponseException;
+import com.hotels.styx.client.StyxClientError;
 import com.hotels.styx.client.connectionpool.ResourceExhaustedException;
 import com.hotels.styx.client.netty.ConsumerDisconnectedException;
 import com.hotels.styx.common.QueueDrainingEventProcessor;
@@ -94,6 +95,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
             )
             .add(SERVICE_UNAVAILABLE, ResourceExhaustedException.class)
             .add(GATEWAY_TIMEOUT, ResponseTimeoutException.class)
+            .add(INTERNAL_SERVER_ERROR, StyxClientError.class)
             .build();
 
     private final HttpHandler2 httpPipeline;

--- a/components/server/src/test/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandlerTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandlerTest.java
@@ -24,7 +24,7 @@ import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.metrics.HttpErrorStatusListener;
 import com.hotels.styx.api.metrics.RequestStatsCollector;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
-import com.hotels.styx.client.StyxClientError;
+import com.hotels.styx.client.StyxClientException;
 import com.hotels.styx.server.BadRequestException;
 import com.hotels.styx.server.RequestTimeoutException;
 import com.hotels.styx.server.netty.codec.NettyToStyxRequestDecoder;
@@ -625,11 +625,11 @@ public class HttpPipelineHandlerTest {
     @Test
     public void mapsStyxClientExceptionToInternalServerErrorInWaitingForResponseState() throws Exception {
         // In Waiting For Response state,
-        // The response observable emits a StyxClientError.
+        // The response observable emits a StyxClientException.
         // Then, respond with INTERNAL_SERVER_ERROR and close the channel.
         setupHandlerTo(WAITING_FOR_RESPONSE);
 
-        responseObservable.onError(new StyxClientError("Client error occurred", new RuntimeException("Something went wrong")));
+        responseObservable.onError(new StyxClientException("Client error occurred", new RuntimeException("Something went wrong")));
 
         assertThat(responseUnsubscribed.get(), is(true));
         verify(responseWriter).write(response(INTERNAL_SERVER_ERROR)

--- a/components/server/src/test/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandlerTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandlerTest.java
@@ -24,6 +24,7 @@ import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.metrics.HttpErrorStatusListener;
 import com.hotels.styx.api.metrics.RequestStatsCollector;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
+import com.hotels.styx.client.StyxClientError;
 import com.hotels.styx.server.BadRequestException;
 import com.hotels.styx.server.RequestTimeoutException;
 import com.hotels.styx.server.netty.codec.NettyToStyxRequestDecoder;
@@ -76,7 +77,6 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
 import static io.netty.handler.codec.http.HttpResponseStatus.REQUEST_TIMEOUT;
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
@@ -221,10 +221,6 @@ public class HttpPipelineHandlerTest {
 
     @Test
     public void mapsUnrecoverableInternalErrorsToInternalServerError500ResponseCode() {
-        HttpInterceptor filter = (request, chain) -> {
-            throw new RuntimeException("Forced exception for testing");
-        };
-
         HttpHandler2 handler = (request, context) -> {
             throw new RuntimeException("Forced exception for testing");
         };
@@ -620,6 +616,30 @@ public class HttpPipelineHandlerTest {
         writerFuture.complete(null);
         verify(statsCollector).onComplete(request.id(), 502);
         verify(errorListener).proxyErrorOccurred(any(HttpRequest.class), eq(BAD_GATEWAY), any(RuntimeException.class));
+
+        // NOTE: channel closure is not verified. This is because cannot mock channel future.
+        verify(ctx).close();
+        assertThat(handler.state(), is(TERMINATED));
+    }
+
+    @Test
+    public void mapsStyxClientExceptionToInternalServerErrorInWaitingForResponseState() throws Exception {
+        // In Waiting For Response state,
+        // The response observable emits a StyxClientError.
+        // Then, respond with INTERNAL_SERVER_ERROR and close the channel.
+        setupHandlerTo(WAITING_FOR_RESPONSE);
+
+        responseObservable.onError(new StyxClientError("Client error occurred", new RuntimeException("Something went wrong")));
+
+        assertThat(responseUnsubscribed.get(), is(true));
+        verify(responseWriter).write(response(INTERNAL_SERVER_ERROR)
+                .header(CONTENT_LENGTH, "29")
+                .body("Site temporarily unavailable.")
+                .build());
+
+        writerFuture.complete(null);
+        verify(statsCollector).onComplete(request.id(), 500);
+        verify(errorListener).proxyErrorOccurred(any(HttpRequest.class), eq(INTERNAL_SERVER_ERROR), any(RuntimeException.class));
 
         // NOTE: channel closure is not verified. This is because cannot mock channel future.
         verify(ctx).close();


### PR DESCRIPTION
Fixes an issue where an OutOfDirectMemoryError in Styx Client is mistakenly treated as a bad HTTP response from origin. It used to result a 502 Bad Gateway, but now results a more appropriate 500 Internal Server Error.

Q: You might ask what is the point of attempting to respond when Styx has already ran out of direct memory? 

A: We have discovered after upgrading to Netty 4.1 we started observing occasional OutOfDirectMemoryErrors, which don't appear to be fatal. Styx appears to straight away recover to serve the next request without problems. (At the moment we suspect this is a direct memory sizing issue.)

