### PR TITLE
Issue28: Specify TLS protocol version for backend services

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/ssl/Certificate.java
+++ b/components/client/src/main/java/com/hotels/styx/client/ssl/Certificate.java
@@ -19,6 +19,9 @@ package com.hotels.styx.client.ssl;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
+import static com.google.common.base.Objects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -60,24 +63,27 @@ public class Certificate {
         if (this == o) {
             return true;
         }
+
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
         Certificate that = (Certificate) o;
-
-        if (alias != null ? !alias.equals(that.alias) : that.alias != null) {
-            return false;
-        }
-        return certificatePath != null ? certificatePath.equals(that.certificatePath) : that.certificatePath == null;
-
+        return Objects.equals(alias, that.alias)
+                && Objects.equals(certificatePath, that.certificatePath);
     }
 
     @Override
     public int hashCode() {
-        int result = alias != null ? alias.hashCode() : 0;
-        result = 31 * result + (certificatePath != null ? certificatePath.hashCode() : 0);
-        return result;
+        return Objects.hash(alias, certificatePath);
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add("alias", this.alias)
+                .add("certificatePath", this.certificatePath)
+                .toString();
     }
 
     /**

--- a/components/client/src/main/java/com/hotels/styx/client/ssl/SslContextFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/ssl/SslContextFactory.java
@@ -30,6 +30,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -66,7 +67,16 @@ public final class SslContextFactory {
                 .forClient()
                 .sslProvider(SslProvider.valueOf(tlsSettings.sslProvider()))
                 .trustManager(trustManagerFactory(tlsSettings))
+                .protocols(toNettyProtocols(tlsSettings.protocols()))
                 .build();
+    }
+
+    private static String[] toNettyProtocols(List<String> protocols) {
+        if (protocols == null || protocols.isEmpty()) {
+            return null;
+        } else {
+            return protocols.toArray(new String[protocols.size()]);
+        }
     }
 
     private static TrustManagerFactory trustManagerFactory(TlsSettings tlsSettings) throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {

--- a/components/client/src/main/java/com/hotels/styx/client/ssl/TlsSettings.java
+++ b/components/client/src/main/java/com/hotels/styx/client/ssl/TlsSettings.java
@@ -18,6 +18,7 @@ package com.hotels.styx.client.ssl;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import java.io.File;
@@ -56,7 +57,7 @@ public class TlsSettings {
         this.additionalCerts = builder.additionalCerts;
         this.trustStorePath = builder.trustStorePath;
         this.trustStorePassword = toCharArray(builder.trustStorePassword);
-        this.protocols = builder.protocols;
+        this.protocols = ImmutableList.copyOf(builder.protocols);
     }
 
     private char[] toCharArray(String password) {
@@ -111,7 +112,8 @@ public class TlsSettings {
                 && Objects.equals(this.sslProvider, other.sslProvider)
                 && Objects.equals(this.additionalCerts, other.additionalCerts)
                 && Objects.equals(this.trustStorePath, other.trustStorePath)
-                && Arrays.equals(this.trustStorePassword, other.trustStorePassword);
+                && Arrays.equals(this.trustStorePassword, other.trustStorePassword)
+                && Objects.equals(this.protocols, other.protocols);
     }
 
     @Override
@@ -122,13 +124,14 @@ public class TlsSettings {
                 .add("additionalCerts", this.additionalCerts)
                 .add("trustStorePath", this.trustStorePath)
                 .add("trustStorePassword", this.trustStorePassword)
+                .add("protocols", this.protocols)
                 .toString();
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(trustAllCerts, sslProvider, additionalCerts,
-                trustStorePath, trustStorePassword);
+                trustStorePath, Arrays.hashCode(trustStorePassword), protocols);
     }
 
     /**

--- a/components/client/src/main/java/com/hotels/styx/client/ssl/TlsSettings.java
+++ b/components/client/src/main/java/com/hotels/styx/client/ssl/TlsSettings.java
@@ -22,6 +22,8 @@ import com.google.common.collect.Sets;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -46,6 +48,7 @@ public class TlsSettings {
     private final Set<Certificate> additionalCerts;
     private final String trustStorePath;
     private final char[] trustStorePassword;
+    private final List<String> protocols;
 
     private TlsSettings(Builder builder) {
         this.trustAllCerts = checkNotNull(builder.trustAllCerts);
@@ -53,6 +56,7 @@ public class TlsSettings {
         this.additionalCerts = builder.additionalCerts;
         this.trustStorePath = builder.trustStorePath;
         this.trustStorePassword = toCharArray(builder.trustStorePassword);
+        this.protocols = builder.protocols;
     }
 
     private char[] toCharArray(String password) {
@@ -87,6 +91,11 @@ public class TlsSettings {
     @JsonProperty("trustStorePassword")
     public char[] trustStorePassword() {
         return trustStorePassword;
+    }
+
+    @JsonProperty("protocols")
+    public List<String> protocols() {
+        return protocols;
     }
 
     @Override
@@ -133,6 +142,7 @@ public class TlsSettings {
         private String trustStorePath = firstNonNull(System.getProperty("javax.net.ssl.trustStore"),
                 DEFAULT_TRUST_STORE_PATH);
         private String trustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword");
+        private List<String> protocols = Collections.emptyList();
 
         /**
          * @deprecated
@@ -200,6 +210,12 @@ public class TlsSettings {
         @JsonProperty("trustStorePassword")
         public Builder trustStorePassword(String trustStorePwd) {
             this.trustStorePassword = trustStorePwd;
+            return this;
+        }
+
+        @JsonProperty("protocols")
+        public Builder protocols(List<String> protocols) {
+            this.protocols = protocols;
             return this;
         }
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/ssl/TlsSettingsTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/ssl/TlsSettingsTest.java
@@ -17,12 +17,14 @@ package com.hotels.styx.client.ssl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hotels.styx.client.ssl.Certificate.certificate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
@@ -155,14 +157,19 @@ public class TlsSettingsTest {
     }
 
     @Test
-    public void protocolsIsImmutable() throws Exception {
-        List<String> protocols = new ArrayList<>();
-        protocols.add("TLSv1");
+    public void isImmutable() throws Exception {
+        List<String> protocols = new ArrayList<String>() {{ add("TLSv1"); }};
+        Certificate[] certificates = new Certificate[] { certificate("x", "x") };
 
-        TlsSettings tlsSettings = new TlsSettings.Builder().protocols(protocols).build();
+        TlsSettings tlsSettings = new TlsSettings.Builder()
+                .additionalCerts(certificates)
+                .protocols(protocols)
+                .build();
 
         protocols.add("TLSv1.2");
+        certificates[0] = certificate("y", "y");
 
         assertThat(tlsSettings.protocols(), equalTo(ImmutableList.of("TLSv1")));
+        assertThat(tlsSettings.additionalCerts(), equalTo(ImmutableSet.of(certificate("x", "x"))));
     }
 }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/ssl/TlsSettingsTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/ssl/TlsSettingsTest.java
@@ -16,12 +16,17 @@
 package com.hotels.styx.client.ssl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class TlsSettingsTest {
@@ -96,4 +101,68 @@ public class TlsSettingsTest {
         assertThat(result, containsString("\"trustStorePassword\" : \"foobar\""));
     }
 
+    @Test
+    public void equalsToConsidersProtocols() throws Exception {
+        TlsSettings tlsSettings1 = new TlsSettings.Builder()
+                .protocols(ImmutableList.of("TLSv1", "TLSv1.1"))
+                .build();
+
+        TlsSettings tlsSettings2 = new TlsSettings.Builder()
+                .build();
+
+        assertThat(tlsSettings1.equals(tlsSettings2), is(false));
+
+        tlsSettings1 = new TlsSettings.Builder()
+                .protocols(ImmutableList.of("TLSv1", "TLSv1.1"))
+                .build();
+
+        tlsSettings2 = new TlsSettings.Builder()
+                .protocols(ImmutableList.of("TLSv1", "TLSv1.1"))
+                .build();
+
+        assertThat(tlsSettings1.equals(tlsSettings2), is(true));
+    }
+
+    @Test
+    public void hashCodeConsidersProtocols() throws Exception {
+        TlsSettings tlsSettings1 = new TlsSettings.Builder()
+                .protocols(ImmutableList.of("TLSv1", "TLSv1.1"))
+                .build();
+
+        TlsSettings tlsSettings2 = new TlsSettings.Builder()
+                .build();
+
+        assertThat(tlsSettings1.hashCode() == tlsSettings2.hashCode(), is(false));
+
+        tlsSettings1 = new TlsSettings.Builder()
+                .protocols(ImmutableList.of("TLSv1", "TLSv1.1"))
+                .build();
+
+        tlsSettings2 = new TlsSettings.Builder()
+                .protocols(ImmutableList.of("TLSv1", "TLSv1.1"))
+                .build();
+
+        assertThat(tlsSettings1.hashCode() == tlsSettings2.hashCode(), is(true));
+    }
+
+    @Test
+    public void toStringPrintsprotocols() throws Exception {
+        TlsSettings tlsSettings = new TlsSettings.Builder()
+                .protocols(ImmutableList.of("TLSv1", "TLSv1.2"))
+                .build();
+
+        assertThat(tlsSettings.toString(), containsString("protocols=[TLSv1, TLSv1.2]"));
+    }
+
+    @Test
+    public void protocolsIsImmutable() throws Exception {
+        List<String> protocols = new ArrayList<>();
+        protocols.add("TLSv1");
+
+        TlsSettings tlsSettings = new TlsSettings.Builder().protocols(protocols).build();
+
+        protocols.add("TLSv1.2");
+
+        assertThat(tlsSettings.protocols(), equalTo(ImmutableList.of("TLSv1")));
+    }
 }

--- a/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
@@ -90,7 +90,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Objects.hashCode(sslProvider, certificateFile, certificateKeyFile, sessionTimeoutMillis, sessionCacheSize);
+        return 31 * super.hashCode() + Objects.hashCode(sslProvider, certificateFile, certificateKeyFile, sessionTimeoutMillis, sessionCacheSize, protocols);
     }
 
     @Override
@@ -109,7 +109,8 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
                 && Objects.equal(this.certificateFile, other.certificateFile)
                 && Objects.equal(this.certificateKeyFile, other.certificateKeyFile)
                 && Objects.equal(this.sessionTimeoutMillis, other.sessionTimeoutMillis)
-                && Objects.equal(this.sessionCacheSize, other.sessionCacheSize);
+                && Objects.equal(this.sessionCacheSize, other.sessionCacheSize)
+                && Objects.equal(this.protocols, other.protocols);
     }
 
     @Override
@@ -167,7 +168,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
         }
 
         public Builder cipherSuites(List<String> cipherSuites) {
-            this.cipherSuites = checkNotNull(cipherSuites);
+            this.cipherSuites = ImmutableList.copyOf(checkNotNull(cipherSuites));
             return this;
         }
 

--- a/components/server/src/test/java/com/hotels/styx/server/HttpsConnectorConfigTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/HttpsConnectorConfigTest.java
@@ -15,9 +15,14 @@
  */
 package com.hotels.styx.server;
 
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 
 public class HttpsConnectorConfigTest {
@@ -53,4 +58,69 @@ public class HttpsConnectorConfigTest {
 
         assertThat(connectorConfig.isConfigured(), is(false));
     }
+
+    @Test
+    public void isImmutable() throws Exception {
+        String[] protocols = new String[] { "TLSv1.2" };
+        List<String> cipherSuites = new ArrayList<String>() {{ add("A1"); }};
+
+        HttpsConnectorConfig connector1 = new HttpsConnectorConfig.Builder()
+                .protocols(protocols)
+                .cipherSuites(cipherSuites)
+                .build();
+
+        protocols[0] = "TLSv1.1";
+        cipherSuites.add("A2");
+
+        assertThat(connector1.protocols(), equalTo(ImmutableList.of("TLSv1.2")));
+        assertThat(connector1.ciphers(), equalTo(ImmutableList.of("A1")));
+    }
+
+
+    @Test
+    public void equalsToConsidersProtocols() throws Exception {
+        HttpsConnectorConfig connector1 = new HttpsConnectorConfig.Builder()
+                .protocols("TLSv1.2")
+                .build();
+
+        HttpsConnectorConfig connector2 = new HttpsConnectorConfig.Builder()
+                .build();
+
+        assertThat(connector1.equals(connector2), is(false));
+
+
+        connector1 = new HttpsConnectorConfig.Builder()
+                .protocols("TLSv1.1", "TLSv1.2")
+                .build();
+
+        connector2 = new HttpsConnectorConfig.Builder()
+                .protocols("TLSv1.1", "TLSv1.2")
+                .build();
+
+        assertThat(connector1.equals(connector2), is(true));
+    }
+
+    @Test
+    public void hashCodeConsidersProtocols() throws Exception {
+        HttpsConnectorConfig connector1 = new HttpsConnectorConfig.Builder()
+                .protocols("TLSv1.2")
+                .build();
+
+        HttpsConnectorConfig connector2 = new HttpsConnectorConfig.Builder()
+                .build();
+
+        assertThat(connector1.hashCode() == connector2.hashCode(), is(false));
+
+
+        connector1 = new HttpsConnectorConfig.Builder()
+                .protocols("TLSv1.1", "TLSv1.2")
+                .build();
+
+        connector2 = new HttpsConnectorConfig.Builder()
+                .protocols("TLSv1.1", "TLSv1.2")
+                .build();
+
+        assertThat(connector1.hashCode() == connector2.hashCode(), is(true));
+    }
+
 }

