### PR TITLE
Store Full HTTP message content as byte array.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -473,17 +473,14 @@ public final class HttpRequest implements HttpMessage {
             version(request.version);
         }
 
-        public Builder(com.hotels.styx.api.messages.FullHttpRequest request, Observable<ByteBuf> body) {
+        public Builder(com.hotels.styx.api.messages.FullHttpRequest request) {
             this.id = request.id();
             this.secure = request.isSecure();
             this.url = request.url();
             this.method = request.method();
-            this.clientAddress = null;
             this.cookies = new ArrayList<>(request.cookies());
             headers(request.headers().newBuilder());
             version(request.version());
-
-            body(body);
         }
 
         /**

--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -251,7 +251,7 @@ public final class HttpRequest implements HttpMessage {
      * @param maxContentBytes maximum content bytes before an exception is thrown
      * @return a decoded (aggregated/full) request
      */
-    public Observable<FullHttpRequest<String>> toFullHttpRequest(int maxContentBytes) {
+    public Observable<FullHttpRequest> toFullHttpRequest(int maxContentBytes) {
         return toFullHttpRequest(byteBuf -> byteBuf.toString(UTF_8), maxContentBytes);
     }
 
@@ -264,9 +264,9 @@ public final class HttpRequest implements HttpMessage {
      * @param <T> full body type
      * @return a decoded (aggregated/full) request
      */
-    public <T> Observable<FullHttpRequest<T>> toFullHttpRequest(Function<ByteBuf, T> decoder, int maxContentBytes) {
+    public <T> Observable<FullHttpRequest> toFullHttpRequest(Function<ByteBuf, String> decoder, int maxContentBytes) {
         return body.decode(decoder, maxContentBytes)
-                .map(decoded -> new FullHttpRequest.Builder<>(this, decoded))
+                .map(decoded -> new FullHttpRequest.Builder(this, decoded))
                 .map(FullHttpRequest.Builder::build);
     }
 
@@ -479,7 +479,7 @@ public final class HttpRequest implements HttpMessage {
             version(request.version);
         }
 
-        public Builder(com.hotels.styx.api.messages.FullHttpRequest<?> request, Observable<ByteBuf> body) {
+        public Builder(com.hotels.styx.api.messages.FullHttpRequest request, Observable<ByteBuf> body) {
             this.id = request.id();
             this.secure = request.isSecure();
             this.url = request.url();

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -292,7 +292,7 @@ public final class HttpResponse implements HttpMessage {
      * @param maxContentBytes maximum content bytes before an exception is thrown
      * @return a decoded (aggregated/full) response
      */
-    public Observable<FullHttpResponse<String>> toFullHttpResponse(int maxContentBytes) {
+    public Observable<FullHttpResponse> toFullHttpResponse(int maxContentBytes) {
         return toFullHttpResponse(byteBuf -> byteBuf.toString(UTF_8), maxContentBytes);
     }
 
@@ -305,9 +305,9 @@ public final class HttpResponse implements HttpMessage {
      * @param <T> full body type
      * @return a decoded (aggregated/full) response
      */
-    public <T> Observable<FullHttpResponse<T>> toFullHttpResponse(Function<ByteBuf, T> decoder, int maxContentBytes) {
+    public <T> Observable<FullHttpResponse> toFullHttpResponse(Function<ByteBuf, String> decoder, int maxContentBytes) {
         return body.decode(decoder, maxContentBytes)
-                .map(decoded -> new FullHttpResponse.Builder<>(this, decoded))
+                .map(decoded -> new FullHttpResponse.Builder(this, decoded))
                 .map(FullHttpResponse.Builder::build);
     }
 
@@ -417,7 +417,7 @@ public final class HttpResponse implements HttpMessage {
             body(response.body);
         }
 
-        public Builder(FullHttpResponse<?> response, Observable<ByteBuf> body) {
+        public Builder(FullHttpResponse response, Observable<ByteBuf> body) {
             this.status = response.status();
             headers(response.headers().newBuilder());
             this.cookies = new ArrayList<>(response.cookies());

--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpMessage.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpMessage.java
@@ -28,10 +28,8 @@ import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
 
 /**
  * All behaviour common to both full requests and full responses.
- *
- * @param <T> body type
  */
-public interface FullHttpMessage<T> {
+public interface FullHttpMessage {
     /**
      * Returns the protocol version of this.
      *
@@ -58,7 +56,7 @@ public interface FullHttpMessage<T> {
      *
      * @return the body
      */
-    T body();
+    String body();
 
     /**
      * Returns the value of the header with the specified {@code name}.

--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpMessage.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpMessage.java
@@ -20,8 +20,10 @@ import com.hotels.styx.api.HttpHeaders;
 import com.hotels.styx.api.HttpMessageSupport;
 import io.netty.handler.codec.http.HttpVersion;
 
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
@@ -56,7 +58,32 @@ public interface FullHttpMessage {
      *
      * @return the body
      */
-    String body();
+    byte[] body();
+
+    /**
+     * Returns the message body decoded to a business domain object.
+     *
+     * Decodes the message body with a provided decoder function and returns the
+     * result. The decoder is a function from ByteBuf to a specified output type T.
+     * The caller must ensure the provided decoder is compatible with message content
+     * type and encoding.
+     *
+     * @param  decoder    A function from ByteBuf to T.
+     * @return            Message object decoded into a business domain object.
+     */
+    <T> T bodyAs(Function<byte[], T> decoder);
+
+    /**
+     * Returns the message body as a String decoded with provided character set.
+     *
+     * Decodes the message body into a Java String object with a provided charset.
+     * The caller must ensure the provided charset is compatible with message content
+     * type and encoding.
+     *
+     * @param charset     Charset used to decode message body.
+     * @return            Message body as a String.
+     */
+    String bodyAs(Charset charset);
 
     /**
      * Returns the value of the header with the specified {@code name}.

--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpRequest.java
@@ -60,10 +60,8 @@ import static java.util.UUID.randomUUID;
 
 /**
  * HTTP request with a fully aggregated/decoded body.
- *
- * @param <T> content type
  */
-public class FullHttpRequest<T> implements FullHttpMessage<T> {
+public class FullHttpRequest implements FullHttpMessage {
     private final Object id;
     private final InetSocketAddress clientAddress;
     private final HttpVersion version;
@@ -71,10 +69,10 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
     private final Url url;
     private final HttpHeaders headers;
     private final boolean secure;
-    private final T body;
+    private final String body;
     private final List<HttpCookie> cookies;
 
-    FullHttpRequest(Builder<T> builder) {
+    FullHttpRequest(Builder builder) {
         this.id = builder.id == null ? randomUUID() : builder.id;
         this.clientAddress = builder.clientAddress;
         this.version = builder.version;
@@ -92,8 +90,8 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
      * @param uri URI
      * @return {@code this}
      */
-    public static <T> Builder<T> get(String uri) {
-        return new Builder<>(GET, uri);
+    public static <T> Builder get(String uri) {
+        return new Builder(GET, uri);
     }
 
     /**
@@ -102,8 +100,8 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
      * @param uri URI
      * @return {@code this}
      */
-    public static <T> Builder<T> head(String uri) {
-        return new Builder<>(HEAD, uri);
+    public static <T> Builder head(String uri) {
+        return new Builder(HEAD, uri);
     }
 
     /**
@@ -112,8 +110,8 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
      * @param uri URI
      * @return {@code this}
      */
-    public static <T> Builder<T> post(String uri) {
-        return new Builder<>(POST, uri);
+    public static <T> Builder post(String uri) {
+        return new Builder(POST, uri);
     }
 
     /**
@@ -122,8 +120,8 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
      * @param uri URI
      * @return {@code this}
      */
-    public static <T> Builder<T> delete(String uri) {
-        return new Builder<>(DELETE, uri);
+    public static <T> Builder delete(String uri) {
+        return new Builder(DELETE, uri);
     }
 
     /**
@@ -132,8 +130,8 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
      * @param uri URI
      * @return {@code this}
      */
-    public static <T> Builder<T> put(String uri) {
-        return new Builder<>(PUT, uri);
+    public static <T> Builder put(String uri) {
+        return new Builder(PUT, uri);
     }
 
     /**
@@ -142,44 +140,8 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
      * @param uri URI
      * @return {@code this}
      */
-    public static <T> Builder<T> patch(String uri) {
-        return new Builder<>(PATCH, uri);
-    }
-
-    /**
-     * Creates a request with the POST method.
-     *
-     * @param uri URI
-     * @param body body
-     * @param <T> body type
-     * @return {@code this}
-     */
-    public static <T> Builder<T> post(String uri, T body) {
-        return new Builder<T>(POST, uri).body(body);
-    }
-
-    /**
-     * Creates a request with the PUT method.
-     *
-     * @param uri URI
-     * @param body body
-     * @param <T> body type
-     * @return {@code this}
-     */
-    public static <T> Builder<T> put(String uri, T body) {
-        return new Builder<T>(PUT, uri).body(body);
-    }
-
-    /**
-     * Creates a request with the PATCH method.
-     *
-     * @param uri URI
-     * @param body body
-     * @param <T> body type
-     * @return {@code this}
-     */
-    public static <T> Builder<T> patch(String uri, T body) {
-        return new Builder<T>(PATCH, uri).body(body);
+    public static <T> Builder patch(String uri) {
+        return new Builder(PATCH, uri);
     }
 
     @Override
@@ -203,7 +165,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
     }
 
     @Override
-    public T body() {
+    public String body() {
         return body;
     }
 
@@ -319,8 +281,8 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
      *
      * @return new builder based on this request
      */
-    public Builder<T> newBuilder() {
-        return new Builder<>(this);
+    public Builder newBuilder() {
+        return new Builder(this);
     }
 
     /**
@@ -330,7 +292,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
      * @param encoder an encoding function
      * @return an encoded (streaming) request
      */
-    public HttpRequest toStreamingHttpRequest(Function<T, ByteBuf> encoder) {
+    public HttpRequest toStreamingHttpRequest(Function<String, ByteBuf> encoder) {
         return new HttpRequest.Builder(this, encodeBody(this.body, encoder))
                 .build();
     }
@@ -341,7 +303,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
      * @param request a request
      * @return an encoded (streaming) request
      */
-    public static HttpRequest toStreamingHttpRequest(FullHttpRequest<String> request) {
+    public static HttpRequest toStreamingHttpRequest(FullHttpRequest request) {
         return request.toStreamingHttpRequest(string -> Unpooled.copiedBuffer(string, UTF_8));
     }
 
@@ -361,10 +323,8 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
 
     /**
      * Builder.
-     *
-     * @param <T> body type
      */
-    public static final class Builder<T> {
+    public static final class Builder {
         private static final InetSocketAddress LOCAL_HOST = createUnresolved("127.0.0.1", 0);
 
         private Object id;
@@ -375,7 +335,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
         private boolean secure;
         private HttpHeaders.Builder headers;
         private HttpVersion version = HTTP_1_1;
-        private T body;
+        private String body;
         private final List<HttpCookie> cookies;
 
         public Builder() {
@@ -392,7 +352,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
             this.secure = url.isSecure();
         }
 
-        public Builder(HttpRequest request, T body) {
+        public Builder(HttpRequest request, String body) {
             this.id = request.id();
             this.method = request.method();
             this.clientAddress = request.clientAddress();
@@ -404,7 +364,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
             this.cookies = new ArrayList<>(request.cookies());
         }
 
-        Builder(FullHttpRequest<T> request) {
+        Builder(FullHttpRequest request) {
             this.id = request.id();
             this.method = request.method();
             this.clientAddress = request.clientAddress();
@@ -422,7 +382,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param uri URI
          * @return {@code this}
          */
-        public Builder<T> uri(String uri) {
+        public Builder uri(String uri) {
             return this.url(Url.Builder.url(uri).build());
         }
 
@@ -432,7 +392,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param content request body
          * @return {@code this}
          */
-        public Builder<T> body(T content) {
+        public Builder body(String content) {
             this.body = content;
             return this;
         }
@@ -443,7 +403,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param id request ID
          * @return {@code this}
          */
-        public Builder<T> id(Object id) {
+        public Builder id(Object id) {
             this.id = id;
             return this;
         }
@@ -457,7 +417,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param value The value of the header
          * @return {@code this}
          */
-        public Builder<T> header(CharSequence name, Object value) {
+        public Builder header(CharSequence name, Object value) {
             checkNotCookie(name);
             this.headers.set(name, value);
             return this;
@@ -469,7 +429,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param headers headers
          * @return {@code this}
          */
-        public Builder<T> headers(HttpHeaders headers) {
+        public Builder headers(HttpHeaders headers) {
             this.headers = headers.newBuilder();
             return this;
         }
@@ -483,7 +443,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param value The value of the header
          * @return {@code this}
          */
-        public Builder<T> addHeader(CharSequence name, Object value) {
+        public Builder addHeader(CharSequence name, Object value) {
             checkNotCookie(name);
             this.headers.add(name, value);
             return this;
@@ -495,7 +455,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param name The name of the header to remove
          * @return {@code this}
          */
-        public Builder<T> removeHeader(CharSequence name) {
+        public Builder removeHeader(CharSequence name) {
             headers.remove(name);
             return this;
         }
@@ -506,7 +466,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param url fully qualified url
          * @return {@code this}
          */
-        public Builder<T> url(Url url) {
+        public Builder url(Url url) {
             this.url = url;
             this.secure = url.isSecure();
             return this;
@@ -518,7 +478,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param version HTTP version
          * @return {@code this}
          */
-        public Builder<T> version(HttpVersion version) {
+        public Builder version(HttpVersion version) {
             this.version = requireNonNull(version);
             return this;
         }
@@ -529,7 +489,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param method HTTP method
          * @return {@code this}
          */
-        public Builder<T> method(HttpMethod method) {
+        public Builder method(HttpMethod method) {
             this.method = requireNonNull(method);
             return this;
         }
@@ -540,7 +500,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param cookie cookie to add
          * @return {@code this}
          */
-        public Builder<T> addCookie(HttpCookie cookie) {
+        public Builder addCookie(HttpCookie cookie) {
             cookies.add(checkNotNull(cookie));
             return this;
         }
@@ -552,7 +512,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param value cookie value
          * @return {@code this}
          */
-        public Builder<T> addCookie(String name, String value) {
+        public Builder addCookie(String name, String value) {
             return addCookie(HttpCookie.cookie(name, value));
         }
 
@@ -562,7 +522,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param name name of the cookie
          * @return {@code this}
          */
-        public Builder<T> removeCookie(String name) {
+        public Builder removeCookie(String name) {
             cookies.stream()
                     .filter(cookie -> cookie.name().equalsIgnoreCase(name))
                     .findFirst()
@@ -577,7 +537,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param address IP address
          * @return {@code this}
          */
-        public Builder<T> clientAddress(InetSocketAddress address) {
+        public Builder clientAddress(InetSocketAddress address) {
             this.clientAddress = requireNonNull(address);
             return this;
         }
@@ -588,7 +548,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          * @param secure true if secure
          * @return {@code this}
          */
-        public Builder<T> secure(boolean secure) {
+        public Builder secure(boolean secure) {
             this.secure = secure;
             return this;
         }
@@ -598,7 +558,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          *
          * @return {@code this}
          */
-        public Builder<T> disableValidation() {
+        public Builder disableValidation() {
             this.validate = false;
             return this;
         }
@@ -608,7 +568,7 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          *
          * @return {@code this}
          */
-        public Builder<T> enableKeepAlive() {
+        public Builder enableKeepAlive() {
             return header(CONNECTION, KEEP_ALIVE);
         }
 
@@ -623,14 +583,14 @@ public class FullHttpRequest<T> implements FullHttpMessage<T> {
          *
          * @return a new full request
          */
-        public FullHttpRequest<T> build() {
+        public FullHttpRequest build() {
             if (validate) {
                 ensureContentLengthIsValid();
                 ensureMethodIsValid();
                 setHostHeader();
             }
 
-            return new FullHttpRequest<T>(this);
+            return new FullHttpRequest(this);
         }
 
         private void setHostHeader() {

--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpRequest.java
@@ -393,7 +393,10 @@ public class FullHttpRequest implements FullHttpMessage {
          * @return {@code this}
          */
         public Builder body(String content) {
-            this.body = content;
+            String sanitisedContent = content == null ? "" : content;
+
+            header(CONTENT_LENGTH, sanitisedContent.getBytes(UTF_8).length);
+            this.body = sanitisedContent;
             return this;
         }
 

--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpResponse.java
@@ -232,7 +232,10 @@ public class FullHttpResponse implements FullHttpMessage {
          * @return {@code this}
          */
         public Builder body(String content) {
-            this.body = content;
+            String sanitisedContent = content == null ? "" : content;
+
+            header(CONTENT_LENGTH, sanitisedContent.getBytes(UTF_8).length);
+            this.body = sanitisedContent;
             return this;
         }
 

--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpResponse.java
@@ -47,17 +47,15 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * HTTP response with a fully aggregated/decoded body.
- *
- * @param <T> content type
  */
-public class FullHttpResponse<T> implements FullHttpMessage<T> {
+public class FullHttpResponse implements FullHttpMessage {
     private final HttpVersion version;
     private final HttpResponseStatus status;
     private final HttpHeaders headers;
-    private final T body;
+    private final String body;
     private final List<HttpCookie> cookies;
 
-    FullHttpResponse(Builder<T> builder) {
+    FullHttpResponse(Builder builder) {
         this.version = builder.version;
         this.status = builder.status;
         this.headers = builder.headers.build();
@@ -68,34 +66,20 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
     /**
      * Creates an HTTP response builder with a status of 200 OK and empty body.
      *
-     * @param <T> response type
      * @return a new builder
      */
-    public static <T> Builder<T> response() {
-        return new Builder<>();
+    public static Builder response() {
+        return new Builder();
     }
 
     /**
      * Creates an HTTP response builder with a given status and empty body.
      *
      * @param status response status
-     * @param <T> response type
      * @return a new builder
      */
-    public static <T> Builder<T> response(HttpResponseStatus status) {
-        return new Builder<>(status);
-    }
-
-    /**
-     * Creates an HTTP response builder with a given status and body.
-     *
-     * @param status response status
-     * @param body response body
-     * @param <T> response type
-     * @return a new builder
-     */
-    public static <T> Builder<T> response(HttpResponseStatus status, T body) {
-        return new Builder<T>(status).body(body);
+    public static Builder response(HttpResponseStatus status) {
+        return new Builder(status);
     }
 
     @Override
@@ -119,7 +103,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
     }
 
     @Override
-    public T body() {
+    public String body() {
         return body;
     }
 
@@ -128,8 +112,8 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
         return version;
     }
 
-    public Builder<T> newBuilder() {
-        return new Builder<>(this);
+    public Builder newBuilder() {
+        return new Builder(this);
     }
 
     public HttpResponseStatus status() {
@@ -147,7 +131,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
      * @param encoder an encoding function
      * @return an encoded (streaming) response
      */
-    public HttpResponse toStreamingHttpResponse(Function<T, ByteBuf> encoder) {
+    public HttpResponse toStreamingHttpResponse(Function<String, ByteBuf> encoder) {
         return new HttpResponse.Builder(this, encodeBody(this.body, encoder))
                 .build();
     }
@@ -158,7 +142,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
      * @param response a response
      * @return an encoded (streaming) response
      */
-    public static HttpResponse toStreamingHttpResponse(FullHttpResponse<String> response) {
+    public static HttpResponse toStreamingHttpResponse(FullHttpResponse response) {
         return response.toStreamingHttpResponse(string -> Unpooled.copiedBuffer(string, UTF_8));
     }
 
@@ -194,15 +178,13 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
 
     /**
      * Builder.
-     *
-     * @param <T> body type
      */
-    public static final class Builder<T> {
+    public static final class Builder {
         private HttpResponseStatus status = OK;
         private HttpHeaders.Builder headers;
         private HttpVersion version = HTTP_1_1;
         private boolean validate = true;
-        private T body;
+        private String body;
         private final List<HttpCookie> cookies;
 
         public Builder() {
@@ -216,7 +198,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
             this.status = status;
         }
 
-        public Builder(FullHttpResponse<T> response) {
+        public Builder(FullHttpResponse response) {
             this.status = response.status();
             this.version = response.version();
             this.headers = response.headers().newBuilder();
@@ -224,7 +206,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
             this.cookies = new ArrayList<>(response.cookies());
         }
 
-        public Builder(HttpResponse response, T decoded) {
+        public Builder(HttpResponse response, String decoded) {
             this.status = response.status();
             this.version = response.version();
             this.headers = response.headers().newBuilder();
@@ -238,7 +220,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          * @param status response status
          * @return {@code this}
          */
-        public Builder<T> status(HttpResponseStatus status) {
+        public Builder status(HttpResponseStatus status) {
             this.status = requireNonNull(status);
             return this;
         }
@@ -249,7 +231,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          * @param content response body
          * @return {@code this}
          */
-        public Builder<T> body(T content) {
+        public Builder body(String content) {
             this.body = content;
             return this;
         }
@@ -260,7 +242,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          * @param version HTTP version
          * @return {@code this}
          */
-        public Builder<T> version(HttpVersion version) {
+        public Builder version(HttpVersion version) {
             this.version = requireNonNull(version);
             return this;
         }
@@ -271,7 +253,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          *
          * @return {@code this}
          */
-        public Builder<T> contentType(MediaType contentType) {
+        public Builder contentType(MediaType contentType) {
             headers.set(CONTENT_TYPE, contentType.toString());
             return this;
         }
@@ -281,7 +263,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          *
          * @return {@code this}
          */
-        public Builder<T> disableCaching() {
+        public Builder disableCaching() {
             header("Pragma", "no-cache");
             header("Expires", "Mon, 1 Jan 2007 08:00:00 GMT");
             header("Cache-Control", "no-cache,must-revalidate,no-store");
@@ -293,7 +275,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          *
          * @return {@code this}
          */
-        public Builder<T> setChunked() {
+        public Builder setChunked() {
             headers.add(TRANSFER_ENCODING, CHUNKED);
             headers.remove(CONTENT_LENGTH);
             return this;
@@ -305,7 +287,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          * @param cookie cookie to add
          * @return {@code this}
          */
-        public Builder<T> addCookie(HttpCookie cookie) {
+        public Builder addCookie(HttpCookie cookie) {
             cookies.add(checkNotNull(cookie));
             return this;
         }
@@ -317,7 +299,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          * @param value cookie value
          * @return {@code this}
          */
-        public Builder<T> addCookie(String name, String value) {
+        public Builder addCookie(String name, String value) {
             return addCookie(HttpCookie.cookie(name, value));
         }
 
@@ -327,7 +309,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          * @param name name of the cookie
          * @return {@code this}
          */
-        public Builder<T> removeCookie(String name) {
+        public Builder removeCookie(String name) {
             cookies.stream()
                     .filter(cookie -> cookie.name().equalsIgnoreCase(name))
                     .findFirst()
@@ -345,7 +327,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          * @param value The value of the header
          * @return {@code this}
          */
-        public Builder<T> header(CharSequence name, Object value) {
+        public Builder header(CharSequence name, Object value) {
             this.headers.set(name, value);
             return this;
         }
@@ -359,7 +341,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          * @param value The value of the header
          * @return {@code this}
          */
-        public Builder<T> addHeader(CharSequence name, Object value) {
+        public Builder addHeader(CharSequence name, Object value) {
             headers.add(name, value);
             return this;
         }
@@ -370,7 +352,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          * @param name The name of the header to remove
          * @return {@code this}
          */
-        public Builder<T> removeHeader(CharSequence name) {
+        public Builder removeHeader(CharSequence name) {
             headers.remove(name);
             return this;
         }
@@ -381,7 +363,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          * @param headers headers
          * @return {@code this}
          */
-        public Builder<T> headers(HttpHeaders headers) {
+        public Builder headers(HttpHeaders headers) {
             this.headers = headers.newBuilder();
             return this;
         }
@@ -391,7 +373,7 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          *
          * @return {@code this}
          */
-        public Builder<T> disableValidation() {
+        public Builder disableValidation() {
             this.validate = false;
             return this;
         }
@@ -405,15 +387,15 @@ public class FullHttpResponse<T> implements FullHttpMessage<T> {
          *
          * @return a new full response
          */
-        public FullHttpResponse<T> build() {
+        public FullHttpResponse build() {
             if (validate) {
                 ensureContentLengthIsValid();
             }
 
-            return new FullHttpResponse<>(this);
+            return new FullHttpResponse(this);
         }
 
-        Builder<T> ensureContentLengthIsValid() {
+        Builder ensureContentLengthIsValid() {
             List<String> contentLengths = headers.build().getAll(CONTENT_LENGTH);
 
             checkArgument(contentLengths.size() <= 1, "Duplicate Content-Length found. %s", contentLengths);

--- a/components/api/src/main/java/com/hotels/styx/api/service/spi/AbstractStyxService.java
+++ b/components/api/src/main/java/com/hotels/styx/api/service/spi/AbstractStyxService.java
@@ -17,13 +17,15 @@ package com.hotels.styx.api.service.spi;
 
 import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.HttpHandler;
-import com.hotels.styx.api.HttpResponse;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.APPLICATION_JSON;
+import static com.hotels.styx.api.messages.FullHttpResponse.response;
 import static com.hotels.styx.api.service.spi.StyxServiceStatus.CREATED;
 import static com.hotels.styx.api.service.spi.StyxServiceStatus.FAILED;
 import static com.hotels.styx.api.service.spi.StyxServiceStatus.RUNNING;
@@ -32,6 +34,7 @@ import static com.hotels.styx.api.service.spi.StyxServiceStatus.STOPPED;
 import static com.hotels.styx.api.service.spi.StyxServiceStatus.STOPPING;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static rx.Observable.just;
 
@@ -96,10 +99,12 @@ public abstract class AbstractStyxService implements StyxService {
 
     @Override
     public Map<String, HttpHandler> adminInterfaceHandlers() {
-        return ImmutableMap.of("status", request -> just(HttpResponse.Builder
-                .response(OK)
-                .body(format("{ name: \"%s\" status: \"%s\" }", name, status))
-                .build()));
+        return ImmutableMap.of("status", request -> just(
+                response(OK)
+                        .addHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .body(format("{ name: \"%s\" status: \"%s\" }", name, status), UTF_8)
+                        .build()
+                        .toStreamingResponse()));
     }
 
 }

--- a/components/api/src/test/java/com/hotels/styx/api/HttpMessageBodyTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpMessageBodyTest.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.hotels.styx.api.TestSupport.bodyAsString;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,7 +49,7 @@ public class HttpMessageBodyTest {
     }
 
     private Function<ByteBuf, String> toStringDecoder(Charset charset) {
-        return byteBuf -> byteBuf.toString(charset);
+        return bytes -> bytes.toString(UTF_8);
     }
 
     private Function<ByteBuf, String> utf8Decoder = toStringDecoder(Charsets.UTF_8);
@@ -85,7 +86,7 @@ public class HttpMessageBodyTest {
         assertThat(additional2.refCnt(), is(1));
 
         try {
-            body.decode(buf -> buf.toString(UTF_8), 6).toBlocking().single();
+            body.decode(bytes -> bytes.toString(UTF_8), 6).toBlocking().single();
         } catch (RuntimeException e) {
             cause = e;
         }
@@ -125,7 +126,7 @@ public class HttpMessageBodyTest {
         assertThat(buf1.refCnt(), is(1));
         assertThat(buf2.refCnt(), is(1));
 
-        String result = body.decode((buf) -> buf.toString(Charsets.US_ASCII), 100).toBlocking().single();
+        String result = body.decode(bytes -> bytes.toString(US_ASCII), 100).toBlocking().single();
         assertThat(result, is("foobar"));
 
         assertThat(buf1.refCnt(), is(0));
@@ -167,7 +168,7 @@ public class HttpMessageBodyTest {
         content.onError(new RuntimeException("something went wrong"));
         HttpMessageBody body = new HttpMessageBody(content);
 
-        Observable<String> aggregated = body.decode(byteBuf -> byteBuf.toString(Charsets.UTF_8), 1000);
+        Observable<String> aggregated = body.decode(bytes -> bytes.toString(UTF_8), 1000);
 
         TestSubscriber<String> subscriber = new TestSubscriber<>();
         aggregated.subscribe(subscriber);

--- a/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
@@ -529,7 +529,7 @@ public class HttpRequestTest {
                 .body(stream("foo", "bar", "baz"))
                 .build();
 
-        FullHttpRequest<String> full = request.toFullHttpRequest(byteBuf -> byteBuf.toString(UTF_8), 0x100000)
+        FullHttpRequest full = request.toFullHttpRequest(byteBuf -> byteBuf.toString(UTF_8), 0x100000)
                 .toBlocking()
                 .single();
 
@@ -550,7 +550,7 @@ public class HttpRequestTest {
                 .body(empty())
                 .build();
 
-        FullHttpRequest<String> full = request.toFullHttpRequest(byteBuf -> byteBuf.toString(UTF_8), 0x100000)
+        FullHttpRequest full = request.toFullHttpRequest(byteBuf -> byteBuf.toString(UTF_8), 0x100000)
                 .toBlocking()
                 .single();
 
@@ -564,7 +564,7 @@ public class HttpRequestTest {
                 .body(stream("foo", "bar", "baz"))
                 .build();
 
-        FullHttpRequest<String> full = request.toFullHttpRequest(0x100000)
+        FullHttpRequest full = request.toFullHttpRequest(0x100000)
                 .toBlocking()
                 .single();
 

--- a/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
@@ -529,19 +529,17 @@ public class HttpRequestTest {
                 .body(stream("foo", "bar", "baz"))
                 .build();
 
-        FullHttpRequest full = request.toFullHttpRequest(byteBuf -> byteBuf.toString(UTF_8), 0x100000)
+        FullHttpRequest full = request.toFullRequest(0x100000)
                 .toBlocking()
                 .single();
 
         assertThat(full.method(), is(POST));
-        assertThat(full.clientAddress().getHostName(), is("example.org"));
-        assertThat(full.clientAddress().getPort(), is(8080));
         assertThat(full.isSecure(), is(true));
         assertThat(full.version(), is(HTTP_1_0));
         assertThat(full.headers(), contains(header("HeaderName", "HeaderValue")));
         assertThat(full.cookies(), contains(cookie("CookieName", "CookieValue")));
         assertThat(full.url().toString(), is("/foo/bar"));
-        assertThat(full.body(), is("foobarbaz"));
+        assertThat(full.bodyAs(UTF_8), is("foobarbaz"));
     }
 
     @Test
@@ -550,12 +548,12 @@ public class HttpRequestTest {
                 .body(empty())
                 .build();
 
-        FullHttpRequest full = request.toFullHttpRequest(byteBuf -> byteBuf.toString(UTF_8), 0x100000)
+        FullHttpRequest full = request.toFullRequest(0x100000)
                 .toBlocking()
                 .single();
 
         assertThat(full.url().toString(), is("/foo/bar"));
-        assertThat(full.body(), is(""));
+        assertThat(full.bodyAs(UTF_8), is(""));
     }
 
     @Test
@@ -564,12 +562,12 @@ public class HttpRequestTest {
                 .body(stream("foo", "bar", "baz"))
                 .build();
 
-        FullHttpRequest full = request.toFullHttpRequest(0x100000)
+        FullHttpRequest full = request.toFullRequest(0x100000)
                 .toBlocking()
                 .single();
 
         assertThat(full.url().toString(), is("/foo/bar"));
-        assertThat(full.body(), is("foobarbaz"));
+        assertThat(full.bodyAs(UTF_8), is("foobarbaz"));
     }
 
     private static Observable<ByteBuf> stream(String... strings) {

--- a/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
@@ -570,6 +570,24 @@ public class HttpRequestTest {
         assertThat(full.bodyAs(UTF_8), is("foobarbaz"));
     }
 
+    @Test
+    public void retainsClientAddressAfterConversionToFullHttpMessage() {
+        InetSocketAddress address = InetSocketAddress.createUnresolved("styx.io", 8080);
+        HttpRequest original = HttpRequest.Builder.get("/")
+                .clientAddress(address)
+                .build();
+
+        FullHttpRequest fullRequest = original
+                .toFullRequest(100)
+                .toBlocking()
+                .first();
+
+        HttpRequest streaming = fullRequest.toStreamingRequest();
+
+        assertThat(streaming.clientAddress().getHostName(), is("styx.io"));
+        assertThat(streaming.clientAddress().getPort(), is(8080));
+    }
+
     private static Observable<ByteBuf> stream(String... strings) {
         return Observable.from(Stream.of(strings)
                 .map(string -> Unpooled.copiedBuffer(string, UTF_8))

--- a/components/api/src/test/java/com/hotels/styx/api/HttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpResponseTest.java
@@ -184,7 +184,8 @@ public class HttpResponseTest {
 
         String reply = shouldClearBody
                 .body()
-                .decode(byteBuf -> byteBuf.toString(StandardCharsets.UTF_8), 18)
+                .aggregate(18)
+                .map(bytebuf -> bytebuf.toString(UTF_8))
                 .toBlocking()
                 .first();
 
@@ -399,7 +400,7 @@ public class HttpResponseTest {
                 .body(stream("foo", "bar", "baz"))
                 .build();
 
-        FullHttpResponse full = request.toFullHttpResponse(byteBuf -> byteBuf.toString(StandardCharsets.UTF_8), 0x100000)
+        FullHttpResponse full = request.toFullResponse(0x100000)
                 .toBlocking()
                 .single();
 
@@ -409,7 +410,7 @@ public class HttpResponseTest {
         assertThat(full.cookies(), contains(cookie("CookieName", "CookieValue")));
 
         assertThat(full.status(), is(CREATED));
-        assertThat(full.body(), is("foobarbaz"));
+        assertThat(full.bodyAs(UTF_8), is("foobarbaz"));
     }
 
     @Test
@@ -418,12 +419,12 @@ public class HttpResponseTest {
                 .body(empty())
                 .build();
 
-        FullHttpResponse full = request.toFullHttpResponse(byteBuf -> byteBuf.toString(StandardCharsets.UTF_8), 0x100000)
+        FullHttpResponse full = request.toFullResponse(0x100000)
                 .toBlocking()
                 .single();
 
         assertThat(full.status(), is(CREATED));
-        assertThat(full.body(), is(""));
+        assertThat(full.bodyAs(UTF_8), is(""));
     }
 
     @Test
@@ -432,12 +433,12 @@ public class HttpResponseTest {
                 .body(stream("foo", "bar", "baz"))
                 .build();
 
-        FullHttpResponse full = request.toFullHttpResponse(0x100000)
+        FullHttpResponse full = request.toFullResponse(0x100000)
                 .toBlocking()
                 .single();
 
         assertThat(full.status(), is(CREATED));
-        assertThat(full.body(), is("foobarbaz"));
+        assertThat(full.bodyAs(UTF_8), is("foobarbaz"));
     }
 
     private static Observable<ByteBuf> stream(String... strings) {

--- a/components/api/src/test/java/com/hotels/styx/api/HttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpResponseTest.java
@@ -399,7 +399,7 @@ public class HttpResponseTest {
                 .body(stream("foo", "bar", "baz"))
                 .build();
 
-        FullHttpResponse<String> full = request.toFullHttpResponse(byteBuf -> byteBuf.toString(StandardCharsets.UTF_8), 0x100000)
+        FullHttpResponse full = request.toFullHttpResponse(byteBuf -> byteBuf.toString(StandardCharsets.UTF_8), 0x100000)
                 .toBlocking()
                 .single();
 
@@ -418,7 +418,7 @@ public class HttpResponseTest {
                 .body(empty())
                 .build();
 
-        FullHttpResponse<String> full = request.toFullHttpResponse(byteBuf -> byteBuf.toString(StandardCharsets.UTF_8), 0x100000)
+        FullHttpResponse full = request.toFullHttpResponse(byteBuf -> byteBuf.toString(StandardCharsets.UTF_8), 0x100000)
                 .toBlocking()
                 .single();
 
@@ -432,7 +432,7 @@ public class HttpResponseTest {
                 .body(stream("foo", "bar", "baz"))
                 .build();
 
-        FullHttpResponse<String> full = request.toFullHttpResponse(0x100000)
+        FullHttpResponse full = request.toFullHttpResponse(0x100000)
                 .toBlocking()
                 .single();
 

--- a/components/api/src/test/java/com/hotels/styx/api/TestSupport.java
+++ b/components/api/src/test/java/com/hotels/styx/api/TestSupport.java
@@ -17,11 +17,12 @@ package com.hotels.styx.api;
 
 import rx.Observable;
 
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class TestSupport {
     static String bodyAsString(HttpMessageBody body) {
-        return body.decode(byteBuf -> byteBuf.toString(StandardCharsets.UTF_8), 0x100000)
+        return body.aggregate(0x100000)
+                .map(bytes -> bytes.toString(UTF_8))
                 .toBlocking()
                 .single();
     }

--- a/components/api/src/test/java/com/hotels/styx/api/messages/FullHttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/messages/FullHttpRequestTest.java
@@ -146,7 +146,7 @@ public class FullHttpRequestTest {
                 .build();
 
         assertThat(request.toString(), is("FullHttpRequest{version=HTTP/1.1, method=PATCH, uri=https://hotels.com, " +
-                "headers=[headerName=a, Host=hotels.com], cookies=[cfoo=bar], id=id, secure=true}"));
+                "headers=[headerName=a, Host=hotels.com], cookies=[cfoo=bar], id=id, clientAddress=127.0.0.1:0, secure=true}"));
 
         assertThat(request.headers("headerName"), is(singletonList("a")));
     }

--- a/components/api/src/test/java/com/hotels/styx/api/messages/FullHttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/messages/FullHttpRequestTest.java
@@ -79,7 +79,9 @@ public class FullHttpRequestTest {
         assertThat(streaming.clientAddress().getPort(), is(8080));
         assertThat(streaming.isSecure(), is(true));
         assertThat(streaming.version(), is(HTTP_1_0));
-        assertThat(streaming.headers(), contains(header("HeaderName", "HeaderValue")));
+        assertThat(streaming.headers(), containsInAnyOrder(
+                header("Content-Length", "6"),
+                header("HeaderName", "HeaderValue")));
         assertThat(streaming.cookies(), contains(cookie("CookieName", "CookieValue")));
 
         String body = streaming.body()

--- a/components/api/src/test/java/com/hotels/styx/api/messages/FullHttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/messages/FullHttpResponseTest.java
@@ -62,7 +62,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class FullHttpResponseTest {
     @Test
     public void encodesToStreamingHttpResponse() {
-        FullHttpResponse<String> response = response(CREATED)
+        FullHttpResponse response = response(CREATED)
                 .version(HTTP_1_0)
                 .header("HeaderName", "HeaderValue")
                 .addCookie("CookieName", "CookieValue")
@@ -85,7 +85,7 @@ public class FullHttpResponseTest {
     }
 
     @Test(dataProvider = "emptyBodyResponses")
-    public void encodesToStreamingHttpResponseWithEmptyBody(FullHttpResponse<String> response) {
+    public void encodesToStreamingHttpResponseWithEmptyBody(FullHttpResponse response) {
         HttpResponse streaming = response.toStreamingHttpResponse(string -> copiedBuffer(string, UTF_8));
 
         TestSubscriber<ByteBuf> subscriber = TestSubscriber.create(0);
@@ -114,7 +114,7 @@ public class FullHttpResponseTest {
 
     @Test
     public void encodingToStreamingHttpResponseDefaultsToUTF8() {
-        FullHttpResponse<String> response = response()
+        FullHttpResponse response = response()
                 .body("foobar")
                 .build();
 
@@ -132,7 +132,7 @@ public class FullHttpResponseTest {
 
     @Test
     public void createsAResponseWithDefaultValues() {
-        FullHttpResponse<String> response = response().build();
+        FullHttpResponse response = response().build();
         assertThat(response.version(), is(HTTP_1_1));
         assertThat(response.cookies(), is(emptyIterable()));
         assertThat(response.headers(), is(emptyIterable()));
@@ -141,7 +141,7 @@ public class FullHttpResponseTest {
 
     @Test
     public void createsResponseWithMinimalInformation() {
-        FullHttpResponse<String> response = response()
+        FullHttpResponse response = response()
                 .status(BAD_GATEWAY)
                 .version(HTTP_1_0)
                 .build();
@@ -160,7 +160,7 @@ public class FullHttpResponseTest {
 
     @Test
     public void setsASingleOutboundCookie() {
-        FullHttpResponse<String> response = response()
+        FullHttpResponse response = response()
                 .addCookie(cookie("user", "QSplbl9HX1VL", domain(".hotels.com"), path("/"), maxAge(3600)))
                 .build();
 
@@ -169,7 +169,7 @@ public class FullHttpResponseTest {
 
     @Test
     public void setsMultipleOutboundCookies() {
-        FullHttpResponse<String> response = response()
+        FullHttpResponse response = response()
                 .addCookie("a", "b")
                 .addCookie("c", "d")
                 .build();
@@ -183,7 +183,7 @@ public class FullHttpResponseTest {
 
     @Test
     public void getASingleCookieValue() {
-        FullHttpResponse<String> response = response()
+        FullHttpResponse response = response()
                 .addCookie("a", "b")
                 .addCookie("c", "d")
                 .build();
@@ -194,11 +194,11 @@ public class FullHttpResponseTest {
     @Test
     public void canRemoveAHeader() {
         Object headerValue = "b";
-        FullHttpResponse<String> response = response()
+        FullHttpResponse response = response()
                 .header("a", headerValue)
                 .addHeader("c", headerValue)
                 .build();
-        FullHttpResponse<String> shouldRemoveHeader = response.newBuilder()
+        FullHttpResponse shouldRemoveHeader = response.newBuilder()
                 .removeHeader("c")
                 .build();
 
@@ -207,18 +207,18 @@ public class FullHttpResponseTest {
 
     @Test
     public void removesACookie() {
-        FullHttpResponse<String> response = new FullHttpResponse.Builder<>(seeOther("/home"))
+        FullHttpResponse response = new FullHttpResponse.Builder(seeOther("/home"))
                 .addCookie(cookie("a", "b"))
                 .addCookie(cookie("c", "d"))
                 .build();
-        FullHttpResponse<String> shouldClearCookie = response.newBuilder()
+        FullHttpResponse shouldClearCookie = response.newBuilder()
                 .removeCookie("a")
                 .build();
 
         assertThat(shouldClearCookie.cookies(), contains(cookie("c", "d")));
     }
 
-    private static FullHttpResponse<String> seeOther(String newLocation) {
+    private static FullHttpResponse seeOther(String newLocation) {
         return response(SEE_OTHER)
                 .header(LOCATION, newLocation)
                 .build();
@@ -226,11 +226,11 @@ public class FullHttpResponseTest {
 
     @Test
     public void canRemoveResponseBody() {
-        FullHttpResponse<String> response = response(NO_CONTENT)
+        FullHttpResponse response = response(NO_CONTENT)
                 .body("shouldn't be here")
                 .build();
 
-        FullHttpResponse<String> shouldClearBody = response.newBuilder()
+        FullHttpResponse shouldClearBody = response.newBuilder()
                 .body(null)
                 .build();
 
@@ -239,13 +239,13 @@ public class FullHttpResponseTest {
 
     @Test
     public void supportsCaseInsensitiveHeaderNames() {
-        FullHttpResponse<String> response = response(OK).header("Content-Type", "text/plain").build();
+        FullHttpResponse response = response(OK).header("Content-Type", "text/plain").build();
         assertThat(response.header("content-type"), isValue("text/plain"));
     }
 
     @Test
     public void headerValuesAreCaseSensitive() {
-        FullHttpResponse<String> response = response(OK).header("Content-Type", "TEXT/PLAIN").build();
+        FullHttpResponse response = response(OK).header("Content-Type", "TEXT/PLAIN").build();
         assertThat(response.header("content-type"), not(isValue("text/plain")));
     }
 
@@ -262,8 +262,8 @@ public class FullHttpResponseTest {
 
     @Test
     public void shouldRemoveContentLengthFromChunkedMessages() {
-        FullHttpResponse<String> response = response().header(CONTENT_LENGTH, 5).build();
-        FullHttpResponse<String> chunkedResponse = response.newBuilder().setChunked().build();
+        FullHttpResponse response = response().header(CONTENT_LENGTH, 5).build();
+        FullHttpResponse chunkedResponse = response.newBuilder().setChunked().build();
 
         assertThat(chunkedResponse.chunked(), is(true));
         assertThat(chunkedResponse.header(CONTENT_LENGTH).isPresent(), is(false));
@@ -271,8 +271,8 @@ public class FullHttpResponseTest {
 
     @Test
     public void shouldNotFailToRemoveNonExistentContentLength() {
-        FullHttpResponse<String> response = response().build();
-        FullHttpResponse<String> chunkedResponse = response.newBuilder().setChunked().build();
+        FullHttpResponse response = response().build();
+        FullHttpResponse chunkedResponse = response.newBuilder().setChunked().build();
 
         assertThat(chunkedResponse.chunked(), is(true));
         assertThat(chunkedResponse.header(CONTENT_LENGTH).isPresent(), is(false));
@@ -280,7 +280,7 @@ public class FullHttpResponseTest {
 
     @Test
     public void overridesContent() {
-        FullHttpResponse<String> response = response()
+        FullHttpResponse response = response()
                 .body("Response content.")
                 .body(" ")
                 .body("Extra content")
@@ -291,7 +291,7 @@ public class FullHttpResponseTest {
 
     @Test
     public void addsHeaderValue() {
-        FullHttpResponse<String> response = response()
+        FullHttpResponse response = response()
                 .header("name", "value1")
                 .addHeader("name", "value2")
                 .build();
@@ -363,13 +363,13 @@ public class FullHttpResponseTest {
 
     @Test
     public void allowsModificationOfHeadersBasedOnBody() {
-        FullHttpResponse<String> response = response()
+        FullHttpResponse response = response()
                 .body("foobar")
                 .build();
 
         assertThat(response.header("some-header"), isAbsent());
 
-        FullHttpResponse<String> newResponse = response.newBuilder()
+        FullHttpResponse newResponse = response.newBuilder()
                 .header("some-header", contentLength(response.body()))
                 .build();
 
@@ -379,22 +379,22 @@ public class FullHttpResponseTest {
 
     @Test
     public void allowsModificationOfBodyBasedOnExistingBody() {
-        FullHttpResponse<String> response = response()
+        FullHttpResponse response = response()
                 .body("foobar")
                 .build();
 
-        FullHttpResponse<String> newResponse = response.newBuilder()
+        FullHttpResponse newResponse = response.newBuilder()
                 .body(response.body() + "x")
                 .build();
 
         assertThat(newResponse.body(), is("foobarx"));
     }
 
-    private static FullHttpResponse.Builder<String> response() {
+    private static FullHttpResponse.Builder response() {
         return FullHttpResponse.response();
     }
 
-    private static FullHttpResponse.Builder<String> response(HttpResponseStatus status) {
+    private static FullHttpResponse.Builder response(HttpResponseStatus status) {
         return FullHttpResponse.response(status);
     }
 
@@ -402,7 +402,7 @@ public class FullHttpResponseTest {
         return content.getBytes(UTF_8).length;
     }
 
-    private static Optional<String> contentLength(FullHttpResponse.Builder<?> builder) {
+    private static Optional<String> contentLength(FullHttpResponse.Builder builder) {
         return builder.build().header(CONTENT_LENGTH);
     }
 }

--- a/components/api/src/test/java/com/hotels/styx/api/messages/FullHttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/messages/FullHttpResponseTest.java
@@ -53,6 +53,7 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
@@ -73,7 +74,9 @@ public class FullHttpResponseTest {
 
         assertThat(streaming.status(), is(CREATED));
         assertThat(streaming.version(), is(HTTP_1_0));
-        assertThat(streaming.headers(), contains(header("HeaderName", "HeaderValue")));
+        assertThat(streaming.headers(), containsInAnyOrder(
+                header("Content-Length", "6"),
+                header("HeaderName", "HeaderValue")));
         assertThat(streaming.cookies(), contains(cookie("CookieName", "CookieValue")));
 
         String body = streaming.body()
@@ -234,7 +237,7 @@ public class FullHttpResponseTest {
                 .body(null)
                 .build();
 
-        assertThat(shouldClearBody.body(), is(nullValue()));
+        assertThat(shouldClearBody.body(), is(""));
     }
 
     @Test

--- a/components/api/src/test/java/com/hotels/styx/api/service/spi/AbstractStyxServiceTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/service/spi/AbstractStyxServiceTest.java
@@ -26,6 +26,7 @@ import static com.hotels.styx.api.service.spi.StyxServiceStatus.RUNNING;
 import static com.hotels.styx.api.service.spi.StyxServiceStatus.STARTING;
 import static com.hotels.styx.api.service.spi.StyxServiceStatus.STOPPED;
 import static com.hotels.styx.api.service.spi.StyxServiceStatus.STOPPING;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -38,12 +39,12 @@ public class AbstractStyxServiceTest {
     public void exposesNameAndStatusViaAdminInterface() {
         DerivedStyxService service = new DerivedStyxService("derived-service", new CompletableFuture<>());
 
-        FullHttpResponse<String> response = service.adminInterfaceHandlers().get("status").handle(get)
-                .flatMap(r -> r.toFullHttpResponse(1024))
+        FullHttpResponse response = service.adminInterfaceHandlers().get("status").handle(get)
+                .flatMap(r -> r.toFullResponse(1024))
                 .toBlocking()
                 .first();
 
-        assertThat(response.body(), is("{ name: \"derived-service\" status: \"CREATED\" }"));
+        assertThat(response.bodyAs(UTF_8), is("{ name: \"derived-service\" status: \"CREATED\" }"));
     }
 
     @Test

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/HttpClientSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/HttpClientSpec.scala
@@ -88,7 +88,7 @@ class HttpClientSpec extends FunSuite with BeforeAndAfterAll with ShouldMatchers
     val response = waitForResponse(client.sendRequest(get("/foo/2").build()))
 
     assert(response.status() == OK, s"\nDid not get response with 200 OK status.\n$response\n")
-    assert(response.body() == "Test message body.", s"\nReceived wrong/unexpected response body.")
+    assert(response.bodyAs(UTF_8) == "Test message body.", s"\nReceived wrong/unexpected response body.")
   }
 
 
@@ -99,7 +99,7 @@ class HttpClientSpec extends FunSuite with BeforeAndAfterAll with ShouldMatchers
     assert(response.status() == OK, s"\nDid not get response with 200 OK status.\n$response\n")
 
     assert(response.body().nonEmpty, s"\nResponse body is absent.")
-    assert(response.body() == "Test message body.", s"\nIncorrect response body.")
+    assert(response.bodyAs(UTF_8) == "Test message body.", s"\nIncorrect response body.")
   }
 
   test("Emits onError when origin responds too slowly") {

--- a/components/client/src/test/unit/java/com/hotels/styx/client/SimpleNettyHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/SimpleNettyHttpClientTest.java
@@ -19,7 +19,6 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.hotels.styx.api.HttpClient;
 import com.hotels.styx.api.HttpRequest;
-import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.ConnectionDestination;
 import com.hotels.styx.api.messages.FullHttpResponse;
@@ -32,7 +31,6 @@ import com.hotels.styx.client.ssl.TlsSettings;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import rx.Subscription;
 import rx.observers.TestSubscriber;
 import rx.subjects.ReplaySubject;
 
@@ -71,8 +69,8 @@ public class SimpleNettyHttpClientTest {
     @Test
     public void sendsHttp() throws IOException {
         withOrigin(HTTP, port -> {
-            FullHttpResponse<String> response = httpClient().sendRequest(httpRequest(port))
-                    .flatMap(r -> r.toFullHttpResponse(MAX_LENGTH))
+            FullHttpResponse response = httpClient().sendRequest(httpRequest(port))
+                    .flatMap(r -> r.toFullResponse(MAX_LENGTH))
                     .toBlocking()
                     .single();
 
@@ -83,8 +81,8 @@ public class SimpleNettyHttpClientTest {
     @Test
     public void sendsHttps() throws IOException {
         withOrigin(HTTPS, port -> {
-            FullHttpResponse<String> response = httpsClient().sendRequest(httpsRequest(port))
-                    .flatMap(r -> r.toFullHttpResponse(MAX_LENGTH))
+            FullHttpResponse response = httpsClient().sendRequest(httpsRequest(port))
+                    .flatMap(r -> r.toFullResponse(MAX_LENGTH))
                     .toBlocking()
                     .single();
 
@@ -95,8 +93,8 @@ public class SimpleNettyHttpClientTest {
     @Test(expectedExceptions = Exception.class)
     public void cannotSendHttpsWhenConfiguredForHttp() throws IOException {
         withOrigin(HTTPS, port -> {
-            FullHttpResponse<String> response = httpClient().sendRequest(httpsRequest(port))
-                    .flatMap(r -> r.toFullHttpResponse(MAX_LENGTH))
+            FullHttpResponse response = httpClient().sendRequest(httpsRequest(port))
+                    .flatMap(r -> r.toFullResponse(MAX_LENGTH))
                     .toBlocking()
                     .single();
 
@@ -107,8 +105,8 @@ public class SimpleNettyHttpClientTest {
     @Test(expectedExceptions = Exception.class)
     public void cannotSendHttpWhenConfiguredForHttps() throws IOException {
         withOrigin(HTTP, port -> {
-            FullHttpResponse<String> response = httpsClient().sendRequest(httpRequest(port))
-                    .flatMap(r -> r.toFullHttpResponse(MAX_LENGTH))
+            FullHttpResponse response = httpsClient().sendRequest(httpRequest(port))
+                    .flatMap(r -> r.toFullResponse(MAX_LENGTH))
                     .toBlocking()
                     .single();
 
@@ -225,7 +223,7 @@ public class SimpleNettyHttpClientTest {
                 .build();
 
         client.sendRequest(request)
-                .flatMap(r -> r.toFullHttpResponse(MAX_LENGTH))
+                .flatMap(r -> r.toFullResponse(MAX_LENGTH))
                 .toBlocking()
                 .single();
     }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxHttpClientTest.java
@@ -119,8 +119,8 @@ public class StyxHttpClientTest {
     @Test
     public void sendsHttp() throws IOException {
         withOrigin(HTTP, port -> {
-            FullHttpResponse<String> response = httpClient(port).sendRequest(httpRequest(8080))
-                    .flatMap(r -> r.toFullHttpResponse(MAX_LENGTH))
+            FullHttpResponse response = httpClient(port).sendRequest(httpRequest(8080))
+                    .flatMap(r -> r.toFullResponse(MAX_LENGTH))
                     .toBlocking()
                     .single();
 
@@ -131,8 +131,8 @@ public class StyxHttpClientTest {
     @Test
     public void sendsHttps() throws IOException {
         withOrigin(HTTPS, port -> {
-            FullHttpResponse<String> response = httpsClient(port).sendRequest(httpsRequest(8080))
-                    .flatMap(r -> r.toFullHttpResponse(MAX_LENGTH))
+            FullHttpResponse response = httpsClient(port).sendRequest(httpsRequest(8080))
+                    .flatMap(r -> r.toFullResponse(MAX_LENGTH))
                     .toBlocking()
                     .single();
 
@@ -143,8 +143,8 @@ public class StyxHttpClientTest {
     @Test(expectedExceptions = Exception.class)
     public void cannotSendHttpsWhenConfiguredForHttp() throws IOException {
         withOrigin(HTTPS, port -> {
-            FullHttpResponse<String> response = httpClient(port).sendRequest(httpsRequest(8080))
-                    .flatMap(r -> r.toFullHttpResponse(MAX_LENGTH))
+            FullHttpResponse response = httpClient(port).sendRequest(httpsRequest(8080))
+                    .flatMap(r -> r.toFullResponse(MAX_LENGTH))
                     .toBlocking()
                     .single();
 
@@ -155,8 +155,8 @@ public class StyxHttpClientTest {
     @Test(expectedExceptions = Exception.class)
     public void cannotSendHttpWhenConfiguredForHttps() throws IOException {
         withOrigin(HTTP, port -> {
-            FullHttpResponse<String> response = httpsClient(port).sendRequest(httpRequest(8080))
-                    .flatMap(r -> r.toFullHttpResponse(MAX_LENGTH))
+            FullHttpResponse response = httpsClient(port).sendRequest(httpRequest(8080))
+                    .flatMap(r -> r.toFullResponse(MAX_LENGTH))
                     .toBlocking()
                     .single();
 

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/LoggingConfigurationHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/LoggingConfigurationHandlerTest.java
@@ -29,6 +29,7 @@ import static com.hotels.styx.support.api.BlockingObservables.waitForResponse;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class LoggingConfigurationHandlerTest {
     @Test
@@ -38,10 +39,10 @@ public class LoggingConfigurationHandlerTest {
                 .build();
         LoggingConfigurationHandler handler = new LoggingConfigurationHandler(startupConfig.logConfigLocation());
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/").build()));
 
         assertThat(response.status(), is(OK));
-        assertThat(response.body(), is("Could not load resource='/foo/bar'"));
+        assertThat(response.bodyAs(UTF_8), is("Could not load resource='/foo/bar'"));
     }
 
     @Test
@@ -51,11 +52,11 @@ public class LoggingConfigurationHandlerTest {
                 .build();
         LoggingConfigurationHandler handler = new LoggingConfigurationHandler(startupConfig.logConfigLocation());
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/").build()));
 
         String expected = Resources.load(new ClasspathResource("conf/environment/styx-config-test.yml", LoggingConfigurationHandlerTest.class));
 
         assertThat(response.status(), is(OK));
-        assertThat(response.body(), is(expected));
+        assertThat(response.bodyAs(UTF_8), is(expected));
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/MetricsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/MetricsHandlerTest.java
@@ -25,6 +25,7 @@ import static com.google.common.net.MediaType.JSON_UTF_8;
 import static com.hotels.styx.api.HttpRequest.Builder.get;
 import static com.hotels.styx.support.api.BlockingObservables.waitForResponse;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -34,7 +35,7 @@ public class MetricsHandlerTest {
 
     @Test
     public void respondsToRequestWithJsonResponse() {
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/metrics").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/metrics").build()));
         assertThat(response.status(), is(OK));
         assertThat(response.contentType().get(), is(JSON_UTF_8.toString()));
     }
@@ -42,7 +43,7 @@ public class MetricsHandlerTest {
     @Test
     public void exposesRegisteredMetrics() {
         metricRegistry.counter("foo").inc();
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/metrics").build()));
-        assertThat(response.body(), is("{\"version\":\"3.0.0\",\"gauges\":{},\"counters\":{\"foo\":{\"count\":1}},\"histograms\":{},\"meters\":{},\"timers\":{}}"));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/metrics").build()));
+        assertThat(response.bodyAs(UTF_8), is("{\"version\":\"3.0.0\",\"gauges\":{},\"counters\":{\"foo\":{\"count\":1}},\"histograms\":{},\"meters\":{},\"timers\":{}}"));
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/OriginsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/OriginsHandlerTest.java
@@ -43,6 +43,7 @@ import static java.util.stream.StreamSupport.stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class OriginsHandlerTest {
     static final ObjectMapper MAPPER = new ObjectMapper().disable(FAIL_ON_UNKNOWN_PROPERTIES);
@@ -64,12 +65,12 @@ public class OriginsHandlerTest {
 
     @Test
     public void respondsToRequestWithJsonResponse() throws IOException {
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/admin/configuration/origins").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/admin/configuration/origins").build()));
 
         assertThat(response.status(), is(OK));
         assertThat(response.contentType(), isValue(JSON_UTF_8.toString()));
 
-        assertThat(response.body(), unmarshalApplications(response.body()), containsInAnyOrder(expected()));
+        assertThat(response.bodyAs(UTF_8), unmarshalApplications(response.bodyAs(UTF_8)), containsInAnyOrder(expected()));
     }
 
     @Test
@@ -77,12 +78,12 @@ public class OriginsHandlerTest {
         Registry<BackendService> backendServicesRegistry = new MemoryBackedRegistry<>();
         OriginsHandler handler = new OriginsHandler(backendServicesRegistry);
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/admin/configuration/origins").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/admin/configuration/origins").build()));
 
         assertThat(response.status(), is(OK));
         assertThat(response.contentType(), isValue(JSON_UTF_8.toString()));
 
-        assertThat(response.body(), is("[]"));
+        assertThat(response.bodyAs(UTF_8), is("[]"));
     }
 
     private ApplicationConfigurationMatcher[] expected() {

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/OriginsInventoryHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/OriginsInventoryHandlerTest.java
@@ -43,6 +43,7 @@ import static java.util.stream.IntStream.range;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class OriginsInventoryHandlerTest {
     private static final Id APP_ID = id("foo");
@@ -58,10 +59,10 @@ public class OriginsInventoryHandlerTest {
 
         eventBus.post(new OriginsInventorySnapshot(APP_ID, pool(activeOrigins), pool(inactiveOrigins), pool(disabledOrigins)));
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/").build()));
-        assertThat(response.body().split("\n").length, is(1));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/").build()));
+        assertThat(response.bodyAs(UTF_8).split("\n").length, is(1));
 
-        Map<Id, OriginsInventorySnapshot> output = deserialiseJson(response.body());
+        Map<Id, OriginsInventorySnapshot> output = deserialiseJson(response.bodyAs(UTF_8));
 
         assertThat(output.keySet(), contains(APP_ID));
 
@@ -82,8 +83,8 @@ public class OriginsInventoryHandlerTest {
 
         eventBus.post(new OriginsInventorySnapshot(APP_ID, pool(emptySet()), pool(emptySet()), pool(disabledOrigins)));
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/?pretty=1").build()));
-        assertThat(response.body(), matchesRegex("\\{\n" +
+        FullHttpResponse response = waitForResponse(handler.handle(get("/?pretty=1").build()));
+        assertThat(response.bodyAs(UTF_8), matchesRegex("\\{\n" +
                 "  \"" + APP_ID + "\" : \\{\n" +
                 "    \"appId\" : \"" + APP_ID + "\",\n" +
                 "    \"activeOrigins\" : \\[ ],\n" +
@@ -103,9 +104,9 @@ public class OriginsInventoryHandlerTest {
     public void returnsEmptyObjectWhenNoOrigins() {
         OriginsInventoryHandler handler = new OriginsInventoryHandler(new EventBus());
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/").build()));
 
-        assertThat(response.body(), is("{}"));
+        assertThat(response.bodyAs(UTF_8), is("{}"));
     }
 
     private static Map<Id, OriginsInventorySnapshot> deserialiseJson(String json) throws IOException {

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/PingHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/PingHandlerTest.java
@@ -22,6 +22,7 @@ import static com.hotels.styx.api.HttpRequest.Builder.get;
 import static com.hotels.styx.support.api.BlockingObservables.waitForResponse;
 import static com.hotels.styx.support.api.matchers.HttpHeadersMatcher.isNotCacheable;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -30,11 +31,11 @@ public class PingHandlerTest {
 
     @Test
     public void respondsPongToPingRequest() {
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/ping").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/ping").build()));
         assertThat(response.status(), is(OK));
         assertThat(response.headers(), isNotCacheable());
         assertThat(response.contentType().get(), is("text/plain; charset=utf-8"));
-        assertThat(response.body(), is("pong"));
+        assertThat(response.bodyAs(UTF_8), is("pong"));
     }
 
 }

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/PluginListHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/PluginListHandlerTest.java
@@ -27,6 +27,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class PluginListHandlerTest {
     @Test
@@ -43,10 +44,10 @@ public class PluginListHandlerTest {
 
         PluginListHandler handler = new PluginListHandler(plugins);
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/").build()));
 
         assertThat(response.status(), is(OK));
-        assertThat(response.body(), is("" +
+        assertThat(response.bodyAs(UTF_8), is("" +
                 "<h3>Enabled</h3>" +
                 "<a href='/admin/plugins/one'>one</a><br />" +
                 "<a href='/admin/plugins/four'>four</a><br />" +

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/PluginToggleHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/PluginToggleHandlerTest.java
@@ -34,6 +34,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class PluginToggleHandlerTest {
     private NamedPlugin initiallyEnabled;
@@ -57,10 +58,10 @@ public class PluginToggleHandlerTest {
     public void enablesDisabledPlugin() {
         HttpRequest request = put("/foo/off/enabled").body("true").build();
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(OK));
-        assertThat(response.body(), is("{\"message\":\"State of 'off' changed to 'enabled'\",\"plugin\":{\"name\":\"off\",\"state\":\"enabled\"}}\n"));
+        assertThat(response.bodyAs(UTF_8), is("{\"message\":\"State of 'off' changed to 'enabled'\",\"plugin\":{\"name\":\"off\",\"state\":\"enabled\"}}\n"));
         assertThat(initiallyEnabled.enabled(), is(true));
         assertThat(initiallyDisabled.enabled(), is(true));
     }
@@ -69,10 +70,10 @@ public class PluginToggleHandlerTest {
     public void disablesEnabledPlugin() {
         HttpRequest request = put("/foo/on/enabled").body("false").build();
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(OK));
-        assertThat(response.body(), is("{\"message\":\"State of 'on' changed to 'disabled'\",\"plugin\":{\"name\":\"on\",\"state\":\"disabled\"}}\n"));
+        assertThat(response.bodyAs(UTF_8), is("{\"message\":\"State of 'on' changed to 'disabled'\",\"plugin\":{\"name\":\"on\",\"state\":\"disabled\"}}\n"));
         assertThat(initiallyEnabled.enabled(), is(false));
         assertThat(initiallyDisabled.enabled(), is(false));
     }
@@ -81,10 +82,10 @@ public class PluginToggleHandlerTest {
     public void notifiesWhenPluginAlreadyDisabled() {
         HttpRequest request = put("/foo/off/enabled").body("false").build();
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(OK));
-        assertThat(response.body(), is("{\"message\":\"State of 'off' was already 'disabled'\",\"plugin\":{\"name\":\"off\",\"state\":\"disabled\"}}\n"));
+        assertThat(response.bodyAs(UTF_8), is("{\"message\":\"State of 'off' was already 'disabled'\",\"plugin\":{\"name\":\"off\",\"state\":\"disabled\"}}\n"));
         assertThat(initiallyEnabled.enabled(), is(true));
         assertThat(initiallyDisabled.enabled(), is(false));
     }
@@ -93,10 +94,10 @@ public class PluginToggleHandlerTest {
     public void notifiesWhenPluginAlreadyEnabled() {
         HttpRequest request = put("/foo/on/enabled").body("true").build();
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(OK));
-        assertThat(response.body(), is("{\"message\":\"State of 'on' was already 'enabled'\",\"plugin\":{\"name\":\"on\",\"state\":\"enabled\"}}\n"));
+        assertThat(response.bodyAs(UTF_8), is("{\"message\":\"State of 'on' was already 'enabled'\",\"plugin\":{\"name\":\"on\",\"state\":\"enabled\"}}\n"));
         assertThat(initiallyEnabled.enabled(), is(true));
         assertThat(initiallyDisabled.enabled(), is(false));
     }
@@ -105,10 +106,10 @@ public class PluginToggleHandlerTest {
     public void saysBadRequestWhenUrlIsInvalid() {
         HttpRequest request = put("/foo//enabled").body("true").build();
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(BAD_REQUEST));
-        assertThat(response.body(), is("Invalid URL\n"));
+        assertThat(response.bodyAs(UTF_8), is("Invalid URL\n"));
         assertThat(initiallyEnabled.enabled(), is(true));
         assertThat(initiallyDisabled.enabled(), is(false));
     }
@@ -117,10 +118,10 @@ public class PluginToggleHandlerTest {
     public void saysBadRequestWhenNoStateSpecified() {
         HttpRequest request = put("/foo/on/enabled").build();
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(BAD_REQUEST));
-        assertThat(response.body(), is("No such state: only 'true' and 'false' are valid.\n"));
+        assertThat(response.bodyAs(UTF_8), is("No such state: only 'true' and 'false' are valid.\n"));
         assertThat(initiallyEnabled.enabled(), is(true));
         assertThat(initiallyDisabled.enabled(), is(false));
     }
@@ -129,10 +130,10 @@ public class PluginToggleHandlerTest {
     public void saysBadRequestWhenPluginDoesNotExist() {
         HttpRequest request = put("/foo/nonexistent/enabled").body("true").build();
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(NOT_FOUND));
-        assertThat(response.body(), is("No such plugin\n"));
+        assertThat(response.bodyAs(UTF_8), is("No such plugin\n"));
         assertThat(initiallyEnabled.enabled(), is(true));
         assertThat(initiallyDisabled.enabled(), is(false));
     }
@@ -141,10 +142,10 @@ public class PluginToggleHandlerTest {
     public void saysBadRequestWhenValueIsInvalid() {
         HttpRequest request = put("/foo/off/enabled").body("invalid").build();
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(BAD_REQUEST));
-        assertThat(response.body(), is("No such state: only 'true' and 'false' are valid.\n"));
+        assertThat(response.bodyAs(UTF_8), is("No such state: only 'true' and 'false' are valid.\n"));
         assertThat(initiallyEnabled.enabled(), is(true));
         assertThat(initiallyDisabled.enabled(), is(false));
     }

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/StartupConfigHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/StartupConfigHandlerTest.java
@@ -25,6 +25,7 @@ import static com.hotels.styx.support.api.BlockingObservables.waitForResponse;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class StartupConfigHandlerTest {
     @Test
@@ -37,10 +38,10 @@ public class StartupConfigHandlerTest {
 
         StartupConfigHandler handler = new StartupConfigHandler(startupConfig);
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/").build()));
 
         assertThat(response.status(), is(OK));
-        assertThat(response.body(), is("<html><body>" +
+        assertThat(response.bodyAs(UTF_8), is("<html><body>" +
                 "Styx Home='/foo'" +
                 "<br />Config File Location='/bar/configure-me.yml'" +
                 "<br />Log Config Location='/baz/logback-conf.xml'" +

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/StatusHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/StatusHandlerTest.java
@@ -28,6 +28,7 @@ import static com.hotels.styx.api.HttpResponse.Builder.response;
 import static com.hotels.styx.support.api.BlockingObservables.waitForResponse;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -36,15 +37,15 @@ public class StatusHandlerTest {
     @Test
     public void returnsOKForHealthyHealthcheck() {
         StatusHandler statusHandler = new StatusHandler(underlyingHealthCheckIs(OK));
-        FullHttpResponse<String> response = waitForResponse(statusHandler.handle(get("/status").build()));
-        assertThat(response.body(), is("OK"));
+        FullHttpResponse response = waitForResponse(statusHandler.handle(get("/status").build()));
+        assertThat(response.bodyAs(UTF_8), is("OK"));
     }
 
     @Test
     public void returnsNOT_OKForFaultyHealthcheck() {
         StatusHandler statusHandler = new StatusHandler(underlyingHealthCheckIs(INTERNAL_SERVER_ERROR));
-        FullHttpResponse<String> response = waitForResponse(statusHandler.handle(get("/status").build()));
-        assertThat(response.body(), is("NOT_OK"));
+        FullHttpResponse response = waitForResponse(statusHandler.handle(get("/status").build()));
+        assertThat(response.bodyAs(UTF_8), is("NOT_OK"));
     }
 
     private static HttpHandler underlyingHealthCheckIs(HttpResponseStatus status) {

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/StyxConfigurationHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/StyxConfigurationHandlerTest.java
@@ -25,6 +25,7 @@ import rx.Observable;
 import static com.hotels.styx.api.HttpRequest.Builder.get;
 import static com.hotels.styx.support.ResourcePaths.fixturesHome;
 import static com.hotels.styx.support.api.BlockingObservables.waitForResponse;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -42,9 +43,9 @@ public class StyxConfigurationHandlerTest {
                 "  strategy: ROUND_ROBIN\n" +
                 "originsFile: " + ORIGINS_FILE + "\n";
 
-        FullHttpResponse<String> adminPageResponse = waitForResponse(browseForCurrentConfiguration(yaml, false));
+        FullHttpResponse adminPageResponse = waitForResponse(browseForCurrentConfiguration(yaml, false));
 
-        assertThat(adminPageResponse.body(), is("{\"proxy\":{\"connectors\":{\"http\":{\"port\":8080}}},\"loadBalancing\":{\"strategy\":\"ROUND_ROBIN\"},\"originsFile\":\"" + ORIGINS_FILE + "\"}\n"));
+        assertThat(adminPageResponse.bodyAs(UTF_8), is("{\"proxy\":{\"connectors\":{\"http\":{\"port\":8080}}},\"loadBalancing\":{\"strategy\":\"ROUND_ROBIN\"},\"originsFile\":\"" + ORIGINS_FILE + "\"}\n"));
     }
 
     @Test
@@ -58,9 +59,9 @@ public class StyxConfigurationHandlerTest {
                 "  strategy: ROUND_ROBIN\n" +
                 "originsFile: " + ORIGINS_FILE + "\n";
 
-        FullHttpResponse<String> adminPageResponse = waitForResponse(browseForCurrentConfiguration(yaml, true));
+        FullHttpResponse adminPageResponse = waitForResponse(browseForCurrentConfiguration(yaml, true));
 
-        assertThat(adminPageResponse.body(), is("{\n" +
+        assertThat(adminPageResponse.bodyAs(UTF_8), is("{\n" +
                         "  \"proxy\" : {\n" +
                         "    \"connectors\" : {\n" +
                         "      \"http\" : {\n" +

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ThreadsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ThreadsHandlerTest.java
@@ -29,17 +29,18 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.StringContains.containsString;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ThreadsHandlerTest {
     final ThreadsHandler handler = new ThreadsHandler();
 
     @Test
     public void dumpsCurrentThreadsState() {
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/threads").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/threads").build()));
         assertThat(response.status(), is(OK));
         assertThat(response.headers(), isNotCacheable());
         assertThat(response.contentType().get(), is("text/plain; charset=utf-8"));
-        assertThat(response.body(), containsString("Finalizer"));
+        assertThat(response.bodyAs(UTF_8), containsString("Finalizer"));
     }
 
     private HttpResponse handle(HttpRequest request) {

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/VersionTextHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/VersionTextHandlerTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 
 import static com.hotels.styx.api.HttpRequest.Builder.get;
 import static com.hotels.styx.support.api.BlockingObservables.waitForResponse;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,36 +33,36 @@ public class VersionTextHandlerTest {
     public void canProvideASingleVersionTextFile() {
         VersionTextHandler handler = new VersionTextHandler(resources("classpath:/versions/version1.txt"));
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle( get("/version.txt").build()));
+        FullHttpResponse response = waitForResponse(handler.handle( get("/version.txt").build()));
 
-        assertThat(response.body(), is("foo\n"));
+        assertThat(response.bodyAs(UTF_8), is("foo\n"));
     }
 
     @Test
     public void canCombineVersionTextFiles() {
         VersionTextHandler handler = new VersionTextHandler(resources("classpath:/versions/version1.txt", "classpath:/versions/version2.txt"));
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle( get("/version.txt").build()));
+        FullHttpResponse response = waitForResponse(handler.handle( get("/version.txt").build()));
 
-        assertThat(response.body(), is("foo\nbar\n"));
+        assertThat(response.bodyAs(UTF_8), is("foo\nbar\n"));
     }
 
     @Test
     public void nonExistentFilesAreIgnored() {
         VersionTextHandler handler = new VersionTextHandler(resources("classpath:/versions/version1.txt", "version-nonexistent.txt"));
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle( get("/version.txt").build()));
+        FullHttpResponse response = waitForResponse(handler.handle( get("/version.txt").build()));
 
-        assertThat(response.body(), is("foo\n"));
+        assertThat(response.bodyAs(UTF_8), is("foo\n"));
     }
 
     @Test
     public void returnsUnknownVersionIfNoFilesAreFound() {
         VersionTextHandler handler = new VersionTextHandler(resources("version-nonexistent1.txt", "version-nonexistent2.txt"));
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle( get("/version.txt").build()));
+        FullHttpResponse response = waitForResponse(handler.handle( get("/version.txt").build()));
 
-        assertThat(response.body(), is("Unknown version\n"));
+        assertThat(response.bodyAs(UTF_8), is("Unknown version\n"));
     }
 
     private static Iterable<Resource> resources(String... filenames) {

--- a/components/proxy/src/test/java/com/hotels/styx/admin/tasks/OriginsReloadCommandHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/tasks/OriginsReloadCommandHandlerTest.java
@@ -33,6 +33,7 @@ import static com.hotels.styx.support.matchers.RegExMatcher.matchesRegex;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -53,40 +54,40 @@ public class OriginsReloadCommandHandlerTest {
     public void returnsWithConfirmationWhenChangesArePerformed() {
         mockRegistryReload(completedFuture(reloaded("ok")));
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/").build()));
 
         assertThat(response.status(), is(OK));
-        assertThat(response.body(), is("Origins reloaded successfully.\n"));
+        assertThat(response.bodyAs(UTF_8), is("Origins reloaded successfully.\n"));
     }
 
     @Test
     public void returnsWithInformationWhenChangesAreUnnecessary() {
         mockRegistryReload(completedFuture(unchanged("this test returns 'no meaningful changes'")));
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/").build()));
 
         assertThat(response.status(), is(OK));
-        assertThat(response.body(), is("Origins were not reloaded because this test returns 'no meaningful changes'.\n"));
+        assertThat(response.bodyAs(UTF_8), is("Origins were not reloaded because this test returns 'no meaningful changes'.\n"));
     }
 
     @Test
     public void returnsWithInformationWhenJsonErrorOccursDuringReload() {
         mockRegistryReload(failedFuture(new RuntimeException(new JsonMappingException("simulated error"))));
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/").build()));
 
         assertThat(response.status(), is(BAD_REQUEST));
-        assertThat(response.body(), is(matchesRegex("There was an error processing your request. It has been logged \\(ID [0-9a-f-]+\\)\\.\n")));
+        assertThat(response.bodyAs(UTF_8), is(matchesRegex("There was an error processing your request. It has been logged \\(ID [0-9a-f-]+\\)\\.\n")));
     }
 
     @Test
     public void returnsWithInformationWhenErrorDuringReload() {
         mockRegistryReload(failedFuture(new RuntimeException(new RuntimeException("simulated error"))));
 
-        FullHttpResponse<String> response = waitForResponse(handler.handle(get("/").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/").build()));
 
         assertThat(response.status(), is(INTERNAL_SERVER_ERROR));
-        assertThat(response.body(), is(matchesRegex("There was an error processing your request. It has been logged \\(ID [0-9a-f-]+\\)\\.\n")));
+        assertThat(response.bodyAs(UTF_8), is(matchesRegex("There was an error processing your request. It has been logged \\(ID [0-9a-f-]+\\)\\.\n")));
     }
 
     private CompletableFuture<ReloadResult> failedFuture(RuntimeException simulated_error) {

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/BackendServicesRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/BackendServicesRouterTest.java
@@ -56,9 +56,9 @@ public class BackendServicesRouterTest {
     @Test
     public void registersAllRoutes() {
         Registry.Changes<BackendService> changes = added(
-                appA().newCopy().path("/headers").build(),
-                appB().newCopy().path("/badheaders").build(),
-                appB().newCopy().path("/cookies").build());
+                appA().newCopy().id("a01").path("/headers").build(),
+                appB().newCopy().id("b01").path("/badheaders").build(),
+                appB().newCopy().id("b02").path("/cookies").build());
 
         BackendServicesRouter router = new BackendServicesRouter(serviceClientFactory);
         router.onChange(changes);

--- a/components/server/src/test/java/com/hotels/styx/server/handlers/ClassPathResourceHandlerTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/handlers/ClassPathResourceHandlerTest.java
@@ -28,6 +28,7 @@ import static com.hotels.styx.support.matchers.IsOptional.isValue;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -37,17 +38,17 @@ public class ClassPathResourceHandlerTest {
     @Test
     public void readsClassPathResources() throws IOException {
         HttpRequest request = get("/admin/dashboard/expected.txt").build();
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(OK));
         assertThat(response.contentLength(), isValue("Foo\nBar\n".length()));
-        assertThat(response.body(), is("Foo\nBar\n"));
+        assertThat(response.bodyAs(UTF_8), is("Foo\nBar\n"));
     }
 
     @Test
     public void returns404IfResourceDoesNotExist() throws IOException {
         HttpRequest request = get("/admin/dashboard/unexpected.txt").build();
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(NOT_FOUND));
     }
@@ -65,7 +66,7 @@ public class ClassPathResourceHandlerTest {
     @Test(dataProvider = "forbiddenPaths")
     public void returns403IfTryingToAccessResourcesOutsidePermittedRoot(String path) throws IOException {
         HttpRequest request = get(path).build();
-        FullHttpResponse<String> response = waitForResponse(handler.handle(request));
+        FullHttpResponse response = waitForResponse(handler.handle(request));
 
         assertThat(response.status(), is(FORBIDDEN));
     }

--- a/support/api-testsupport/src/main/java/com/hotels/styx/support/api/BlockingObservables.java
+++ b/support/api-testsupport/src/main/java/com/hotels/styx/support/api/BlockingObservables.java
@@ -25,9 +25,9 @@ public final class BlockingObservables {
         return observable.toBlocking().single();
     }
 
-    public static FullHttpResponse<String> waitForResponse(Observable<HttpResponse> responseObs) {
+    public static FullHttpResponse waitForResponse(Observable<HttpResponse> responseObs) {
         return responseObs
-                .flatMap(response -> response.toFullHttpResponse(120*1024))
+                .flatMap(response -> response.toFullResponse(120*1024))
                 .toBlocking()
                 .first();
     }

--- a/support/api-testsupport/src/main/java/com/hotels/styx/support/api/HttpMessageBodies.java
+++ b/support/api-testsupport/src/main/java/com/hotels/styx/support/api/HttpMessageBodies.java
@@ -36,7 +36,7 @@ public final class HttpMessageBodies {
     }
 
     static String bodyAsString(HttpMessageBody body) {
-        return body.decode(byteBuf -> byteBuf.toString(UTF_8), 0x100000)
+        return body.decode(bytes -> bytes.toString(UTF_8), 0x100000)
                 .toBlocking()
                 .single();
     }

--- a/system-tests/e2e-suite/src/test/java/com/hotels/styx/metrics/ProtocolMetricsTest.java
+++ b/system-tests/e2e-suite/src/test/java/com/hotels/styx/metrics/ProtocolMetricsTest.java
@@ -99,7 +99,7 @@ public class ProtocolMetricsTest {
                 .addRoute("/", nonSslOrigin.port())
                 .start();
 
-        FullHttpResponse<String> response = doGet("/");
+        FullHttpResponse response = doGet("/");
 
         assertThat(response.status(), is(OK));
 
@@ -116,7 +116,7 @@ public class ProtocolMetricsTest {
                 .addRoute("/", nonSslOrigin.port())
                 .start();
 
-        FullHttpResponse<String> response = doHttpsGet("/");
+        FullHttpResponse response = doHttpsGet("/");
 
         assertThat(response.status(), is(OK));
 
@@ -127,16 +127,16 @@ public class ProtocolMetricsTest {
         assertThat(styxServer.metrics().meter("styx.server.https.responses.200").getCount(), is(1L));
     }
 
-    private FullHttpResponse<String> doGet(String path) {
+    private FullHttpResponse doGet(String path) {
         return doRequest(client, "http", styxServer.proxyHttpPort(), startWithSlash(path));
     }
 
-    private FullHttpResponse<String> doHttpsGet(String path) {
+    private FullHttpResponse doHttpsGet(String path) {
         UrlConnectionHttpClient client1 = new UrlConnectionHttpClient(2000, 5000);
         return doRequest(client1, "https", styxServer.proxyHttpsPort(), path);
     }
 
-    private static FullHttpResponse<String> doRequest(HttpClient client, String protocol, int port, String path) {
+    private static FullHttpResponse doRequest(HttpClient client, String protocol, int port, String path) {
         String url = format("%s://localhost:%s%s", protocol, port, startWithSlash(path));
 
         HttpRequest request = get(url)

--- a/system-tests/e2e-suite/src/test/java/com/hotels/styx/plugins/ContentCutoffPlugin.java
+++ b/system-tests/e2e-suite/src/test/java/com/hotels/styx/plugins/ContentCutoffPlugin.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
 
-import java.nio.charset.StandardCharsets;
+import static com.hotels.styx.api.HttpMessageBody.utf8String;
 
 public class ContentCutoffPlugin implements Plugin {
     private static Logger LOGGER = LoggerFactory.getLogger(ContentCutoffPlugin.class);
@@ -31,7 +31,8 @@ public class ContentCutoffPlugin implements Plugin {
     public Observable<HttpResponse> intercept(HttpRequest request, Chain chain) {
         return chain.proceed(request)
                 .flatMap(response -> {
-                    Observable<String> body = response.body().decode(buf -> buf.toString(StandardCharsets.UTF_8), 1024);
+                    Observable<String> body = response.body()
+                            .decode(utf8String(), 1024);
                     return body
                             .doOnNext(content -> LOGGER.info("Throw away response body={}", content))
                             .flatMap(content -> Observable.just(response));

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/HttpResponseSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/HttpResponseSpec.scala
@@ -15,7 +15,7 @@
  */
 package com.hotels.styx
 
-import com.google.common.base.Charsets._
+import java.nio.charset.StandardCharsets.UTF_8
 import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.client.StyxHttpClient
 import com.hotels.styx.client.StyxHttpClient._
@@ -69,7 +69,7 @@ class HttpResponseSpec extends FunSuite
     val response = waitForResponse(client.sendRequest(get("/foo/3").build()))
 
     assert(response.status() == OK, s"\nDid not get response with 200 OK status.\n$response\n")
-    assert(response.body() == "Test message body.", s"\nIncorrect response body.")
+    assert(response.bodyAs(UTF_8) == "Test message body.", s"\nIncorrect response body.")
   }
 
   def response200OkFollowedFollowedByServerConnectionClose(content: String): (ChannelHandlerContext, Any) => Any = {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxClientSupplier.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxClientSupplier.scala
@@ -54,10 +54,10 @@ trait StyxClientSupplier {
 
   def decodedRequest(request: HttpRequest,
                      debug: Boolean = false,
-                     maxSize: Int = 1024 * 1024, timeout: Duration = 30.seconds): FullHttpResponse[String] = {
+                     maxSize: Int = 1024 * 1024, timeout: Duration = 30.seconds): FullHttpResponse = {
     doRequest(request, debug = debug)
       .doOnNext(response => if (debug) println("StyxClientSupplier: received response for: " + request.url().path()))
-      .flatMap(response => response.toFullHttpResponse(maxSize))
+      .flatMap(response => response.toFullResponse(maxSize))
       .timeout(timeout)
       .toBlocking
       .first
@@ -66,10 +66,10 @@ trait StyxClientSupplier {
   def decodedRequestWithClient(client: HttpClient,
                                request: HttpRequest,
                                debug: Boolean = false,
-                               maxSize: Int = 1024 * 1024, timeout: Duration = 30.seconds): FullHttpResponse[String] = {
+                               maxSize: Int = 1024 * 1024, timeout: Duration = 30.seconds): FullHttpResponse = {
     toScalaObservable(client.sendRequest(request))
       .doOnNext(response => if (debug) println("StyxClientSupplier: received response for: " + request.url().path()))
-      .flatMap(response => response.toFullHttpResponse(maxSize))
+      .flatMap(response => response.toFullResponse(maxSize))
       .timeout(timeout)
       .toBlocking
       .first

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/AdminSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/AdminSpec.scala
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx.admin
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.infrastructure.HttpResponseImplicits
 import com.hotels.styx.{DefaultStyxConfiguration, StyxClientSupplier, StyxProxySpec}
@@ -34,21 +36,21 @@ class AdminSpec extends FunSpec
       val response = decodedRequest(get(styxServer.adminURL("/admin/status")).build())
       assert(response.status == OK)
       assert(response.isNotCacheAble())
-      assert(response.body == "OK")
+      assert(response.bodyAs(UTF_8) == "OK")
     }
 
     it("should return 200 and string 'OK' on /admin/healthcheck") {
       val response = decodedRequest(get(styxServer.adminURL("/admin/healthcheck")).build())
       assert(response.status == OK)
       assert(response.isNotCacheAble())
-      response.body should include("\"healthy\":true")
+      response.bodyAs(UTF_8) should include("\"healthy\":true")
     }
 
     it("should return 200 and string 'PONG' on /admin/ping") {
       val response = decodedRequest(get(styxServer.adminURL("/admin/ping")).build())
       assert(response.status == OK)
       assert(response.isNotCacheAble())
-      response.body should include("pong")
+      response.bodyAs(UTF_8) should include("pong")
     }
   }
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/HealthCheckSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/HealthCheckSpec.scala
@@ -28,6 +28,7 @@ import com.hotels.styx.{PluginAdapter, StyxClientSupplier, StyxProxySpec}
 import org.scalatest.FunSpec
 import org.scalatest.concurrent.Eventually
 import rx.Observable
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.concurrent.duration._
 
@@ -75,7 +76,7 @@ class HealthCheckSpec extends FunSpec
 
         assert(healthCheckResponse.status == INTERNAL_SERVER_ERROR)
         assert(healthCheckResponse.isNotCacheAble())
-        healthCheckResponse.body should include regex "\\{\"errors.rate.500\":\\{\"healthy\":false,\"message\":\"error count=[0-9]+ m1_rate=[0-9.]+ is greater than 1.0\"}"
+        healthCheckResponse.bodyAs(UTF_8) should include regex "\\{\"errors.rate.500\":\\{\"healthy\":false,\"message\":\"error count=[0-9]+ m1_rate=[0-9.]+ is greater than 1.0\"}"
       }
     }
   }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/OriginsCommandsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/OriginsCommandsSpec.scala
@@ -31,6 +31,7 @@ import com.hotels.styx.{DefaultStyxConfiguration, StyxProxySpec}
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.concurrent.duration._
 
@@ -76,7 +77,7 @@ class OriginsCommandsSpec extends FeatureSpec
 
   override protected def afterAll() = {
     val response = get(styxServer.adminURL("/admin/origins/status"))
-    println("after test: " + response.body)
+    println("after test: " + response.bodyAs(UTF_8))
     println("Styx metrics: " + getStyxMetricsSnapshot)
 
     origin1.stop()
@@ -95,7 +96,7 @@ class OriginsCommandsSpec extends FeatureSpec
       enableOrigin("appOne", "appOne-01")
       eventually(timeout(5 seconds)) {
         val response = get(styxServer.routerURL("/appOne/"))
-        response.body should include(s"Response From appOne-01")
+        response.bodyAs(UTF_8) should include(s"Response From appOne-01")
       }
 
       When("a disable command is issued")
@@ -130,7 +131,7 @@ class OriginsCommandsSpec extends FeatureSpec
       Then("traffic should be routed to the newly enabled origin")
       eventually(timeout(5 seconds)) {
         val response = get(styxServer.routerURL("/appOne/"))
-        response.body should include(s"Response From appOne-01")
+        response.bodyAs(UTF_8) should include(s"Response From appOne-01")
       }
 
       And("origins status page shows the origin as active")
@@ -147,7 +148,7 @@ class OriginsCommandsSpec extends FeatureSpec
 
       Then("A Method not allowed error should be shown")
       response.status() should be(METHOD_NOT_ALLOWED)
-      response.body should include("Method Not Allowed. Only [POST] is allowed for this request.")
+      response.bodyAs(UTF_8) should include("Method Not Allowed. Only [POST] is allowed for this request.")
     }
 
     def disableOrigin(appId: String, originId: String) = {
@@ -164,14 +165,12 @@ class OriginsCommandsSpec extends FeatureSpec
   }
 
 
-  def getCurrentOriginsStatusSnapshot: String = get(styxServer.adminURL("/admin/origins/status")).body()
+  def getCurrentOriginsStatusSnapshot: String = get(styxServer.adminURL("/admin/origins/status")).bodyAs(UTF_8)
 
 
-  def getStyxMetricsSnapshot: String = {
-    get(styxServer.adminURL("/admin/metrics")).body()
-  }
+  def getStyxMetricsSnapshot: String = get(styxServer.adminURL("/admin/metrics")).bodyAs(UTF_8)
 
-  private def get(url: String): FullHttpResponse[String] = {
+  private def get(url: String): FullHttpResponse = {
     decodedRequest(HttpRequest.Builder.get(url).build())
   }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/OriginClosesConnectionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/OriginClosesConnectionSpec.scala
@@ -79,7 +79,7 @@ class OriginClosesConnectionSpec extends FunSuite
 
       assert(response.status() == OK, s"\nDid not get response with 200 OK status.\n$response\n")
       assert(response.body.nonEmpty, s"\nResponse body is absent.")
-      assert(response.body == "Test message body." * 1024, s"\nIncorrect response body.")
+      assert(response.bodyAs(UTF_8) == "Test message body." * 1024, s"\nIncorrect response body.")
     }
 
     eventually {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/TlsVersionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/TlsVersionSpec.scala
@@ -24,6 +24,7 @@ import com.hotels.styx.support.configuration._
 import com.hotels.styx.utils.StubOriginHeader.STUB_ORIGIN_INFO
 import com.hotels.styx.{StyxClientSupplier, StyxProxySpec}
 import org.scalatest.{FunSpec, SequentialNestedSuiteExecution}
+import java.nio.charset.StandardCharsets.UTF_8
 
 class TlsVersionSpec extends FunSpec
   with StyxProxySpec
@@ -124,7 +125,7 @@ class TlsVersionSpec extends FunSpec
     it("Proxies to TLSv1.1 origin when TLSv1.1 support enabled.") {
       val response1 = decodedRequest(httpRequest("/tls11/a"))
       assert(response1.status().code() == 200)
-      assert(response1.body() == "Hello, World!")
+      assert(response1.bodyAs(UTF_8) == "Hello, World!")
 
       appOriginTlsv11.verify(
         getRequestedFor(
@@ -133,7 +134,7 @@ class TlsVersionSpec extends FunSpec
 
       val response2 = decodedRequest(httpRequest("/tlsDefault/a2"))
       assert(response2.status().code() == 200)
-      assert(response2.body() == "Hello, World!")
+      assert(response2.bodyAs(UTF_8) == "Hello, World!")
 
       appOriginTlsDefault.verify(
         getRequestedFor(
@@ -144,7 +145,7 @@ class TlsVersionSpec extends FunSpec
     it("Proxies to TLSv1.2 origin when TLSv1.2 support is enabled.") {
       val response1 = decodedRequest(httpRequest("/tlsDefault/b1"))
       assert(response1.status().code() == 200)
-      assert(response1.body() == "Hello, World!")
+      assert(response1.bodyAs(UTF_8) == "Hello, World!")
 
       appOriginTlsDefault.verify(
         getRequestedFor(urlEqualTo("/tlsDefault/b1"))
@@ -153,7 +154,7 @@ class TlsVersionSpec extends FunSpec
 
       val response = decodedRequest(httpRequest("/tls12/b2"))
       assert(response.status().code() == 200)
-      assert(response.body() == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
 
       appOriginTlsv12.verify(
         getRequestedFor(urlEqualTo("/tls12/b2"))
@@ -164,7 +165,7 @@ class TlsVersionSpec extends FunSpec
       val response = decodedRequest(httpRequest("/tls11-to-tls12/c"))
 
       assert(response.status().code() == 502)
-      assert(response.body == "Site temporarily unavailable.")
+      assert(response.bodyAs(UTF_8) == "Site temporarily unavailable.")
 
       appOriginTlsv12B.verify(0, getRequestedFor(urlEqualTo("/tls11-to-tls12/c")))
     }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/infrastructure/HttpResponseImplicits.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/infrastructure/HttpResponseImplicits.scala
@@ -20,7 +20,7 @@ import com.hotels.styx.api.messages.FullHttpResponse
 
 trait HttpResponseImplicits {
 
-  class RichHttpResponse(val response: FullHttpResponse[_]) {
+  class RichHttpResponse(val response: FullHttpResponse) {
 
     def isNotCacheAble(): Boolean = {
       response.header("Pragma").get().equals("no-cache") &&
@@ -30,7 +30,7 @@ trait HttpResponseImplicits {
 
   }
 
-  implicit def toRichHttpResponse(response: FullHttpResponse[_]): RichHttpResponse = {
+  implicit def toRichHttpResponse(response: FullHttpResponse): RichHttpResponse = {
     new RichHttpResponse(response)
   }
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AggregatingPluginSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AggregatingPluginSpec.scala
@@ -60,7 +60,7 @@ class AggregatingPluginSpec extends FunSpec
       assert(resp.status().code() == 200)
       assert(resp.header("test_plugin").get() == "yes")
       assert(resp.header("bytes_aggregated").get() == "0")
-      assert(resp.body == "")
+      assert(resp.bodyAs(UTF_8) == "")
     }
 
     it("Gets response from aggregating plugin (with body)") {
@@ -74,7 +74,7 @@ class AggregatingPluginSpec extends FunSpec
       assert(resp.status().code() == 200)
       assert(resp.header("test_plugin").get() == "yes")
       assert(resp.header("bytes_aggregated").get() == "2500")
-      assert(resp.body == chunkString("a") + chunkString("b") + chunkString("c") + chunkString("d") + chunkString("e"))
+      assert(resp.bodyAs(UTF_8) == chunkString("a") + chunkString("b") + chunkString("c") + chunkString("d") + chunkString("e"))
     }
   }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AsyncRequestContentSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AsyncRequestContentSpec.scala
@@ -15,12 +15,14 @@
  */
 package com.hotels.styx.plugins
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.hotels.styx._
-import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.api.HttpInterceptor.Chain
 import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.api.{HttpRequest, HttpResponse}
+import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration.{HttpBackend, Origins, StyxConfig}
 import com.hotels.styx.support.server.UrlMatchingStrategies._
@@ -68,7 +70,7 @@ class AsyncRequestContentSpec extends FunSpec
       val response = waitForResponse(client.sendRequest(request))
 
       mockServer.verify(1, getRequestedFor(urlStartingWith("/foobar")))
-      response.body() should be("I should be here!")
+      response.bodyAs(UTF_8) should be("I should be here!")
     }
   }
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AsyncRequestSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AsyncRequestSpec.scala
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx.plugins
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.hotels.styx._
 import com.hotels.styx.api.HttpInterceptor.Chain
@@ -22,8 +24,8 @@ import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.api.{HttpRequest, HttpResponse}
 import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.support.backends.FakeHttpServer
-import com.hotels.styx.support.server.UrlMatchingStrategies._
 import com.hotels.styx.support.configuration.{HttpBackend, Origins, StyxConfig}
+import com.hotels.styx.support.server.UrlMatchingStrategies._
 import io.netty.handler.codec.http.HttpHeaders.Names._
 import io.netty.handler.codec.http.HttpHeaders.Values._
 import org.scalatest.FunSpec
@@ -65,7 +67,7 @@ class AsyncRequestSpec extends FunSpec
       val response = waitForResponse(client.sendRequest(request))
 
       mockServer.verify(1, getRequestedFor(urlStartingWith("/foobar")))
-      response.body() should be("I should be here!")
+      response.bodyAs(UTF_8) should be("I should be here!")
     }
   }
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AsyncResponseContentSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AsyncResponseContentSpec.scala
@@ -15,12 +15,14 @@
  */
 package com.hotels.styx.plugins
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.api.HttpInterceptor.Chain
 import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.api.{HttpRequest, HttpResponse}
 import com.hotels.styx.support._
+import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration.{HttpBackend, Origins, StyxConfig}
 import com.hotels.styx.support.server.UrlMatchingStrategies._
@@ -72,7 +74,7 @@ class AsyncResponseContentSpec extends FunSpec
       val response = waitForResponse(client.sendRequest(request))
 
       mockServer.verify(1, getRequestedFor(urlStartingWith("/foobar")))
-      response.body() should be("I should be here!")
+      response.bodyAs(UTF_8) should be("I should be here!")
     }
   }
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AsyncResponseSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AsyncResponseSpec.scala
@@ -15,15 +15,17 @@
  */
 package com.hotels.styx.plugins
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.hotels.styx._
-import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.api.HttpInterceptor.Chain
 import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.api.{HttpRequest, HttpResponse}
+import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.support.backends.FakeHttpServer
-import com.hotels.styx.support.server.UrlMatchingStrategies._
 import com.hotels.styx.support.configuration.{HttpBackend, Origins, StyxConfig}
+import com.hotels.styx.support.server.UrlMatchingStrategies._
 import io.netty.handler.codec.http.HttpHeaders.Names._
 import io.netty.handler.codec.http.HttpHeaders.Values._
 import org.scalatest.{FunSpec, ShouldMatchers}
@@ -69,7 +71,7 @@ class AsyncPluginResponseSpec extends FunSpec
       val response = waitForResponse(client.sendRequest(request))
 
       mockServer.verify(1, getRequestedFor(urlStartingWith("/foobar")))
-      response.body() should be ("I should be here!")
+      response.bodyAs(UTF_8) should be ("I should be here!")
     }
   }
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/FormUrlEncodedDataSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/FormUrlEncodedDataSpec.scala
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx.plugins
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.hotels.styx.StyxProxySpec
 import com.hotels.styx.api.HttpRequest.Builder._
 import com.hotels.styx.support.configuration.StyxConfig
@@ -41,7 +43,7 @@ class FormUrlEncodedDataSpec extends FunSpec with StyxProxySpec with Eventually 
         .build()
       val resp = decodedRequest(request)
       assert(resp.status().code() == 200)
-      assert(resp.body == "version: 54.0")
+      assert(resp.bodyAs(UTF_8) == "version: 54.0")
     }
 
     it("decodes correctly multiple post parameter") {
@@ -51,7 +53,7 @@ class FormUrlEncodedDataSpec extends FunSpec with StyxProxySpec with Eventually 
         .build()
       val resp = decodedRequest(request)
       assert(resp.status().code() == 200)
-      assert(resp.body == "app: bar\nversion: 54.0")
+      assert(resp.bodyAs(UTF_8) == "app: bar\nversion: 54.0")
     }
   }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/PluginAdminInterfaceSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/PluginAdminInterfaceSpec.scala
@@ -27,6 +27,7 @@ import com.hotels.styx.support.configuration.{HttpBackend, Origins, StyxConfig}
 import com.hotels.styx.{PluginAdapter, StyxClientSupplier, StyxProxySpec}
 import org.scalatest.FunSpec
 import rx.Observable
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.collection.JavaConverters._
 
@@ -57,45 +58,45 @@ class PluginAdminInterfaceSpec extends FunSpec with StyxProxySpec with StyxClien
       val respY1 = get(styxServer.adminURL("/admin/plugins/plugy/path/one"))
       val respY2 = get(styxServer.adminURL("/admin/plugins/plugy/path/two"))
 
-      respX1.body() should be("X: Response from first admin interface")
-      respX2.body() should be("X: Response from second admin interface")
-      respY1.body() should be("Y: Response from first admin interface")
-      respY2.body() should be("Y: Response from second admin interface")
+      respX1.bodyAs(UTF_8) should be("X: Response from first admin interface")
+      respX2.bodyAs(UTF_8) should be("X: Response from second admin interface")
+      respY1.bodyAs(UTF_8) should be("Y: Response from first admin interface")
+      respY2.bodyAs(UTF_8) should be("Y: Response from second admin interface")
     }
 
     it("Joins plugin admin path with a path separator character, if one is missing") {
       val respZ1 = get(styxServer.adminURL("/admin/plugins/plugz/path/one"))
       val respZ2 = get(styxServer.adminURL("/admin/plugins/plugz/path/two"))
-      respZ1.body() should be("Z: Response from first admin interface")
-      respZ2.body() should be("Z: Response from second admin interface")
+      respZ1.bodyAs(UTF_8) should be("Z: Response from first admin interface")
+      respZ2.bodyAs(UTF_8) should be("Z: Response from second admin interface")
     }
 
     it("Represents link to plugins index on admin server index page") {
       val response = get(styxServer.adminURL("/admin"))
 
-      response.body() should include("<a href='/admin/plugins'>Plugins</a>")
+      response.bodyAs(UTF_8) should include("<a href='/admin/plugins'>Plugins</a>")
     }
 
     it("Represents links to plugin indexes on plugins index page") {
       val response = get(styxServer.adminURL("/admin/plugins"))
 
-      response.body() should include("<a href='/admin/plugins/plugx'>plugx</a>")
-      response.body() should include("<a href='/admin/plugins/plugy'>plugy</a>")
-      response.body() should include("<a href='/admin/plugins/plugz'>plugz</a>")
-      response.body() should include("<a href='/admin/plugins/plugw'>plugw</a>")
+      response.bodyAs(UTF_8) should include("<a href='/admin/plugins/plugx'>plugx</a>")
+      response.bodyAs(UTF_8) should include("<a href='/admin/plugins/plugy'>plugy</a>")
+      response.bodyAs(UTF_8) should include("<a href='/admin/plugins/plugz'>plugz</a>")
+      response.bodyAs(UTF_8) should include("<a href='/admin/plugins/plugw'>plugw</a>")
     }
 
     it("Represents links to plugin endpoints on admin server plugin index pages") {
       val response = get(styxServer.adminURL("/admin/plugins/plugx"))
 
-      response.body() should include("<a href='/admin/plugins/plugx/path/one'>plugx: path/one</a>")
-      response.body() should include("<a href='/admin/plugins/plugx/path/two'>plugx: path/two</a>")
+      response.bodyAs(UTF_8) should include("<a href='/admin/plugins/plugx/path/one'>plugx: path/one</a>")
+      response.bodyAs(UTF_8) should include("<a href='/admin/plugins/plugx/path/two'>plugx: path/two</a>")
     }
 
     it("Plugins without any admin features should display message instead of index") {
       val response = get(styxServer.adminURL("/admin/plugins/plugw"))
 
-      response.body() should include("This plugin (plugw) does not expose any admin interfaces")
+      response.bodyAs(UTF_8) should include("This plugin (plugw) does not expose any admin interfaces")
     }
   }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/PluginToggleSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/PluginToggleSpec.scala
@@ -25,6 +25,7 @@ import com.hotels.styx.{PluginAdapter, StyxClientSupplier, StyxProxySpec}
 import org.scalatest.FunSpec
 import rx.Observable
 import rx.Observable.just
+import java.nio.charset.StandardCharsets.UTF_8
 
 class PluginToggleSpec extends FunSpec with StyxProxySpec with StyxClientSupplier {
   val normalBackend = FakeHttpServer.HttpStartupConfig().start()
@@ -41,11 +42,11 @@ class PluginToggleSpec extends FunSpec with StyxProxySpec with StyxClientSupplie
 
     val resp1 = decodedRequest(get(styxServer.adminURL("/admin/plugins")).build())
     resp1.status() should be (OK)
-    resp1.body should include("<h3>Enabled</h3><a href='/admin/plugins/pluginUnderTest'>pluginUnderTest</a><br /><h3>Disabled</h3>")
+    resp1.bodyAs(UTF_8) should include("<h3>Enabled</h3><a href='/admin/plugins/pluginUnderTest'>pluginUnderTest</a><br /><h3>Disabled</h3>")
 
     val resp2 = decodedRequest(get(styxServer.routerURL("/")).build())
     resp2.status() should be (OK)
-    resp2.body should include("response-from-plugin")
+    resp2.bodyAs(UTF_8) should include("response-from-plugin")
 
     checkPluginEnabled() should be("enabled\n")
   }
@@ -62,7 +63,7 @@ class PluginToggleSpec extends FunSpec with StyxProxySpec with StyxClientSupplie
       val resp = decodedRequest(get(styxServer.adminURL("/admin/plugins")).build())
 
       resp.status() should be (OK)
-      resp.body should include("<h3>Enabled</h3><h3>Disabled</h3><a href='/admin/plugins/pluginUnderTest'>pluginUnderTest</a><br />")
+      resp.bodyAs(UTF_8) should include("<h3>Enabled</h3><h3>Disabled</h3><a href='/admin/plugins/pluginUnderTest'>pluginUnderTest</a><br />")
     }
 
     it("Plugin should not be called when disabled") {
@@ -97,7 +98,7 @@ class PluginToggleSpec extends FunSpec with StyxProxySpec with StyxClientSupplie
         .build())
 
     resp.status() should be (OK)
-    resp.body
+    resp.bodyAs(UTF_8)
   }
 
   private def checkPluginEnabled(): String = {
@@ -106,7 +107,7 @@ class PluginToggleSpec extends FunSpec with StyxProxySpec with StyxClientSupplie
         .build())
 
     resp.status() should be(OK)
-    resp.body
+    resp.bodyAs(UTF_8)
   }
 
   private class PluginUnderTest extends PluginAdapter {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BadFramingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BadFramingSpec.scala
@@ -137,7 +137,7 @@ class BadFramingSpec extends FunSpec
       response.status() should be(OK)
       response.header(CONTENT_LENGTH).isPresent should be(false)
 
-      assert(response.body == "a" * 10 + "b" * 20 + "c" * 30, s"\nReceived incorrect body: ${response.body()}")
+      assert(response.bodyAs(UTF_8) == "a" * 10 + "b" * 20 + "c" * 30, s"\nReceived incorrect body: ${response.bodyAs(UTF_8)}")
     }
 
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BadResponseFromOriginSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BadResponseFromOriginSpec.scala
@@ -105,7 +105,7 @@ class BadResponseFromOriginSpec extends FunSpec
       val response = decodedRequest(request)
       response.status() should be(BAD_GATEWAY)
       assertThat(response.headers().get(STYX_INFO_DEFAULT), matches(matchesRegex("noJvmRouteSet;[0-9a-f-]+")))
-      response.body should be("Site temporarily unavailable.")
+      response.bodyAs(UTF_8) should be("Site temporarily unavailable.")
       eventually(timeout(7.seconds)) {
         styxServer.metricsSnapshot.count("styx.response.status.502").get should be(1)
       }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BigFileDownloadSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BigFileDownloadSpec.scala
@@ -74,7 +74,7 @@ class BigFileDownloadSpec extends FunSpec
       val resp = decodedRequest(req, maxSize = 2*ONE_HUNDRED_MB.toInt, timeout = 60.seconds)
 
       assert(resp.status() == OK)
-      val actualContentSize = resp.body.getBytes.length
+      val actualContentSize = resp.body.length
 
       println("Actual content size was: " + actualContentSize)
       actualContentSize should be(ONE_HUNDRED_MB)

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedDownloadSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedDownloadSpec.scala
@@ -69,7 +69,7 @@ class ChunkedDownloadSpec extends FunSpec
       response.status() should be(OK)
       response.contentLength().isPresent should be(false)
 
-      assert(response.body() == "a" * 10 + "b" * 20 + "c" * 30, s"\nReceived incorrect content: ${response.body()}")
+      assert(response.bodyAs(UTF_8) == "a" * 10 + "b" * 20 + "c" * 30, s"\nReceived incorrect content: ${response.bodyAs(UTF_8)}")
     }
 
     it("Proxies long lasting HTTP Chunked downloads without triggering gateway read timeout.") {
@@ -81,7 +81,7 @@ class ChunkedDownloadSpec extends FunSpec
 
       response.status() should be(OK)
 
-      assert(response.body().hashCode() == messageBody.hashCode, s"\nReceived incorrect content: ${response.body()}, \nexpected: $messageBody")
+      assert(response.bodyAs(UTF_8).hashCode() == messageBody.hashCode, s"\nReceived incorrect content: ${response.bodyAs(UTF_8)}, \nexpected: $messageBody")
     }
 
     it("Cancels the HTTP download request when browser closes the connection.") {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpMessageLoggingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpMessageLoggingSpec.scala
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx.proxy
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import ch.qos.logback.classic.Level._
 import com.github.tomakehurst.wiremock.client.WireMock.{get => _, _}
 import com.hotels.styx.api.HttpRequest.Builder.get
@@ -80,7 +82,7 @@ class HttpMessageLoggingSpec extends FunSpec
     val request = get(s"http://localhost:${mockServer.port()}/foobar").build()
     val resp = decodedRequest(request)
     resp.status().code() should be (200)
-    resp.body should be ("I should be here!")
+    resp.bodyAs(UTF_8) should be ("I should be here!")
   }
 
   override protected def afterAll(): Unit = {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpOutboundMessageLoggingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpOutboundMessageLoggingSpec.scala
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx.proxy
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import ch.qos.logback.classic.Level._
 import com.github.tomakehurst.wiremock.client.WireMock.{get => _, _}
 import com.hotels.styx.api.HttpRequest.Builder.get
@@ -79,7 +81,7 @@ class HttpOutboundMessageLoggingSpec extends FunSpec
     val request = get(s"http://localhost:${mockServer.port()}/foobar").build()
     val resp = decodedRequest(request)
     resp.status().code() should be (200)
-    resp.body should be ("I should be here!")
+    resp.bodyAs(UTF_8) should be ("I should be here!")
   }
 
   override protected def afterAll(): Unit = {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/LoggingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/LoggingSpec.scala
@@ -15,18 +15,20 @@
  */
 package com.hotels.styx.proxy
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import ch.qos.logback.classic.Level._
 import com.github.tomakehurst.wiremock.client.WireMock.{get => _, _}
 import com.hotels.styx.api.HttpInterceptor.Chain
 import com.hotels.styx.api.HttpRequest.Builder._
-import com.hotels.styx.support.matchers.LoggingEventMatcher._
-import com.hotels.styx.support.matchers.LoggingTestSupport
 import com.hotels.styx.api.metrics.HttpErrorStatusCauseLogger
 import com.hotels.styx.api.plugins.spi.PluginException
 import com.hotels.styx.api.{HttpRequest, HttpResponse}
 import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration.{HttpBackend, Origins, StyxConfig}
+import com.hotels.styx.support.matchers.LoggingEventMatcher._
+import com.hotels.styx.support.matchers.LoggingTestSupport
 import com.hotels.styx.support.server.UrlMatchingStrategies._
 import com.hotels.styx.{PluginAdapter, StyxClientSupplier, StyxProxySpec}
 import io.netty.handler.codec.http.HttpHeaders.Names._
@@ -70,7 +72,7 @@ class LoggingSpec extends FunSpec
     val request = get(s"http://localhost:${mockServer.port()}/foobar").build()
     val resp = decodedRequest(request)
     resp.status().code() should be (200)
-    resp.body should be ("I should be here!")
+    resp.bodyAs(UTF_8) should be ("I should be here!")
   }
 
   override protected def afterAll(): Unit = {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OriginsConnectionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OriginsConnectionSpec.scala
@@ -15,14 +15,15 @@
  */
 package com.hotels.styx.proxy
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post => wmpost}
-import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.api.HttpRequest.Builder.post
-import com.hotels.styx.api.HttpResponse
-import com.hotels.styx.support.matchers.LoggingTestSupport
 import com.hotels.styx.client.StyxHttpClient
+import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration.{HttpBackend, Origins}
+import com.hotels.styx.support.matchers.LoggingTestSupport
 import com.hotels.styx.support.server.UrlMatchingStrategies._
 import com.hotels.styx.{DefaultStyxConfiguration, StyxClientSupplier, StyxProxySpec}
 import org.scalatest.FunSpec
@@ -64,7 +65,7 @@ class OriginsConnectionSpec extends FunSpec
         val response = waitForResponse(client.sendRequest(request))
 
         response.status().code() should be(200)
-        response.body() should be("")
+        response.bodyAs(UTF_8) should be("")
       }
 
       Thread.sleep(6000)
@@ -86,7 +87,7 @@ class OriginsConnectionSpec extends FunSpec
         val response = waitForResponse(client.sendRequest(request))
 
         response.status().code() should be(204)
-        response.body() should be("")
+        response.bodyAs(UTF_8) should be("")
       }
 
       Thread.sleep(6000)

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OriginsReloadRepetitionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OriginsReloadRepetitionSpec.scala
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx.proxy
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.hotels.styx.api.HttpRequest
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration.{HttpBackend, Origins}
@@ -60,9 +62,9 @@ class OriginsReloadRepetitionSpec extends FunSpec
       eventually(timeout(1 seconds)) {
         val response = get(styxServer.adminURL("/admin/origins/status"))
 
-        response.body should include("localhost:" + backend1.port())
-        response.body should not include ("localhost:" + backend2.port())
-        response.body should include("localhost:" + backend3.port())
+        response.bodyAs(UTF_8) should include("localhost:" + backend1.port())
+        response.bodyAs(UTF_8) should not include ("localhost:" + backend2.port())
+        response.bodyAs(UTF_8) should include("localhost:" + backend3.port())
       }
 
       styxServer.setBackends(
@@ -72,9 +74,9 @@ class OriginsReloadRepetitionSpec extends FunSpec
       eventually(timeout(1 seconds)) {
         val response = get(styxServer.adminURL("/admin/origins/status"))
 
-        response.body should not include ("localhost:" + backend1.port())
-        response.body should not include ("localhost:" + backend2.port())
-        response.body should include("localhost:" + backend3.port())
+        response.bodyAs(UTF_8) should not include ("localhost:" + backend1.port())
+        response.bodyAs(UTF_8) should not include ("localhost:" + backend2.port())
+        response.bodyAs(UTF_8) should include("localhost:" + backend3.port())
       }
 
       styxServer.setBackends(
@@ -84,9 +86,9 @@ class OriginsReloadRepetitionSpec extends FunSpec
       eventually(timeout(1 seconds)) {
         val response = get(styxServer.adminURL("/admin/origins/status"))
 
-        response.body should include("localhost:" + backend1.port())
-        response.body should include("localhost:" + backend2.port())
-        response.body should include("localhost:" + backend3.port())
+        response.bodyAs(UTF_8) should include("localhost:" + backend1.port())
+        response.bodyAs(UTF_8) should include("localhost:" + backend2.port())
+        response.bodyAs(UTF_8) should include("localhost:" + backend3.port())
       }
     }
   }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OriginsReloadSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OriginsReloadSpec.scala
@@ -15,13 +15,15 @@
  */
 package com.hotels.styx.proxy
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.hotels.styx.api.HttpRequest
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration.{HttpBackend, Origins}
 import com.hotels.styx.{DefaultStyxConfiguration, StyxClientSupplier, StyxProxySpec}
 import io.netty.handler.codec.http.HttpResponseStatus.{METHOD_NOT_ALLOWED, OK}
+import org.scalatest.FunSpec
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{FunSpec}
 
 import scala.concurrent.duration._
 
@@ -71,9 +73,9 @@ class OriginsReloadSpec extends FunSpec
       eventually(timeout(1.seconds)) {
         val response = get(styxServer.adminURL("/admin/origins/status"))
 
-        response.body should include("localhost:" + backend1.port())
-        response.body should include("localhost:" + backend2.port())
-        response.body should include("localhost:" + backend3.port())
+        response.bodyAs(UTF_8) should include("localhost:" + backend1.port())
+        response.bodyAs(UTF_8) should include("localhost:" + backend2.port())
+        response.bodyAs(UTF_8) should include("localhost:" + backend3.port())
       }
     }
 
@@ -85,9 +87,9 @@ class OriginsReloadSpec extends FunSpec
       eventually(timeout(1.seconds)) {
         val response = get(styxServer.adminURL("/admin/origins/status"))
 
-        response.body should include("localhost:" + backend1.port())
-        response.body should not include ("localhost:" + backend2.port())
-        response.body should not include ("localhost:" + backend3.port())
+        response.bodyAs(UTF_8) should include("localhost:" + backend1.port())
+        response.bodyAs(UTF_8) should not include ("localhost:" + backend2.port())
+        response.bodyAs(UTF_8) should not include ("localhost:" + backend3.port())
       }
     }
   }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ProxySpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ProxySpec.scala
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx.proxy
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.github.tomakehurst.wiremock.client.RequestPatternBuilder
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.hotels.styx.MockServer.responseSupplier
@@ -83,7 +85,7 @@ class ProxySpec extends FunSpec
       recordingBackend.verify(getRequestedFor(urlPathEqualTo("/")))
       assert(resp.status() == OK)
       assertThat(resp.header("headerName"), isValue("headerValue"))
-      assert(resp.body == "bodyContent")
+      assert(resp.bodyAs(UTF_8) == "bodyContent")
       assertThat(resp.header(STYX_INFO_DEFAULT), matches(matchesRegex("noJvmRouteSet;[0-9a-f-]+")))
     }
   }
@@ -183,7 +185,7 @@ class ProxySpec extends FunSpec
         val resp = decodedRequest(req)
 
         println("resp: " + resp)
-        println("body: " + resp.body)
+        println("body: " + resp.bodyAs(UTF_8))
 
         assert(resp.status() == BAD_GATEWAY)
       }
@@ -224,11 +226,11 @@ class ProxySpec extends FunSpec
     }
 
 
-    def assertThatResponseIsBodiless(response: FullHttpResponse[String]) {
+    def assertThatResponseIsBodiless(response: FullHttpResponse) {
       val headers = response.headers()
       assert(response.contentLength().orElse(0) == 0, s"\nexpected headers with no Content-Length header but found $headers")
       assert(!response.chunked(), s"\nexpected headers with no Transfer-Encoding header but found $headers")
-      assert(response.body.isEmpty, s"\nexpected response with no body but found $response.body()")
+      assert(response.bodyAs(UTF_8).isEmpty, s"\nexpected response with no body but found ${response.bodyAs(UTF_8)}")
     }
   }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/TimeoutsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/TimeoutsSpec.scala
@@ -124,8 +124,8 @@ class TimeoutsSpec extends FunSpec
     }
   }
 
-  def responseAndResponseTime(transaction: Observable[HttpResponse]): (FullHttpResponse[String], Long) = {
-    var response: FullHttpResponse[String] = FullHttpResponse.response().build()
+  def responseAndResponseTime(transaction: Observable[HttpResponse]): (FullHttpResponse, Long) = {
+    var response = FullHttpResponse.response().build()
 
     val duration = time {
       response = waitForResponse(transaction)

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/ProtocolsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/ProtocolsSpec.scala
@@ -137,7 +137,7 @@ class ProtocolsSpec extends FunSpec
       val response = decodedRequest(httpRequest("/http/app.x.1"))
 
       assert(response.status().code() == 200)
-      assert(response.body == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
 
       httpServer.verify(
         getRequestedFor(urlEqualTo("/http/app.x.1"))
@@ -148,7 +148,7 @@ class ProtocolsSpec extends FunSpec
       val response = decodedRequest(httpRequest("/https/trustAllCerts/foo.2"))
 
       assert(response.status().code() == 200)
-      assert(response.body == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
 
       httpsOriginWithoutCert.verify(
         getRequestedFor(urlEqualTo("/https/trustAllCerts/foo.2"))
@@ -163,7 +163,7 @@ class ProtocolsSpec extends FunSpec
       )
 
       assert(response.status().code() == 200)
-      assert(response.body == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
 
       httpServer.verify(
         getRequestedFor(urlEqualTo("/http/app.x.3"))
@@ -177,7 +177,7 @@ class ProtocolsSpec extends FunSpec
       val response = decodedRequest(httpsRequest("/http/app.x.4"))
 
       assert(response.status().code() == 200)
-      assert(response.body == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
       httpServer.verify(
         getRequestedFor(urlEqualTo("/http/app.x.4"))
           .withHeader("X-Forwarded-Proto", valueMatchingStrategy("https"))
@@ -188,7 +188,7 @@ class ProtocolsSpec extends FunSpec
       val response = decodedRequest(httpsRequest("/https/trustAllCerts/foo.5"))
 
       assert(response.status().code() == 200)
-      assert(response.body == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
       httpsOriginWithoutCert.verify(
         getRequestedFor(urlEqualTo("/https/trustAllCerts/foo.5"))
           .withHeader("X-Forwarded-Proto", valueMatchingStrategy("https"))
@@ -203,7 +203,7 @@ class ProtocolsSpec extends FunSpec
       )
 
       assert(response.status().code() == 200)
-      assert(response.body == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
       httpsOriginWithoutCert.verify(
         getRequestedFor(urlEqualTo("/https/trustAllCerts/foo.6"))
           .withHeader("X-Forwarded-Proto", valueMatchingStrategy("http"))
@@ -220,7 +220,7 @@ class ProtocolsSpec extends FunSpec
       val response = decodedRequest(request)
 
       assert(response.status().code() == 200)
-      assert(response.body == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
       httpsOriginWithCert.verify(getRequestedFor(urlEqualTo("/https/authenticate/secure/foo.7")))
     }
 
@@ -241,7 +241,7 @@ class ProtocolsSpec extends FunSpec
       val response = decodedRequest(request)
 
       assert(response.status().code() == 200)
-      assert(response.body == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
       httpsOriginWithoutCert.verify(getRequestedFor(urlEqualTo("/https/trustAllCerts/foo.9")))
     }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/routing/ConditionRoutingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/routing/ConditionRoutingSpec.scala
@@ -25,6 +25,7 @@ import com.hotels.styx.support.configuration._
 import com.hotels.styx.utils.StubOriginHeader.STUB_ORIGIN_INFO
 import com.hotels.styx.{BackendServicesRegistrySupplier, StyxClientSupplier, StyxProxySpec}
 import org.scalatest.{FunSpec, SequentialNestedSuiteExecution}
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.concurrent.duration._
 
@@ -131,7 +132,7 @@ class ConditionRoutingSpec extends FunSpec
       val response = decodedRequest(httpRequest("/app.1"))
 
       assert(response.status().code() == 200)
-      assert(response.body == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
 
       httpServer.verify(
         getRequestedFor(urlEqualTo("/app.1"))
@@ -142,7 +143,7 @@ class ConditionRoutingSpec extends FunSpec
       val response = decodedRequest(httpsRequest("/app.2"))
 
       assert(response.status().code() == 200)
-      assert(response.body == "Hello, World!")
+      assert(response.bodyAs(UTF_8) == "Hello, World!")
 
       httpsServer.verify(
         getRequestedFor(urlEqualTo("/app.2"))

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/MockOriginServer.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/MockOriginServer.java
@@ -121,12 +121,12 @@ public final class MockOriginServer {
 
     private static HttpHandler2 newHandler(String originId, RequestHandler wireMockHandler) {
         return (httpRequest, ctx) ->
-                httpRequest.toFullHttpRequest(MAX_CONTENT_LENGTH)
+                httpRequest.toFullRequest(MAX_CONTENT_LENGTH)
                         .doOnNext(fullRequest -> LOGGER.info("{} received: {}\n{}", new Object[]{originId, fullRequest.url(), fullRequest.body()}))
                         .flatMap(fullRequest -> {
                             Request wmRequest = new WiremockStyxRequestAdapter(fullRequest);
                             com.github.tomakehurst.wiremock.http.Response wmResponse = wireMockHandler.handle(wmRequest);
-                            return just(toStyxResponse(wmResponse).toStreamingHttpResponse(MockOriginServer::toByteBuf));
+                            return just(toStyxResponse(wmResponse).toStreamingResponse());
                         });
     }
 
@@ -224,12 +224,12 @@ public final class MockOriginServer {
 
     private static HttpHandler2 newHandler(RequestHandler wireMockHandler) {
         return (httpRequest, ctx) ->
-                httpRequest.toFullHttpRequest(MAX_CONTENT_LENGTH)
+                httpRequest.toFullRequest(MAX_CONTENT_LENGTH)
                         .doOnNext(fullRequest -> LOGGER.info("Received: {}\n{}", new Object[]{fullRequest.url(), fullRequest.body()}))
                         .flatMap(fullRequest -> {
                             Request wmRequest = new WiremockStyxRequestAdapter(fullRequest);
                             com.github.tomakehurst.wiremock.http.Response wmResponse = wireMockHandler.handle(wmRequest);
-                            return just(toStyxResponse(wmResponse).toStreamingHttpResponse(MockOriginServer::toByteBuf));
+                            return just(toStyxResponse(wmResponse).toStreamingResponse());
                         });
     }
 }

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/WiremockResponseConverter.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/WiremockResponseConverter.java
@@ -20,8 +20,6 @@ import com.hotels.styx.api.HttpHeaders;
 import com.hotels.styx.api.messages.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 final class WiremockResponseConverter {
 
     private WiremockResponseConverter() {
@@ -30,9 +28,9 @@ final class WiremockResponseConverter {
     static FullHttpResponse toStyxResponse(Response response) {
         HttpResponseStatus status = HttpResponseStatus.valueOf(response.getStatus());
         HttpHeaders headers = toStyxHeaders(response.getHeaders());
-        String content = response.getBodyAsString();
+        byte[] body = response.getBody();
 
-        return FullHttpResponse.response(status).headers(headers).body(content, UTF_8, false).build();
+        return FullHttpResponse.response(status).headers(headers).body(body, false).build();
     }
 
     private static HttpHeaders toStyxHeaders(com.github.tomakehurst.wiremock.http.HttpHeaders headers) {

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/WiremockResponseConverter.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/WiremockResponseConverter.java
@@ -20,17 +20,19 @@ import com.hotels.styx.api.HttpHeaders;
 import com.hotels.styx.api.messages.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 final class WiremockResponseConverter {
 
     private WiremockResponseConverter() {
     }
 
-    static FullHttpResponse<String> toStyxResponse(Response response) {
+    static FullHttpResponse toStyxResponse(Response response) {
         HttpResponseStatus status = HttpResponseStatus.valueOf(response.getStatus());
         HttpHeaders headers = toStyxHeaders(response.getHeaders());
         String content = response.getBodyAsString();
 
-        return FullHttpResponse.<String>response(status).headers(headers).body(content).build();
+        return FullHttpResponse.response(status).headers(headers).body(content, UTF_8, false).build();
     }
 
     private static HttpHeaders toStyxHeaders(com.github.tomakehurst.wiremock.http.HttpHeaders headers) {

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/WiremockStyxRequestAdapter.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/WiremockStyxRequestAdapter.java
@@ -26,20 +26,20 @@ import com.hotels.styx.api.messages.FullHttpRequest;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 
 public class WiremockStyxRequestAdapter implements Request {
-    private final FullHttpRequest<String> styxRequest;
+    private final FullHttpRequest styxRequest;
 
-    public WiremockStyxRequestAdapter(FullHttpRequest<String> styxRequest) {
+    public WiremockStyxRequestAdapter(FullHttpRequest styxRequest) {
         this.styxRequest = requireNonNull(styxRequest);
     }
 
@@ -107,12 +107,13 @@ public class WiremockStyxRequestAdapter implements Request {
 
     @Override
     public byte[] getBody() {
-        return styxRequest.body().getBytes();
+        return styxRequest.body();
     }
 
+    // TODO: Ensure getBodyAsString works with other character encodings too:
     @Override
     public String getBodyAsString() {
-        return styxRequest.body();
+        return styxRequest.bodyAs(UTF_8);
     }
 
     @Override

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/WiremockStyxRequestAdapter.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/WiremockStyxRequestAdapter.java
@@ -110,7 +110,6 @@ public class WiremockStyxRequestAdapter implements Request {
         return styxRequest.body();
     }
 
-    // TODO: Ensure getBodyAsString works with other character encodings too:
     @Override
     public String getBodyAsString() {
         return styxRequest.bodyAs(UTF_8);

--- a/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/servers/WiremockStyxRequestAdapterTest.java
+++ b/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/servers/WiremockStyxRequestAdapterTest.java
@@ -24,7 +24,6 @@ import org.testng.annotations.Test;
 
 import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static com.hotels.styx.api.HttpHeaderNames.CONNECTION;
-import static com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http.HttpHeaderNames.USER_AGENT;
@@ -40,10 +39,10 @@ import static org.testng.Assert.assertEquals;
 public class WiremockStyxRequestAdapterTest {
     private WiremockStyxRequestAdapter adapter;
     private String content;
-    private FullHttpRequest.Builder<String> styxRequestBuilder;
+    private FullHttpRequest.Builder styxRequestBuilder;
 
     @BeforeMethod
-    public void setUp() throws Exception {
+    public void setUp() {
         content = "{\n" +
                 "    \"request\" : {\n" +
                 "        \"urlPattern\" : \"/.*\",\n" +
@@ -58,19 +57,18 @@ public class WiremockStyxRequestAdapterTest {
                 "    }\n" +
                 "}";
 
-        styxRequestBuilder = FullHttpRequest.<String>post("/__admin/mappings/new?msg=6198.1")
-                .header(CONTENT_LENGTH, "208")
+        styxRequestBuilder = FullHttpRequest.post("/__admin/mappings/new?msg=6198.1")
                 .header(CONTENT_TYPE, "application/json; charset=UTF-8")
                 .header(HOST, "localhost")
                 .header(CONNECTION, "Keep-Alive")
                 .header(USER_AGENT, "Apache-HttpClient/4.3.5 (java 1.5)")
-                .body(content);
+                .body(content, UTF_8);
 
         adapter = new WiremockStyxRequestAdapter(styxRequestBuilder.build());
     }
 
     @Test
-    public void adaptsContainsHeader() throws Exception {
+    public void adaptsContainsHeader() {
         assertThat(adapter.containsHeader("Foo-Bar"), is(false));
         assertThat(adapter.containsHeader("Host"), is(true));
         assertThat(adapter.containsHeader("host"), is(true));
@@ -82,64 +80,64 @@ public class WiremockStyxRequestAdapterTest {
     // HTTP header names from AsciiString to String when toArray() is called on
     // CharSequenceDelegatingStringSet.
     @Test(enabled = false)
-    public void adaptsGetAllHeaderKeys() throws Exception {
+    public void adaptsGetAllHeaderKeys() {
         assertEquals(adapter.getAllHeaderKeys(), contains("Connection", "user-agent", "Content-Type", "Content-Length", "host"));
     }
 
     @Test
-    public void adaptsGetUrl() throws Exception {
+    public void adaptsGetUrl() {
         assertThat(adapter.getUrl(), is("/__admin/mappings/new"));
     }
 
     @Test
-    public void adaptsGetAbsoluteUrl() throws Exception {
+    public void adaptsGetAbsoluteUrl() {
         assertThat(adapter.getAbsoluteUrl(), is("http://localhost/__admin/mappings/new?msg=6198.1"));
     }
 
     @Test
-    public void adaptsGetMethod() throws Exception {
+    public void adaptsGetMethod() {
         assertThat(adapter.getMethod(), is(POST));
     }
 
     @Test
-    public void adaptsGetHeader() throws Exception {
-        assertThat(adapter.getHeader("Content-Length"), is("208"));
+    public void adaptsGetHeader() {
+        assertThat(adapter.getHeader("Content-Length"), is("246"));
         assertThat(adapter.getHeader("Foo-Bar"), is(nullValue()));
     }
 
     @Test
-    public void adaptsGetHeaders() throws Exception {
+    public void adaptsGetHeaders() {
         assertThat(adapter.getHeaders().keys(), containsInAnyOrder("Content-Type", "host", "Connection", "user-agent", "Content-Length"));
 
         assertThat(adapter.getHeader("Content-Type"), is("application/json; charset=UTF-8"));
         assertThat(adapter.getHeader("host"), is("localhost"));
         assertThat(adapter.getHeader("Connection"), is("Keep-Alive"));
         assertThat(adapter.getHeader("user-agent"), is("Apache-HttpClient/4.3.5 (java 1.5)"));
-        assertThat(adapter.getHeader("Content-Length"), is("208"));
+        assertThat(adapter.getHeader("Content-Length"), is("246"));
     }
 
     @Test
-    public void adaptsGetBodyWhenAbsent() throws Exception {
+    public void adaptsGetBodyWhenAbsent() {
         assertThat(adapter.getBody(), is(content.getBytes(UTF_8)));
     }
 
     @Test
-    public void adaptsGetBodyWhenPresent() throws Exception {
+    public void adaptsGetBodyWhenPresent() {
         assertThat(adapter.getBody(), is(content.getBytes(UTF_8)));
     }
 
     @Test
-    public void adaptsGetBodyAsStringWhenAbsent() throws Exception {
+    public void adaptsGetBodyAsStringWhenAbsent() {
         assertThat(adapter.getBodyAsString(), is(content));
     }
 
     @Test
-    public void adaptsGetBodyAsStringWhenPresent() throws Exception {
+    public void adaptsGetBodyAsStringWhenPresent() {
         assertThat(adapter.getBodyAsString(), is(content));
     }
 
     @Test
-    public void adaptsContentTypeHeaderWhenPresent() throws Exception {
+    public void adaptsContentTypeHeaderWhenPresent() {
         ContentTypeHeader contentType = adapter.contentTypeHeader();
 
         assertThat(contentType.encodingPart(), is(Optional.of("UTF-8")));
@@ -147,7 +145,7 @@ public class WiremockStyxRequestAdapterTest {
     }
 
     @Test
-    public void adaptsQueryParameter() throws Exception {
+    public void adaptsQueryParameter() {
         QueryParameter msg = adapter.queryParameter("msg");
 
         assertThat(msg.key(), is("msg"));
@@ -155,7 +153,7 @@ public class WiremockStyxRequestAdapterTest {
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
-    public void adaptsNonExistantQueryParameterToNull() throws Exception {
+    public void adaptsNonExistantQueryParameterToNull() {
         QueryParameter msg = adapter.queryParameter("foobar");
 
         assertThat(msg.key(), is("foobar"));
@@ -163,7 +161,7 @@ public class WiremockStyxRequestAdapterTest {
     }
 
     @Test
-    public void adaptsContentTypeHeaderWhenAbsent() throws Exception {
+    public void adaptsContentTypeHeaderWhenAbsent() {
         adapter = new WiremockStyxRequestAdapter(
                 styxRequestBuilder
                         .removeHeader(CONTENT_TYPE)
@@ -176,7 +174,7 @@ public class WiremockStyxRequestAdapterTest {
     }
 
     @Test
-    public void adaptsIsBrowserProxyRequest() throws Exception {
+    public void adaptsIsBrowserProxyRequest() {
         assertThat(adapter.isBrowserProxyRequest(), is(false));
     }
 


### PR DESCRIPTION
Remove type argument T from the Full HTTP messages. Store the content instead as byte[].