### PR TITLE
Styx server tls protocol

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/client/UrlConnectionHttpClient.java
+++ b/components/api/src/main/java/com/hotels/styx/api/client/UrlConnectionHttpClient.java
@@ -81,7 +81,18 @@ public class UrlConnectionHttpClient implements HttpClient {
      * @param readTimeoutMillis    socket read/write timeout in milliseconds
      */
     public UrlConnectionHttpClient(int connectTimeoutMillis, int readTimeoutMillis) {
-        this(connectTimeoutMillis, readTimeoutMillis, sslSocketFactory());
+        this(connectTimeoutMillis, readTimeoutMillis, sslSocketFactory("TLS"));
+    }
+
+    /**
+     * Constructs a new client.
+     *
+     * @param connectTimeoutMillis socket connection timeout in milliseconds
+     * @param readTimeoutMillis    socket read/write timeout in milliseconds
+     * @param protocol             supported TLS protocol, TLSv1.1, TLSv1.2, etc.
+     */
+    public UrlConnectionHttpClient(int connectTimeoutMillis, int readTimeoutMillis, String protocol) {
+        this(connectTimeoutMillis, readTimeoutMillis, sslSocketFactory(protocol));
     }
 
     private UrlConnectionHttpClient(int connectTimeoutMillis, int readTimeoutMillis, SSLSocketFactory sslSocketFactory) {
@@ -90,9 +101,9 @@ public class UrlConnectionHttpClient implements HttpClient {
         this.sslSocketFactory = checkNotNull(sslSocketFactory);
     }
 
-    private static SSLSocketFactory sslSocketFactory() {
+    private static SSLSocketFactory sslSocketFactory(String protocol) {
         try {
-            SSLContext context = SSLContext.getInstance("TLS");
+            SSLContext context = SSLContext.getInstance(protocol);
             context.init(null, new TrustManager[]{TRUST_ALL}, new SecureRandom());
             return context.getSocketFactory();
         } catch (KeyManagementException | NoSuchAlgorithmException e) {

--- a/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
@@ -19,7 +19,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.hotels.styx.api.common.Joiners;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -45,6 +48,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
     private final Iterable<String> cipherSuites;
     private final long sessionTimeoutMillis;
     private final long sessionCacheSize;
+    private final List<String> protocols;
 
     private HttpsConnectorConfig(Builder builder) {
         super(builder.port);
@@ -54,6 +58,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
         this.cipherSuites = Objects.firstNonNull(builder.cipherSuites, DEFAULT_CIPHER_SUITES);
         this.sessionTimeoutMillis = builder.sessionTimeoutMillis;
         this.sessionCacheSize = builder.sessionCacheSize;
+        this.protocols = builder.protocols;
     }
 
     @Override
@@ -83,6 +88,10 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
 
     public long sessionCacheSize() {
         return sessionCacheSize;
+    }
+
+    public List<String> protocols() {
+        return protocols;
     }
 
     @Override
@@ -119,6 +128,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
                 .add("sessionTimeoutMillis", sessionTimeoutMillis)
                 .add("sessionCacheSize", sessionCacheSize)
                 .add("cipherSuites", cipherSuites)
+                .add("protocols", protocols != null ? Joiners.JOINER_ON_COMMA.join(protocols) : "None")
                 .toString();
     }
 
@@ -156,6 +166,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
         private long sessionTimeoutMillis = 300_000;
         private long sessionCacheSize;
         private List<String> cipherSuites;
+        private List<String> protocols = Collections.emptyList();
 
         @JsonProperty("port")
         public Builder port(int port) {
@@ -190,6 +201,11 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
 
         public Builder sessionCacheSize(long sessionCacheSize) {
             this.sessionCacheSize = sessionCacheSize;
+            return this;
+        }
+
+        public Builder protocols(String... protocols) {
+            this.protocols = ImmutableList.copyOf(protocols);
             return this;
         }
 

--- a/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.common.Joiners;
 
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -31,21 +30,16 @@ import static com.google.common.base.Objects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.hotels.styx.api.io.ResourceFactory.newResource;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Https Connector configuration.
  */
 @JsonDeserialize(builder = HttpsConnectorConfig.Builder.class)
 public final class HttpsConnectorConfig extends HttpConnectorConfig {
-    private static final Iterable<String> DEFAULT_CIPHER_SUITES = EnumSet.allOf(CipherSuite.class).stream()
-            .map(CipherSuite::name)
-            .collect(toSet());
-
     private final String sslProvider;
     private final String certificateFile;
     private final String certificateKeyFile;
-    private final Iterable<String> cipherSuites;
+    private final List<String> cipherSuites;
     private final long sessionTimeoutMillis;
     private final long sessionCacheSize;
     private final List<String> protocols;
@@ -55,7 +49,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
         this.sslProvider = builder.sslProvider;
         this.certificateFile = builder.certificateFile;
         this.certificateKeyFile = builder.certificateKeyFile;
-        this.cipherSuites = Objects.firstNonNull(builder.cipherSuites, DEFAULT_CIPHER_SUITES);
+        this.cipherSuites = builder.cipherSuites;
         this.sessionTimeoutMillis = builder.sessionTimeoutMillis;
         this.sessionCacheSize = builder.sessionCacheSize;
         this.protocols = builder.protocols;
@@ -78,7 +72,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
         return certificateKeyFile;
     }
 
-    public Iterable<String> ciphers() {
+    public List<String> ciphers() {
         return cipherSuites;
     }
 
@@ -137,23 +131,6 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
     }
 
     /**
-     * Supported cipher suites are in order of preference.
-     */
-    public enum CipherSuite {
-        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
-        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-        TLS_RSA_WITH_AES_256_GCM_SHA384,
-        TLS_RSA_WITH_AES_128_GCM_SHA256,
-        TLS_RSA_WITH_AES_256_CBC_SHA256,
-        TLS_RSA_WITH_AES_128_CBC_SHA256,
-        TLS_RSA_WITH_AES_128_CBC_SHA;
-    }
-
-    /**
      * Builder for {@link HttpsConnectorConfig}.
      */
     @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -165,7 +142,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
         private String certificateKeyFile;
         private long sessionTimeoutMillis = 300_000;
         private long sessionCacheSize;
-        private List<String> cipherSuites;
+        private List<String> cipherSuites = Collections.emptyList();
         private List<String> protocols = Collections.emptyList();
 
         @JsonProperty("port")

--- a/components/server/src/main/java/com/hotels/styx/server/netty/SslContexts.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/SslContexts.java
@@ -100,24 +100,24 @@ public final class SslContexts {
     private static SslContextBuilder sslContextFromSelfSignedCertificate(HttpsConnectorConfig httpsConnectorConfig) {
         SelfSignedCertificate certificate = newSelfSignedCertificate();
         return SslContextBuilder.forServer(certificate.certificate(), certificate.privateKey())
-                .protocols(toSslContextProtocols(httpsConnectorConfig.protocols()))
+                .protocols(toProtocolsOrDefault(httpsConnectorConfig.protocols()))
                 .sslProvider(SslProvider.valueOf(httpsConnectorConfig.sslProvider()));
     }
 
     private static SslContextBuilder sslContextFromConfiguration(HttpsConnectorConfig httpsConnectorConfig) {
         return SslContextBuilder.forServer(new File(httpsConnectorConfig.certificateFile()), new File(httpsConnectorConfig.certificateKeyFile()))
                 .sslProvider(SslProvider.valueOf(httpsConnectorConfig.sslProvider()))
-                .ciphers(httpsConnectorConfig.ciphers())
+                .ciphers(toCiphersOrDefault(httpsConnectorConfig.ciphers()))
                 .sessionTimeout(MILLISECONDS.toSeconds(httpsConnectorConfig.sessionTimeoutMillis()))
                 .sessionCacheSize(httpsConnectorConfig.sessionCacheSize())
-                .protocols(toSslContextProtocols(httpsConnectorConfig.protocols()));
+                .protocols(toProtocolsOrDefault(httpsConnectorConfig.protocols()));
     }
 
-    private static String[] toSslContextProtocols(List<String> elems) {
-        if (elems != null && elems.size() > 0) {
-            return elems.toArray(new String[elems.size()]);
-        } else {
-            return null;
-        }
+    private static Iterable<String> toCiphersOrDefault(List<String> ciphers) {
+        return ciphers.isEmpty() ? null : ciphers;
+    }
+
+    private static String[] toProtocolsOrDefault(List<String> elems) {
+        return (elems != null && elems.size() > 0) ? elems.toArray(new String[elems.size()]) : null;
     }
 }

--- a/components/server/src/main/java/com/hotels/styx/server/netty/SslContexts.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/SslContexts.java
@@ -29,6 +29,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSessionContext;
 import java.io.File;
 import java.security.cert.CertificateException;
+import java.util.List;
 
 import static com.google.common.base.Throwables.propagate;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -99,6 +100,7 @@ public final class SslContexts {
     private static SslContextBuilder sslContextFromSelfSignedCertificate(HttpsConnectorConfig httpsConnectorConfig) {
         SelfSignedCertificate certificate = newSelfSignedCertificate();
         return SslContextBuilder.forServer(certificate.certificate(), certificate.privateKey())
+                .protocols(toSslContextProtocols(httpsConnectorConfig.protocols()))
                 .sslProvider(SslProvider.valueOf(httpsConnectorConfig.sslProvider()));
     }
 
@@ -107,6 +109,15 @@ public final class SslContexts {
                 .sslProvider(SslProvider.valueOf(httpsConnectorConfig.sslProvider()))
                 .ciphers(httpsConnectorConfig.ciphers())
                 .sessionTimeout(MILLISECONDS.toSeconds(httpsConnectorConfig.sessionTimeoutMillis()))
-                .sessionCacheSize(httpsConnectorConfig.sessionCacheSize());
+                .sessionCacheSize(httpsConnectorConfig.sessionCacheSize())
+                .protocols(toSslContextProtocols(httpsConnectorConfig.protocols()));
+    }
+
+    private static String[] toSslContextProtocols(List<String> elems) {
+        if (elems != null && elems.size() > 0) {
+            return elems.toArray(new String[elems.size()]);
+        } else {
+            return null;
+        }
     }
 }

--- a/components/server/src/main/java/com/hotels/styx/server/netty/SslContexts.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/SslContexts.java
@@ -118,6 +118,8 @@ public final class SslContexts {
     }
 
     private static String[] toProtocolsOrDefault(List<String> elems) {
-        return (elems != null && elems.size() > 0) ? elems.toArray(new String[elems.size()]) : null;
+        return (elems != null && elems.size() > 0)
+                ? elems.toArray(new String[elems.size()])
+                : null;
     }
 }

--- a/docs/user-guide/configure-tls.md
+++ b/docs/user-guide/configure-tls.md
@@ -55,11 +55,9 @@ TLS-protected HTTPS ports simultaneously.
     objects, in seconds. Set `0` to use the default value.
     This is an optional attribute. When absent, it reverts to a default value.
 
-  - *cipherSuites* - Specifies the cipher suites to enable, in the order
-    of preference. Leave absent to use default cipher suites. Note that
-    cipher suite names are specific to the enabled `sslProvider`. `JDK` and
-    `OPENSSL` support different cipher suites, and they may use different
-    names for the same cipher suite.
+  - *cipherSuites* - A list of enabled cipher suites, in order
+    of preference. Leave absent to use the SSL provider defaults.
+    Note that the cipher suite names are specific to a SSL provider.
 
   - *protocols* - A list of TLS protocol versions to use.
     Use this attribute to enforce a more secure version like `TLSv1.2`.

--- a/docs/user-guide/configure-tls.md
+++ b/docs/user-guide/configure-tls.md
@@ -62,7 +62,7 @@ TLS-protected HTTPS ports simultaneously.
   - *protocols* - A list of TLS protocol versions to use.
     Use this attribute to enforce a more secure version like `TLSv1.2`.
     In this case Styx will only accept connections secured with `TLSv1.2`,
-    and willo reject any connection attempts with older versions.
+    and will reject any connection attempts with older versions.
     When absent, enables all default protocols depending on the `sslProvider`.
     Possible protocol names are: `TLS`, `TLSv1`, `TLSv1.1`, and `TLSv1.2`.
 

--- a/docs/user-guide/configure-tls.md
+++ b/docs/user-guide/configure-tls.md
@@ -25,6 +25,12 @@ TLS-protected HTTPS ports simultaneously.
         certificateKeyFile:   /conf/tls/testCredentials.key
         sessionTimeoutMillis: 300000
         sessionCacheSize:     20000
+        protocols:
+          - TLSv1.2
+        cipherSuites:
+          - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+          - ECDHE-RSA-AES256-GCM-SHA384
+          - ECDHE-RSA-AES128-GCM-SHA256
 ```
 
 
@@ -50,7 +56,20 @@ TLS-protected HTTPS ports simultaneously.
     This is an optional attribute. When absent, it reverts to a default value.
 
   - *cipherSuites* - Specifies the cipher suites to enable, in the order
-    of preference. Leave absent to use default cipher suites.
+    of preference. Leave absent to use default cipher suites. Note that
+    cipher suite names are specific to the enabled `sslProvider`. `JDK` and
+    `OPENSSL` support different cipher suites, and they may use different
+    names for the same cipher suite.
+
+  - *protocols* - A list of TLS protocol versions to use.
+    Use this attribute to enforce a more secure version like `TLSv1.2`.
+    In this case Styx will only accept connections secured with `TLSv1.2`,
+    and willo reject any connection attempts with older versions.
+    When absent, enables all default protocols depending on the `sslProvider`.
+    Possible protocol names are: `TLS`, `TLSv1`, `TLSv1.1`, and `TLSv1.2`.
+
+The accepted protocol names and cipher suite names for `JDK` provider
+are listed in [Oracle Java Cryptography Architecture documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html).
 
 
 ## Backend Applications Configuration

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxProxySpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxProxySpec.scala
@@ -18,8 +18,7 @@ package com.hotels.styx
 import com.hotels.styx.infrastructure.MemoryBackedRegistry
 import com.hotels.styx.plugins.PluginPipelineSpec
 import com.hotels.styx.support.{ImplicitStyxConversions, configuration}
-import com.hotels.styx.support.configuration.{ImplicitOriginConversions, StyxBackend}
-import com.hotels.styx.support.configuration.StyxConfig.startServer
+import com.hotels.styx.support.configuration.{ImplicitOriginConversions, StyxBackend, StyxBaseConfig}
 import org.scalatest._
 
 
@@ -38,7 +37,6 @@ trait StyxProxySpec extends StyxClientSupplier
 
   implicit class StyxServerOperations(val styxServer: StyxServer) extends StyxServerSupplements
     with BackendServicesRegistrySupplier {
-    def staticConfig = styxConfig
     def setBackends(backends: (String, StyxBackend)*): Unit = setBackends(backendsRegistry, backends:_*)
   }
 
@@ -48,7 +46,7 @@ trait StyxProxySpec extends StyxClientSupplier
   }
 
   override protected def beforeAll() = {
-    styxServer = startServer(styxConfig, backendsRegistry)
+    styxServer = styxConfig.startServer(backendsRegistry)
     println("Styx http port is: [%d]".format(styxServer.httpPort))
     println("Styx https port is: [%d]".format(styxServer.secureHttpPort))
   }
@@ -61,9 +59,9 @@ trait StyxProxySpec extends StyxClientSupplier
 }
 
 trait StyxConfiguration {
-  def styxConfig: configuration.StyxConfig
+  def styxConfig: StyxBaseConfig
 }
 
 trait DefaultStyxConfiguration extends StyxConfiguration {
-  lazy val styxConfig = configuration.StyxConfig()
+  lazy val styxConfig: StyxBaseConfig = configuration.StyxConfig()
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxProxySpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxProxySpec.scala
@@ -49,11 +49,13 @@ trait StyxProxySpec extends StyxClientSupplier
 
   override protected def beforeAll() = {
     styxServer = startServer(styxConfig, backendsRegistry)
-    println("Styx port is: [%d]".format(styxServer.httpPort))
+    println("Styx http port is: [%d]".format(styxServer.httpPort))
+    println("Styx https port is: [%d]".format(styxServer.secureHttpPort))
   }
 
   override protected def afterAll() = {
-    println("Styx port was: [%d]".format(styxServer.httpPort))
+    println("Styx http port was: [%d]".format(styxServer.httpPort))
+    println("Styx https port was: [%d]".format(styxServer.secureHttpPort))
     styxServer.stopAsync().awaitTerminated()
   }
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxServerSupport.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxServerSupport.scala
@@ -122,20 +122,21 @@ trait StyxServerSupplements {
 
   def adminURL(path: String) = s"http://$adminHost$path"
 
-  def secureHttpPort = if(styxServer.proxyHttpsAddress() != null) {
-    styxServer.proxyHttpsAddress().getPort
-  } else {
-    -1
-  }
+  def secureHttpPort = portNumberOrElse(styxServer.proxyHttpsAddress())
 
-  def httpPort = styxServer.proxyHttpAddress().getPort
+  def httpPort = portNumberOrElse(styxServer.proxyHttpAddress())
 
-  def adminPort = styxServer.adminHttpAddress().getPort
+  def adminPort = portNumberOrElse(styxServer.adminHttpAddress())
 
   def metricsSnapshot = {
     val adminHostName = styxServer.adminHttpAddress().getHostName
     new CodaHaleMetricsFacade(StyxMetrics.downloadFrom(adminHostName, adminPort))
   }
+
+  private def portNumberOrElse(address: InetSocketAddress) = Option(address)
+    .map(_.getPort)
+    .orElse(Some(-1))
+    .get
 }
 
 class PluginAdapter extends Plugin {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxServerSupport.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxServerSupport.scala
@@ -122,7 +122,11 @@ trait StyxServerSupplements {
 
   def adminURL(path: String) = s"http://$adminHost$path"
 
-  def secureHttpPort = styxServer.proxyHttpsAddress().getPort
+  def secureHttpPort = if(styxServer.proxyHttpsAddress() != null) {
+    styxServer.proxyHttpsAddress().getPort
+  } else {
+    -1
+  }
 
   def httpPort = styxServer.proxyHttpAddress().getPort
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/HealthCheckSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/HealthCheckSpec.scala
@@ -21,7 +21,6 @@ import com.hotels.styx.api.HttpInterceptor.Chain
 import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.api._
 import com.hotels.styx.infrastructure.HttpResponseImplicits
-import com.hotels.styx.proxy.ProtocolsSpec
 import com.hotels.styx.support.ResourcePaths.fixturesHome
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration._
@@ -39,7 +38,7 @@ class HealthCheckSpec extends FunSpec
   with Eventually {
 
   val originOne = FakeHttpServer.HttpStartupConfig(appId = "app", originId="h1").start()
-  val logback = fixturesHome(classOf[ProtocolsSpec], "/conf/logback/logback-suppress-errors.xml")
+  val logback = fixturesHome(this.getClass, "/conf/logback/logback-suppress-errors.xml")
 
   override val styxConfig = StyxConfig(
     plugins = List("faulty" -> new FaultyPlugin),

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/OriginsReloadCommandSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/OriginsReloadCommandSpec.scala
@@ -22,7 +22,6 @@ import com.google.common.io.Files.createTempDir
 import com.hotels.styx.api.HttpRequest
 import com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry
 import com.hotels.styx.support.ResourcePaths.fixturesHome
-import com.hotels.styx.support.configuration.StyxConfig.startServer
 import com.hotels.styx.support.configuration.{BackendService, ConnectionPoolSettings, HealthCheckConfig, Origin, Origins, StyxConfig}
 import com.hotels.styx.{StyxClientSupplier, StyxServer, StyxServerSupport}
 import io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST
@@ -47,7 +46,7 @@ class OriginsReloadCommandSpec extends FunSpec
 
   it("Responds with BAD_REQUEST when the origins cannot be read") {
     val fileBasedBackendsRegistry = new FileBackedBackendServicesRegistry(styxOriginsFile.toString)
-    styxServer = startServer(StyxConfig(), fileBasedBackendsRegistry)
+    styxServer = StyxConfig().startServer(fileBasedBackendsRegistry)
     styxServer.isRunning should be(true)
 
     Files.copy(originsNok, styxOriginsFile, REPLACE_EXISTING)

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/ErrorMetricsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/ErrorMetricsSpec.scala
@@ -38,7 +38,6 @@ import rx.functions.Func1
 
 import scala.compat.java8.OptionConverters.RichOptionalGeneric
 import scala.concurrent.duration._
-import com.hotels.styx.support.configuration.StyxConfig.startServer
 
 class ErrorMetricsSpec extends FunSpec
   with StyxServerSupport
@@ -73,7 +72,7 @@ class ErrorMetricsSpec extends FunSpec
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     backendsRegistry = new MemoryBackedRegistry[com.hotels.styx.client.applications.BackendService]
-    styxServer = startServer(styxConfig, backendsRegistry)
+    styxServer = styxConfig.startServer(backendsRegistry)
         setBackends(
           backendsRegistry,
           "/" -> HttpBackend(

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpMessageLoggingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpMessageLoggingSpec.scala
@@ -19,11 +19,11 @@ import ch.qos.logback.classic.Level._
 import com.github.tomakehurst.wiremock.client.WireMock.{get => _, _}
 import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.client.StyxHeaderConfig.ORIGIN_ID_DEFAULT
-import com.hotels.styx.support.matchers.LoggingEventMatcher._
-import com.hotels.styx.support.matchers.LoggingTestSupport
 import com.hotels.styx.support.ResourcePaths.fixturesHome
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration._
+import com.hotels.styx.support.matchers.LoggingEventMatcher._
+import com.hotels.styx.support.matchers.LoggingTestSupport
 import com.hotels.styx.support.server.UrlMatchingStrategies._
 import com.hotels.styx.{StyxClientSupplier, StyxProxySpec}
 import io.netty.handler.codec.http.HttpHeaders.Names._
@@ -41,8 +41,8 @@ class HttpMessageLoggingSpec extends FunSpec
   with StyxClientSupplier
   with Eventually {
 
-  val crtFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.crt").toString
-  val keyFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.key").toString
+  val crtFile = fixturesHome(this.getClass, "/ssl/testCredentials.crt").toString
+  val keyFile = fixturesHome(this.getClass, "/ssl/testCredentials.key").toString
 
   override val styxConfig = StyxConfig(
     ProxyConfig(

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpOutboundMessageLoggingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpOutboundMessageLoggingSpec.scala
@@ -18,11 +18,11 @@ package com.hotels.styx.proxy
 import ch.qos.logback.classic.Level._
 import com.github.tomakehurst.wiremock.client.WireMock.{get => _, _}
 import com.hotels.styx.api.HttpRequest.Builder.get
-import com.hotels.styx.support.matchers.LoggingEventMatcher._
-import com.hotels.styx.support.matchers.LoggingTestSupport
 import com.hotels.styx.support.ResourcePaths.fixturesHome
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration._
+import com.hotels.styx.support.matchers.LoggingEventMatcher._
+import com.hotels.styx.support.matchers.LoggingTestSupport
 import com.hotels.styx.support.server.UrlMatchingStrategies._
 import com.hotels.styx.{StyxClientSupplier, StyxProxySpec}
 import io.netty.handler.codec.http.HttpHeaders.Names._
@@ -40,8 +40,8 @@ class HttpOutboundMessageLoggingSpec extends FunSpec
   with StyxClientSupplier
   with Eventually {
 
-  val crtFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.crt").toString
-  val keyFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.key").toString
+  val crtFile = fixturesHome(this.getClass, "/ssl/testCredentials.crt").toString
+  val keyFile = fixturesHome(this.getClass, "/ssl/testCredentials.key").toString
 
   override val styxConfig = StyxConfig(
     ProxyConfig(

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ProxySpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ProxySpec.scala
@@ -26,7 +26,7 @@ import com.hotels.styx.support.matchers.RegExMatcher.matchesRegex
 import com.hotels.styx.api.support.HostAndPorts._
 import com.hotels.styx.api.{HttpRequest, HttpResponse}
 import com.hotels.styx.support.backends.FakeHttpServer
-import com.hotels.styx.support.configuration.{HttpBackend, Origins}
+import com.hotels.styx.support.configuration.{HttpBackend, Origin, Origins}
 import com.hotels.styx.support.server.UrlMatchingStrategies.urlStartingWith
 import com.hotels.styx.{DefaultStyxConfiguration, MockServer, StyxProxySpec}
 import io.netty.handler.codec.http.HttpHeaders.Names._
@@ -157,10 +157,9 @@ class ProxySpec extends FunSpec
 
     describe("backend services unavailable") {
       it("should return a 502 BAD_GATEWAY if the connection to the backend is refused") {
-        val unavailableService = new MockServer(freePort())
         styxServer.setBackends(
           "/" -> HttpBackend("app-1", Origins(recordingBackend)),
-          "/unavailable" -> HttpBackend("http10", Origins(unavailableService))
+          "/unavailable" -> HttpBackend("http10", Origins(Origin("localhost", freePort(), "app-1-01")))
         )
 
         val req = new Builder(GET, "/unavailable")

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/EmptyTlsProtocolsListSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/EmptyTlsProtocolsListSpec.scala
@@ -16,15 +16,15 @@
 package com.hotels.styx.proxy.https
 
 import com.github.tomakehurst.wiremock.client.WireMock._
+import com.hotels.styx.api.HttpClient
+import com.hotels.styx.api.HttpRequest.Builder
 import com.hotels.styx.api.client.UrlConnectionHttpClient
-import com.hotels.styx.api.{HttpClient, HttpRequest}
 import com.hotels.styx.infrastructure.HttpResponseImplicits
 import com.hotels.styx.support.ResourcePaths.fixturesHome
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration._
 import com.hotels.styx.{SSLSetup, StyxProxySpec}
 import io.netty.handler.codec.http.HttpHeaders.Names._
-import io.netty.handler.codec.http.HttpMethod._
 import io.netty.handler.codec.http.HttpResponseStatus.OK
 import org.scalatest.{FunSpec, ShouldMatchers}
 
@@ -70,7 +70,7 @@ class EmptyTlsProtocolsListSpec extends FunSpec
     recordingBackend.stub(urlPathEqualTo("/secure"), aResponse.withStatus(200))
 
     it("Empty TLS protocols list activates all supported protocols") {
-      val req = new HttpRequest.Builder(GET, styxServer.secureRouterURL("/secure"))
+      val req = Builder.get(styxServer.secureRouterURL("/secure"))
         .header(HOST, styxServer.httpsProxyHost)
         .secure(true)
         .build()

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/EmptyTlsProtocolsListSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/EmptyTlsProtocolsListSpec.scala
@@ -1,0 +1,90 @@
+/**
+  * Copyright (C) 2013-2017 Expedia Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package com.hotels.styx.proxy.https
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.hotels.styx.api.client.UrlConnectionHttpClient
+import com.hotels.styx.api.{HttpClient, HttpRequest}
+import com.hotels.styx.infrastructure.HttpResponseImplicits
+import com.hotels.styx.support.ResourcePaths.fixturesHome
+import com.hotels.styx.support.backends.FakeHttpServer
+import com.hotels.styx.support.configuration._
+import com.hotels.styx.{SSLSetup, StyxProxySpec}
+import io.netty.handler.codec.http.HttpHeaders.Names._
+import io.netty.handler.codec.http.HttpMethod._
+import io.netty.handler.codec.http.HttpResponseStatus.OK
+import org.scalatest.{FunSpec, ShouldMatchers}
+
+class EmptyTlsProtocolsListSpec extends FunSpec
+  with StyxProxySpec
+  with HttpResponseImplicits
+  with ShouldMatchers
+  with SSLSetup {
+
+  val crtFile = fixturesHome(this.getClass, "/ssl/testCredentials.crt").toString
+  val keyFile = fixturesHome(this.getClass, "/ssl/testCredentials.key").toString
+  val clientV12 = newClient("TLSv1.2")
+  val clientV11 = newClient("TLSv1.1")
+
+  override val styxConfig = StyxConfig(
+    ProxyConfig(
+      Connectors(
+        HttpConnectorConfig(),
+        HttpsConnectorConfig(
+          certificateFile = crtFile,
+          certificateKeyFile = keyFile,
+          protocols = List()
+        ))
+    )
+  )
+
+  val recordingBackend = FakeHttpServer.HttpsStartupConfig(needClientAuth = false)
+    .start()
+
+  override protected def beforeAll() = {
+    super.beforeAll()
+    styxServer.setBackends("/secure" -> HttpsBackend(
+      "https-app", Origins(recordingBackend), TlsSettings()
+    ))
+  }
+
+  override protected def afterAll() = {
+    recordingBackend.stop()
+    super.afterAll()
+  }
+
+  describe("Empty TLS protocols list") {
+    recordingBackend.stub(urlPathEqualTo("/secure"), aResponse.withStatus(200))
+
+    it("Empty TLS protocols list activates all supported protocols") {
+      val req = new HttpRequest.Builder(GET, styxServer.secureRouterURL("/secure"))
+        .header(HOST, styxServer.httpsProxyHost)
+        .secure(true)
+        .build()
+
+      val (resp1, _) = decodedRequestWithClient(clientV11, req)
+      resp1.status() should be(OK)
+
+      val (resp2, _) = decodedRequestWithClient(clientV12, req)
+      resp2.status() should be(OK)
+    }
+  }
+
+  def newClient(supportedProtocols: String): HttpClient = {
+    new UrlConnectionHttpClient(TWO_SECONDS, FIVE_SECONDS, supportedProtocols)
+  }
+
+}

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/HttpsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/HttpsSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hotels.styx.proxy
+package com.hotels.styx.proxy.https
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.hotels.styx.api.HttpHeaderNames.X_FORWARDED_PROTO
@@ -21,7 +21,7 @@ import com.hotels.styx.api.HttpRequest
 import com.hotels.styx.infrastructure.HttpResponseImplicits
 import com.hotels.styx.support.ResourcePaths.fixturesHome
 import com.hotels.styx.support.backends.FakeHttpServer
-import com.hotels.styx.support.configuration.{Connectors, HttpConnectorConfig, HttpsBackend, HttpsConnectorConfig, Origins, ProxyConfig, TlsSettings, StyxConfig}
+import com.hotels.styx.support.configuration._
 import com.hotels.styx.{SSLSetup, StyxClientSupplier, StyxProxySpec}
 import io.netty.handler.codec.http.HttpHeaders.Names._
 import io.netty.handler.codec.http.HttpMethod._
@@ -35,8 +35,8 @@ class HttpsSpec extends FunSpec
   with ShouldMatchers
   with SSLSetup {
 
-  val crtFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.crt").toString
-  val keyFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.key").toString
+  val crtFile = fixturesHome(this.getClass, "/ssl/testCredentials.crt").toString
+  val keyFile = fixturesHome(this.getClass, "/ssl/testCredentials.key").toString
 
   override val styxConfig = StyxConfig(
     ProxyConfig(

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/ProtocolsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/ProtocolsSpec.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hotels.styx.proxy
+package com.hotels.styx.proxy.https
 
 import java.nio.charset.StandardCharsets.UTF_8
 
@@ -22,9 +22,9 @@ import com.github.tomakehurst.wiremock.client.{ValueMatchingStrategy, WireMock}
 import com.hotels.styx.api.HttpHeaderNames.X_FORWARDED_PROTO
 import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.support.ResourcePaths.fixturesHome
-import com.hotels.styx.utils.StubOriginHeader.STUB_ORIGIN_INFO
 import com.hotels.styx.support.backends.FakeHttpServer
-import com.hotels.styx.support.configuration.{Connectors, HttpBackend, HttpConnectorConfig, HttpsBackend, HttpsConnectorConfig, Origins, ProxyConfig, StyxConfig, TlsSettings}
+import com.hotels.styx.support.configuration._
+import com.hotels.styx.utils.StubOriginHeader.STUB_ORIGIN_INFO
 import com.hotels.styx.{StyxClientSupplier, StyxProxySpec}
 import io.netty.buffer.{ByteBuf, Unpooled}
 import org.scalatest.{FunSpec, SequentialNestedSuiteExecution}
@@ -36,11 +36,11 @@ class ProtocolsSpec extends FunSpec
   with StyxClientSupplier
   with SequentialNestedSuiteExecution {
 
-  val logback = fixturesHome(classOf[ProtocolsSpec], "/conf/logback/logback-debug-stdout.xml")
-  val crtFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.crt").toString
-  val keyFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.key").toString
-  val keystore = fixturesHome(classOf[ProtocolsSpec], "/ssl/protocolsSpec/keystore").toString
-  val truststore = fixturesHome(classOf[ProtocolsSpec], "/ssl/protocolsSpec/truststore").toString
+  val logback = fixturesHome(this.getClass, "/conf/logback/logback-debug-stdout.xml")
+  val crtFile = fixturesHome(this.getClass, "/ssl/testCredentials.crt").toString
+  val keyFile = fixturesHome(this.getClass, "/ssl/testCredentials.key").toString
+  val keystore = fixturesHome(this.getClass, "/ssl/protocolsSpec/keystore").toString
+  val truststore = fixturesHome(this.getClass, "/ssl/protocolsSpec/truststore").toString
 
   val httpServer = FakeHttpServer.HttpStartupConfig(
     appId = "app",

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/Tls12Spec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/Tls12Spec.scala
@@ -39,16 +39,19 @@ class Tls12Spec extends FunSpec
   val clientV12 = newClient("TLSv1.2")
   val clientV11 = newClient("TLSv1.1")
 
-  override val styxConfig = StyxConfig(
-    ProxyConfig(
-      Connectors(
-        HttpConnectorConfig(),
-        HttpsConnectorConfig(
-          certificateFile = crtFile,
-          certificateKeyFile = keyFile,
-          protocols = List("TLSv1.2")
-        ))
-    )
+  override val styxConfig = StyxYamlConfig(
+    yamlConfig =
+      s"""
+        |proxy:
+        |  connectors:
+        |    https:
+        |      port: 8443
+        |      sslProvider: JDK
+        |      certificateFile: $crtFile
+        |      certificateKeyFile: $keyFile
+        |      protocols:
+        |       - TLSv1.2
+      """.stripMargin
   )
 
   val recordingBackend = FakeHttpServer.HttpsStartupConfig(needClientAuth = false)

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/Tls12Spec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/Tls12Spec.scala
@@ -1,0 +1,99 @@
+/**
+  * Copyright (C) 2013-2017 Expedia Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package com.hotels.styx.proxy.https
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.hotels.styx.api.client.UrlConnectionHttpClient
+import com.hotels.styx.api.{HttpClient, HttpRequest}
+import com.hotels.styx.infrastructure.HttpResponseImplicits
+import com.hotels.styx.support.ResourcePaths.fixturesHome
+import com.hotels.styx.support.backends.FakeHttpServer
+import com.hotels.styx.support.configuration._
+import com.hotels.styx.{SSLSetup, StyxProxySpec}
+import io.netty.handler.codec.http.HttpHeaders.Names._
+import io.netty.handler.codec.http.HttpMethod._
+import io.netty.handler.codec.http.HttpResponseStatus.OK
+import org.scalatest.{FunSpec, ShouldMatchers}
+
+class Tls12Spec extends FunSpec
+  with StyxProxySpec
+  with HttpResponseImplicits
+  with ShouldMatchers
+  with SSLSetup {
+
+  val crtFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.crt").toString
+  val keyFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.key").toString
+  val clientV12 = newClient("TLSv1.2")
+  val clientV11 = newClient("TLSv1.1")
+
+  override val styxConfig = StyxConfig(
+    ProxyConfig(
+      Connectors(
+        HttpConnectorConfig(),
+        HttpsConnectorConfig(
+          certificateFile = crtFile,
+          certificateKeyFile = keyFile,
+          protocols = List("TLSv1.2")
+        ))
+    )
+  )
+
+  val recordingBackend = FakeHttpServer.HttpsStartupConfig(needClientAuth = false)
+    .start()
+
+  override protected def beforeAll() = {
+    super.beforeAll()
+    styxServer.setBackends("/secure" -> HttpsBackend(
+      "https-app", Origins(recordingBackend), TlsSettings()
+    ))
+  }
+
+  override protected def afterAll() = {
+    recordingBackend.stop()
+    super.afterAll()
+  }
+
+  describe("TLS protocol restriction") {
+    recordingBackend.stub(urlPathEqualTo("/secure"), aResponse.withStatus(200))
+
+    it("Accepts TLS 1.2 only") {
+      val req = new HttpRequest.Builder(GET, styxServer.secureRouterURL("/secure"))
+        .header(HOST, styxServer.httpsProxyHost)
+        .secure(true)
+        .build()
+
+      val (resp, _) = decodedRequestWithClient(clientV12, req)
+
+      resp.status() should be(OK)
+    }
+
+    it("Refuses TLS 1.1 when TLS 1.2 is required") {
+      val req = new HttpRequest.Builder(GET, styxServer.secureRouterURL("/secure"))
+        .header(HOST, styxServer.httpsProxyHost)
+        .secure(true)
+        .build()
+
+      an[RuntimeException] should be thrownBy {
+        decodedRequestWithClient(clientV11, req)
+      }
+    }
+  }
+
+  def newClient(supportedProtocols: String): HttpClient = {
+    new UrlConnectionHttpClient(TWO_SECONDS, FIVE_SECONDS, supportedProtocols)
+  }
+
+}

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/Tls12Spec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/Tls12Spec.scala
@@ -45,7 +45,7 @@ class Tls12Spec extends FunSpec
         |proxy:
         |  connectors:
         |    https:
-        |      port: 8443
+        |      port: 0
         |      sslProvider: JDK
         |      certificateFile: $crtFile
         |      certificateKeyFile: $keyFile

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/LongDownloadsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/LongDownloadsSpec.scala
@@ -196,7 +196,7 @@ object SharedStyx extends BackendServicesRegistrySupplier with ImplicitOriginCon
 
   private val styxStartOp = Future {
     val backendsRegistry = new MemoryBackedRegistry[com.hotels.styx.client.applications.BackendService]
-    val styxServer = StyxConfig.startServer(StyxConfig(), backendsRegistry)
+    val styxServer = StyxConfig().startServer(backendsRegistry)
 
     setBackends(backendsRegistry, "/download" -> HttpBackend("myapp", Origins(SharedOrigins.fileServer), responseTimeout = 25.seconds))
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/ProxyResiliencySpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/ProxyResiliencySpec.scala
@@ -18,9 +18,8 @@ package com.hotels.styx.proxy.resiliency
 import java.util.concurrent.TimeUnit._
 
 import com.google.common.base.Charsets._
-import com.hotels.styx.{DefaultStyxConfiguration, StyxProxySpec}
+import com.hotels.styx.StyxProxySpec
 import com.hotels.styx.generators.HttpRequestGenerator
-import com.hotels.styx.proxy.ProtocolsSpec
 import com.hotels.styx.support.ResourcePaths.fixturesHome
 import com.hotels.styx.support.configuration.{HttpBackend, Origins, StyxConfig}
 import com.hotels.styx.support.{NettyOrigins, TestClientSupport}
@@ -46,7 +45,7 @@ class ProxyResiliencySpec extends FunSpec
 
   val (originOne, originOneServer) = originAndCustomResponseWebServer("NettyOrigin")
 
-  val logback = fixturesHome(classOf[ProtocolsSpec], "/conf/logback/logback-suppress-errors.xml")
+  val logback = fixturesHome(this.getClass, "/conf/logback/logback-suppress-errors.xml")
   override val styxConfig = StyxConfig(
     logbackXmlLocation = logback
   )

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/routing/ConditionRoutingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/routing/ConditionRoutingSpec.scala
@@ -19,11 +19,10 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.client.{ValueMatchingStrategy, WireMock}
 import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.infrastructure.MemoryBackedRegistry
-import com.hotels.styx.proxy.ProtocolsSpec
 import com.hotels.styx.support.ResourcePaths.fixturesHome
-import com.hotels.styx.utils.StubOriginHeader.STUB_ORIGIN_INFO
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration._
+import com.hotels.styx.utils.StubOriginHeader.STUB_ORIGIN_INFO
 import com.hotels.styx.{BackendServicesRegistrySupplier, StyxClientSupplier, StyxProxySpec}
 import org.scalatest.{FunSpec, SequentialNestedSuiteExecution}
 
@@ -35,11 +34,11 @@ class ConditionRoutingSpec extends FunSpec
   with SequentialNestedSuiteExecution
   with BackendServicesRegistrySupplier {
 
-  val logback = fixturesHome(classOf[ConditionRoutingSpec], "/conf/logback/logback-debug-stdout.xml")
+  val logback = fixturesHome(this.getClass, "/conf/logback/logback-debug-stdout.xml")
   val httpBackendRegistry = new MemoryBackedRegistry[com.hotels.styx.client.applications.BackendService]()
   val httpsBackendRegistry = new MemoryBackedRegistry[com.hotels.styx.client.applications.BackendService]()
-  val crtFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.crt").toString
-  val keyFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.key").toString
+  val crtFile = fixturesHome(this.getClass, "/ssl/testCredentials.crt").toString
+  val keyFile = fixturesHome(this.getClass, "/ssl/testCredentials.key").toString
 
   val httpServer = FakeHttpServer.HttpStartupConfig(
     appId = "app",

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/server/StyxServerStartupSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/server/StyxServerStartupSpec.scala
@@ -19,7 +19,6 @@ import com.hotels.styx.StyxClientSupplier
 import com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry
 import com.hotels.styx.support.ResourcePaths.fixturesHome
 import com.hotels.styx.support.configuration.StyxConfig
-import com.hotels.styx.support.configuration.StyxConfig.startServer
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, ShouldMatchers}
 
@@ -30,10 +29,9 @@ class StyxServerStartupSpec extends FunSpec
 
   val origins = fixturesHome(classOf[StyxServerStartupSpec], "/conf/origins/origins-incorrect.yml")
   val fileBasedBackendsRegistry = new FileBackedBackendServicesRegistry(origins.toString)
-  val styxConfig = StyxConfig()
 
   it ("should not start up when incorrect origins file is encountered") {
-    an [IllegalStateException] should be thrownBy startServer(styxConfig, fileBasedBackendsRegistry)
+    an [IllegalStateException] should be thrownBy StyxConfig().startServer(fileBasedBackendsRegistry)
   }
 
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/StyxConfig.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/StyxConfig.scala
@@ -1,30 +1,31 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+  * Copyright (C) 2013-2017 Expedia Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package com.hotels.styx.support.configuration
 
 import java.nio.file.Path
 
 import com.google.common.util.concurrent.Service
-import com.hotels.styx.StyxServer
 import com.hotels.styx.StyxServerSupport._
 import com.hotels.styx.api.support.HostAndPorts._
 import com.hotels.styx.infrastructure.Registry
+import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig
 import com.hotels.styx.proxy.ProxyServerConfig
 import com.hotels.styx.proxy.plugin.NamedPlugin
 import com.hotels.styx.support.ResourcePaths
+import com.hotels.styx.{StyxServer, StyxServerBuilder}
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
@@ -39,16 +40,42 @@ case class Connectors(httpConnectorConfig: HttpConnectorConfig,
   }
 }
 
+sealed trait StyxBaseConfig {
+  def logbackXmlLocation: Path
+
+  def startServer(backendsRegistry: Registry[com.hotels.styx.client.applications.BackendService]): StyxServer
+}
+
 case class StyxConfig(proxyConfig: ProxyConfig = ProxyConfig(),
                       plugins: List[NamedPlugin] = List(),
-                      logbackXmlLocation: Path = StyxConfig.defaultLogbackXml,
+                      logbackXmlLocation: Path = StyxBaseConfig.defaultLogbackXml,
                       yamlText: String = "originRestrictionCookie: \"originRestrictionCookie\"\n",
                       adminPort: Int = 0,
                       additionalServices: Map[String, Service] = Map.empty
-                     )
+                     ) extends StyxBaseConfig {
+  override def startServer(backendsRegistry: Registry[com.hotels.styx.client.applications.BackendService]): StyxServer = {
+    StyxConfig.startServer(this, backendsRegistry)
+  }
+}
+
+case class StyxYamlConfig(yamlConfig: String,
+                          logbackXmlLocation: Path = StyxBaseConfig.defaultLogbackXml
+                         ) extends StyxBaseConfig {
+  override def startServer(backendsRegistry: Registry[com.hotels.styx.client.applications.BackendService]): StyxServer = {
+    val config: YamlConfig = new YamlConfig(yamlConfig)
+    val styxConfig = new com.hotels.styx.StyxConfig(yamlConfig)
+    val styxServer = new StyxServerBuilder(styxConfig)
+      .logConfigLocation(logbackXmlLocation.toString).build()
+    styxServer.startAsync().awaitRunning()
+    styxServer
+  }
+}
+
+object StyxBaseConfig {
+  val defaultLogbackXml = ResourcePaths.fixturesHome(this.getClass, "/conf/logback/logback.xml")
+}
 
 object StyxConfig {
-  private val defaultLogbackXml = ResourcePaths.fixturesHome(this.getClass, "/conf/logback/logback.xml")
 
   private def adminPort(config: StyxConfig) = if (config.adminPort == 0) freePort() else config.adminPort
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/StyxServerConnector.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/StyxServerConnector.scala
@@ -34,7 +34,8 @@ case class HttpsConnectorConfig(port: Int = 0,
                                 certificateKeyFile: String = defaultHttpsConfig.certificateKeyFile(),
                                 cipherSuites: Seq[String] = defaultHttpsConfig.ciphers().asScala.toSeq,
                                 sessionTimeoutMillis: Long = defaultHttpsConfig.sessionTimeoutMillis(),
-                                sessionCacheSize: Long = defaultHttpsConfig.sessionCacheSize()
+                                sessionCacheSize: Long = defaultHttpsConfig.sessionCacheSize(),
+                                protocols: Seq[String] = defaultHttpsConfig.protocols().asScala
                                ) extends StyxServerConnector {
   def asJava: com.hotels.styx.server.HttpsConnectorConfig = new com.hotels.styx.server.HttpsConnectorConfig.Builder()
     .port(port)
@@ -44,6 +45,7 @@ case class HttpsConnectorConfig(port: Int = 0,
     .cipherSuites(cipherSuites.asJava)
     .sessionTimeout(sessionTimeoutMillis, TimeUnit.MILLISECONDS)
     .sessionCacheSize(sessionCacheSize)
+    .protocols(protocols.toArray:_*)
     .build()
 }
 


### PR DESCRIPTION
Adds a *protocols* config option to Styx HTTPS server connector to specify the accepted TLS protocol versions. This is to allow operators to enforce TLS 1.2 support.

End-to-end test enhancements:
- Allow styx server to be configured with YAML string alone.
- Automatically allocate styx server port when a port number 0 is used.