--- a/docs/user-guide/configure-tls.md
+++ b/docs/user-guide/configure-tls.md
@@ -89,6 +89,8 @@ backend services configuration, as follows:
         path:            "/path/to/altcert"
     trustStorePath:      "/path/to/truststore"
     trustStorePassword:  "your_password"
+    protocols:
+      - TLSv1.2
   ...
 ```
 
@@ -123,3 +125,7 @@ be specified as separate backends.
   - *trustStorePassword* - A password for the keystore file specified in
     *trustStorePath* attribute.
 
+  - *protocols* - A list of TLS protocol versions to use.
+    Use this attribute to enforce a more secure version like `TLSv1.2`.
+    When absent, enables all default protocols depending on the `sslProvider`.
+    Possible protocol names are: `TLS`, `TLSv1`, `TLSv1.1`, and `TLSv1.2`.

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/TlsVersionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/TlsVersionSpec.scala
@@ -1,0 +1,142 @@
+/**
+  * Copyright (C) 2013-2017 Expedia Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package com.hotels.styx.client
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.{ValueMatchingStrategy, WireMock}
+import com.hotels.styx.api.HttpRequest.Builder.get
+import com.hotels.styx.support.ResourcePaths.fixturesHome
+import com.hotels.styx.support.backends.FakeHttpServer
+import com.hotels.styx.support.configuration._
+import com.hotels.styx.utils.StubOriginHeader.STUB_ORIGIN_INFO
+import com.hotels.styx.{StyxClientSupplier, StyxProxySpec}
+import org.scalatest.{FunSpec, SequentialNestedSuiteExecution}
+
+class TlsVersionSpec extends FunSpec
+  with StyxProxySpec
+  with StyxClientSupplier
+  with SequentialNestedSuiteExecution {
+
+  val logback = fixturesHome(this.getClass, "/conf/logback/logback-debug-stdout.xml")
+
+  val appOriginTlsv11 = FakeHttpServer.HttpsStartupConfig(
+    appId = "appTls11",
+    originId = "appTls11-01"
+//    , protocols = Seq("TLSv1.1")
+  )
+    .start()
+    .stub(WireMock.get(urlMatching("/.*")), originResponse("App TLS v1.1"))
+
+  val appOriginTlsv12 = FakeHttpServer.HttpsStartupConfig(
+    appId = "appTls12",
+    originId = "appTls12-02"
+//    , protocols = Seq("TLSv1.2")
+  )
+    .start()
+    .stub(WireMock.get(urlMatching("/.*")), originResponse("App TLS v1.2"))
+
+  override val styxConfig = StyxYamlConfig(
+    """
+      |proxy:
+      |  connectors:
+      |    http:
+      |      port: 0
+      |admin:
+      |  connectors:
+      |    http:
+      |      port: 0
+      |request-logging:
+      |  enabled: true
+    """.stripMargin,
+    logbackXmlLocation = logback)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    styxServer.setBackends(
+      "/tls11/" -> HttpsBackend(
+        "appTls11",
+        Origins(appOriginTlsv11),
+        TlsSettings(authenticate = false, sslProvider = "JDK", protocols = List("TLSv1.1", "TLSv1.2"))),
+
+      "/tls12/" -> HttpsBackend(
+        "appTls12",
+        Origins(appOriginTlsv12),
+        TlsSettings(authenticate = false, sslProvider = "JDK", protocols = List("TLSv1.2"))),
+
+      "/tls12-wrong-origin/" -> HttpsBackend(
+        "appTls12-wrong-origin",
+        Origins(appOriginTlsv11),
+        TlsSettings(authenticate = false, sslProvider = "JDK", protocols = List("TLSv1.2")))
+    )
+  }
+
+  println("TLSv1.1 origin: " + appOriginTlsv11.port())
+  println("TLSv1.2 origin: " + appOriginTlsv12.port())
+
+  override protected def afterAll(): Unit = {
+    appOriginTlsv11.stop()
+    appOriginTlsv12.stop()
+    super.afterAll()
+  }
+
+  def httpRequest(path: String) = get(styxServer.routerURL(path)).build()
+
+  def valueMatchingStrategy(matches: String) = {
+    val matchingStrategy = new ValueMatchingStrategy()
+    matchingStrategy.setMatches(matches)
+    matchingStrategy
+  }
+
+  describe("Backend Service TLS Protocol Setting") {
+
+    it("Proxies to TLSv1.1 origin when TLSv1.1 support enabled.") {
+      val (response, body) = decodedRequest(httpRequest("/tls11/a"))
+
+      assert(response.status().code() == 200)
+      assert(body == "Hello, World!")
+
+      appOriginTlsv11.verify(
+        getRequestedFor(
+          urlEqualTo("/tls11/a"))
+          .withHeader("X-Forwarded-Proto", valueMatchingStrategy("http")))
+    }
+
+    it("Proxies to TLSv1.2 origin when TLSv1.2 support is enabled.") {
+      val (response, body) = decodedRequest(httpRequest("/tls12/b"))
+
+      assert(response.status().code() == 200)
+      assert(body == "Hello, World!")
+
+      appOriginTlsv12.verify(
+        getRequestedFor(urlEqualTo("/tls12/b"))
+          .withHeader("X-Forwarded-Proto", valueMatchingStrategy("http")))
+    }
+
+    it("Refuses to connect to TLSv1.1 origin when TLSv1.1 is disabled") {
+      val (response, body) = decodedRequest(httpRequest("/tls12-wrong-origin/c"))
+
+      assert(response.status().code() == 502)
+      assert(body == "Bad Gateway")
+    }
+  }
+
+  def originResponse(appId: String) = aResponse
+    .withStatus(200)
+    .withHeader(STUB_ORIGIN_INFO.toString, appId)
+    .withBody("Hello, World!")
+
+}

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/TlsVersionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/TlsVersionSpec.scala
@@ -105,9 +105,6 @@ class TlsVersionSpec extends FunSpec
     )
   }
 
-  println("TLSv1.1 origin: " + appOriginTlsv11.port())
-  println("TLSv1.2 origin: " + appOriginTlsv12.port())
-
   override protected def afterAll(): Unit = {
     appOriginTlsv11.stop()
     appOriginTlsv12.stop()

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/TlsVersionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/TlsVersionSpec.scala
@@ -34,16 +34,32 @@ class TlsVersionSpec extends FunSpec
 
   val appOriginTlsv11 = FakeHttpServer.HttpsStartupConfig(
     appId = "appTls11",
-    originId = "appTls11-01"
-//    , protocols = Seq("TLSv1.1")
+    originId = "appTls11-01",
+    protocols = Seq("TLSv1.1")
+  )
+    .start()
+    .stub(WireMock.get(urlMatching("/.*")), originResponse("App TLS v1.1"))
+
+  val appOriginTlsv12B = FakeHttpServer.HttpsStartupConfig(
+    appId = "appTls11B",
+    originId = "appTls11B-01",
+    protocols = Seq("TLSv1.2")
+  )
+    .start()
+    .stub(WireMock.get(urlMatching("/.*")), originResponse("App TLS v1.2 B"))
+
+  val appOriginTlsDefault = FakeHttpServer.HttpsStartupConfig(
+    appId = "appTlsDefault",
+    originId = "appTlsDefault-01",
+    protocols = Seq("TLSv1.1", "TLSv1.2")
   )
     .start()
     .stub(WireMock.get(urlMatching("/.*")), originResponse("App TLS v1.1"))
 
   val appOriginTlsv12 = FakeHttpServer.HttpsStartupConfig(
     appId = "appTls12",
-    originId = "appTls12-02"
-//    , protocols = Seq("TLSv1.2")
+    originId = "appTls12-02",
+    protocols = Seq("TLSv1.2")
   )
     .start()
     .stub(WireMock.get(urlMatching("/.*")), originResponse("App TLS v1.2"))
@@ -70,17 +86,22 @@ class TlsVersionSpec extends FunSpec
       "/tls11/" -> HttpsBackend(
         "appTls11",
         Origins(appOriginTlsv11),
+        TlsSettings(authenticate = false, sslProvider = "JDK", protocols = List("TLSv1.1"))),
+
+      "/tlsDefault/" -> HttpsBackend(
+        "appTlsDefault",
+        Origins(appOriginTlsDefault),
         TlsSettings(authenticate = false, sslProvider = "JDK", protocols = List("TLSv1.1", "TLSv1.2"))),
 
-      "/tls12/" -> HttpsBackend(
+      "/tls12" -> HttpsBackend(
         "appTls12",
         Origins(appOriginTlsv12),
         TlsSettings(authenticate = false, sslProvider = "JDK", protocols = List("TLSv1.2"))),
 
-      "/tls12-wrong-origin/" -> HttpsBackend(
-        "appTls12-wrong-origin",
-        Origins(appOriginTlsv11),
-        TlsSettings(authenticate = false, sslProvider = "JDK", protocols = List("TLSv1.2")))
+      "/tls11-to-tls12" -> HttpsBackend(
+        "appTls11B",
+        Origins(appOriginTlsv12B),
+        TlsSettings(authenticate = false, sslProvider = "JDK", protocols = List("TLSv1.1")))
     )
   }
 
@@ -104,33 +125,51 @@ class TlsVersionSpec extends FunSpec
   describe("Backend Service TLS Protocol Setting") {
 
     it("Proxies to TLSv1.1 origin when TLSv1.1 support enabled.") {
-      val (response, body) = decodedRequest(httpRequest("/tls11/a"))
-
-      assert(response.status().code() == 200)
-      assert(body == "Hello, World!")
+      val (response1, body1) = decodedRequest(httpRequest("/tls11/a"))
+      assert(response1.status().code() == 200)
+      assert(body1 == "Hello, World!")
 
       appOriginTlsv11.verify(
         getRequestedFor(
           urlEqualTo("/tls11/a"))
           .withHeader("X-Forwarded-Proto", valueMatchingStrategy("http")))
+
+      val (response2, body2) = decodedRequest(httpRequest("/tlsDefault/a2"))
+      assert(response2.status().code() == 200)
+      assert(body2 == "Hello, World!")
+
+      appOriginTlsDefault.verify(
+        getRequestedFor(
+          urlEqualTo("/tlsDefault/a2"))
+          .withHeader("X-Forwarded-Proto", valueMatchingStrategy("http")))
     }
 
     it("Proxies to TLSv1.2 origin when TLSv1.2 support is enabled.") {
-      val (response, body) = decodedRequest(httpRequest("/tls12/b"))
+      val (response1, body1) = decodedRequest(httpRequest("/tlsDefault/b1"))
+      assert(response1.status().code() == 200)
+      assert(body1 == "Hello, World!")
 
+      appOriginTlsDefault.verify(
+        getRequestedFor(urlEqualTo("/tlsDefault/b1"))
+          .withHeader("X-Forwarded-Proto", valueMatchingStrategy("http")))
+
+
+      val (response, body) = decodedRequest(httpRequest("/tls12/b2"))
       assert(response.status().code() == 200)
       assert(body == "Hello, World!")
 
       appOriginTlsv12.verify(
-        getRequestedFor(urlEqualTo("/tls12/b"))
+        getRequestedFor(urlEqualTo("/tls12/b2"))
           .withHeader("X-Forwarded-Proto", valueMatchingStrategy("http")))
     }
 
     it("Refuses to connect to TLSv1.1 origin when TLSv1.1 is disabled") {
-      val (response, body) = decodedRequest(httpRequest("/tls12-wrong-origin/c"))
+      val (response, body) = decodedRequest(httpRequest("/tls11-to-tls12/c"))
 
       assert(response.status().code() == 502)
-      assert(body == "Bad Gateway")
+      assert(body == "Site temporarily unavailable.")
+
+      appOriginTlsv12B.verify(0, getRequestedFor(urlEqualTo("/tls11-to-tls12/c")))
     }
   }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/backends/FakeHttpServer.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/backends/FakeHttpServer.scala
@@ -19,7 +19,7 @@ import java.nio.charset.Charset
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
-import com.hotels.styx.api.HttpHeaderNames
+import com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH
 import com.hotels.styx.api.support.HostAndPorts.freePort
 import com.hotels.styx.server.HttpsConnectorConfig
 import com.hotels.styx.servers.MockOriginServer
@@ -70,7 +70,7 @@ object FakeHttpServer {
 
       server.stub(urlStartingWith("/"), aResponse
         .withStatus(200)
-        .withHeader(HttpHeaderNames.CONTENT_LENGTH.toString, response.getBytes(Charset.defaultCharset()).size.toString)
+        .withHeader(CONTENT_LENGTH.toString, response.getBytes(Charset.defaultCharset()).size.toString)
         .withHeader(STUB_ORIGIN_INFO.toString, s"{appId.toUpperCase}-$originId")
         .withBody(response))
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/backends/FakeHttpServer.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/backends/FakeHttpServer.scala
@@ -36,13 +36,15 @@ object FakeHttpServer {
                                 appId: String = "generic-app",
                                 originId: String = "generic-app",
                                 certificateFile: String = null,
-                                certificateKeyFile: String = null
+                                certificateKeyFile: String = null,
+                                protocols: Seq[String] = Seq("TLSv1.1", "TLSv1.2")
                                ) {
 
     def start(): MockOriginServer = {
 
       var builder = new HttpsConnectorConfig.Builder()
         .port(portNumber(httpsPort))
+        .protocols(protocols:_*)
       builder = if (certificateFile != null) builder.certificateFile(certificateFile) else builder
       builder = if (certificateKeyFile != null) builder.certificateFile(certificateKeyFile) else builder
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/TlsSettings.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/TlsSettings.scala
@@ -43,6 +43,7 @@ case class TlsSettings(authenticate: Boolean = default.authenticate(),
         addlCerts.map(_.asJava): _*)
       .trustStorePath(trustStorePath)
       .trustStorePassword(trustStorePassword)
+      .protocols(protocols.asJava)
       .build()
   }
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/TlsSettings.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/TlsSettings.scala
@@ -32,7 +32,8 @@ case class TlsSettings(authenticate: Boolean = default.authenticate(),
                        sslProvider: String = default.sslProvider(),
                        addlCerts: Seq[Certificate] = Seq.empty,
                        trustStorePath: String = default.trustStorePath,
-                       trustStorePassword: String = default.trustStorePassword.toString
+                       trustStorePassword: String = default.trustStorePassword.toString,
+                       protocols: Seq[String] = default.protocols.asScala
 ) {
   def asJava: com.hotels.styx.client.ssl.TlsSettings = {
     new com.hotels.styx.client.ssl.TlsSettings.Builder()
@@ -55,5 +56,7 @@ object TlsSettings {
       sslProvider = from.sslProvider(),
       addlCerts = from.additionalCerts().asScala.map(Certificate.fromJava).toSeq,
       trustStorePath = from.trustStorePath,
-      trustStorePassword = from.trustStorePassword.toString)
+      trustStorePassword = from.trustStorePassword.toString,
+      protocols = from.protocols().asScala
+    )
 }

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/MockOriginServer.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/MockOriginServer.java
@@ -117,10 +117,6 @@ public final class MockOriginServer {
         ));
     }
 
-    private static HttpHandler2 adminHandler(String originId, WireMockApp wireMockApp) {
-        return newHandler(originId, new AdminRequestHandler(wireMockApp, new BasicResponseRenderer()));
-    }
-
     private static HttpHandler2 newHandler(String originId, RequestHandler wireMockHandler) {
         return (httpRequest, ctx) ->
                 httpRequest.decode(byteBuf -> byteBuf.toString(UTF_8), MAX_CONTENT_LENGTH)

--- a/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/servers/WiremockStyxRequestAdapterTest.java
+++ b/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/servers/WiremockStyxRequestAdapterTest.java
@@ -76,6 +76,7 @@ public class WiremockStyxRequestAdapterTest {
         assertThat(adapter.containsHeader("host"), is(true));
     }
 
+
     // Disabled due to a failing test.
     // Looks like it is an underlying problem with Netty, which doesn't convert
     // HTTP header names from AsciiString to String when toArray() is called on

--- a/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/servers/WiremockStyxRequestAdapterTest.java
+++ b/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/servers/WiremockStyxRequestAdapterTest.java
@@ -76,7 +76,6 @@ public class WiremockStyxRequestAdapterTest {
         assertThat(adapter.containsHeader("host"), is(true));
     }
 
-
     // Disabled due to a failing test.
     // Looks like it is an underlying problem with Netty, which doesn't convert
     // HTTP header names from AsciiString to String when toArray() is called on


### PR DESCRIPTION
Add TLS "protocols" attribute to TLS Settings block of the backend services configuration.

This allows one to restrict the TLS version used between Styx and the backend service origins to more secure version 1.2.

Implements: https://github.com/HotelsDotCom/styx/issues/28