### PR TITLE
Remove bodyAs(Function) method from FullHttpMessage API.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpMessage.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpMessage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import io.netty.handler.codec.http.HttpVersion;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
@@ -59,19 +58,6 @@ public interface FullHttpMessage {
      * @return the body
      */
     byte[] body();
-
-    /**
-     * Returns the message body decoded to a business domain object.
-     *
-     * Decodes the message body with a provided decoder function and returns the
-     * result. The decoder is a function from ByteBuf to a specified output type T.
-     * The caller must ensure the provided decoder is compatible with message content
-     * type and encoding.
-     *
-     * @param  decoder    A function from ByteBuf to T.
-     * @return            Message object decoded into a business domain object.
-     */
-    <T> T bodyAs(Function<byte[], T> decoder);
 
     /**
      * Returns the message body as a String decoded with provided character set.

--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 import static com.google.common.base.Objects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -175,22 +174,6 @@ public class FullHttpRequest implements FullHttpMessage {
     @Override
     public byte[] body() {
         return body.clone();
-    }
-
-    /**
-     * Returns the message body decoded to a business domain object.
-     *
-     * Decodes the message body with a provided decoder function and returns the
-     * result. The decoder is a function from ByteBuf to a specified output type T.
-     * The caller must ensure the provided decoder is compatible with message content
-     * type and encoding.
-     *
-     * @param  decoder    A function from ByteBuf to T.
-     * @return            Message object decoded into a business domain object.
-     */
-    @Override
-    public <T> T bodyAs(Function<byte[], T> decoder) {
-        return decoder.apply(body);
     }
 
     /**

--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpResponse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 
 import static com.google.common.base.Objects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -109,22 +108,6 @@ public class FullHttpResponse implements FullHttpMessage {
     @Override
     public byte[] body() {
         return body.clone();
-    }
-
-    /**
-     * Returns the message body decoded to a business domain object.
-     *
-     * Decodes the message body with a provided decoder function and returns the
-     * result. The decoder is a function from ByteBuf to a specified output type T.
-     * The caller must ensure the provided decoder is compatible with message content
-     * type and encoding.
-     *
-     * @param  decoder    A function from ByteBuf to T.
-     * @return            Message object decoded into a business domain object.
-     */
-    @Override
-    public <T> T bodyAs(Function<byte[], T> decoder) {
-        return decoder.apply(this.body);
     }
 
     /**


### PR DESCRIPTION
The `bodyAs(Function)` method:
* Does not add any new functionality (the body method can just be accessed directly)
* Does not add any convenience (just adds boilerplate compared to alternative)
* Grants access to the underlying body array, making classes mutable

As such, it has been removed.
