### PR TITLE
Moving underlying request send logic from client implementstions to connections.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/HttpClient.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 package com.hotels.styx.api;
 
 import rx.Observable;
-
-import java.io.Closeable;
 
 /**
  * HTTP Client that returns an observable of response.

--- a/components/api/src/main/java/com/hotels/styx/api/client/Connection.java
+++ b/components/api/src/main/java/com/hotels/styx/api/client/Connection.java
@@ -21,7 +21,6 @@ import rx.Observable;
 
 import java.io.Closeable;
 import java.util.EventListener;
-import java.util.function.Supplier;
 
 /**
  * A connection to an origin.
@@ -60,15 +59,6 @@ public interface Connection extends Closeable {
          */
         Observable<Connection> createConnection(Origin origin, Settings connectionSettings);
     }
-
-    /**
-     * Executes an operation in the context of this connection, allowing it to collect metrics, handle errors, etc.
-     *
-     * @param operation an operation
-     * @param <R>       result type
-     * @return an observable that provides the operation result
-     */
-    <R> Observable<R> execute(Supplier<Observable<R>> operation);
 
     /**
      * Writes HTTP request to a remote peer in the context of this connection.

--- a/components/api/src/main/java/com/hotels/styx/api/client/Connection.java
+++ b/components/api/src/main/java/com/hotels/styx/api/client/Connection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx.api.client;
 
+import com.hotels.styx.api.HttpRequest;
+import com.hotels.styx.api.HttpResponse;
 import rx.Observable;
 
 import java.io.Closeable;
@@ -67,6 +69,14 @@ public interface Connection extends Closeable {
      * @return an observable that provides the operation result
      */
     <R> Observable<R> execute(Supplier<Observable<R>> operation);
+
+    /**
+     * Writes HTTP request to a remote peer in the context of this connection.
+     *
+     * @param request
+     * @return an observable that provides the response
+     */
+    Observable<HttpResponse> write(HttpRequest request);
 
     /**
      * Returns if the underlying connection is still active.

--- a/components/api/src/main/java/com/hotels/styx/api/client/loadbalancing/spi/LoadBalancingStrategy.java
+++ b/components/api/src/main/java/com/hotels/styx/api/client/loadbalancing/spi/LoadBalancingStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,16 +66,6 @@ public interface LoadBalancingStrategy extends OriginsInventoryStateChangeListen
      * @return the origins sorted into a new order
      */
     Iterable<ConnectionPool> vote(Context context);
-
-    /**
-     * Returns a collection of {@link ConnectionPool}, without any guarantee of ordering.
-     * @return available, unordered origins
-     */
-    default Iterable<ConnectionPool> snapshot() {
-        return Collections.emptyList();
-    }
-
-
 
     default void originsInventoryStateChanged(OriginsInventorySnapshot snapshot) {
         // do nothing

--- a/components/client/src/main/java/com/hotels/styx/client/HttpRequestOperationFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/HttpRequestOperationFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package com.hotels.styx.client;
 
 import com.hotels.styx.api.HttpRequest;
-import com.hotels.styx.client.netty.HttpRequestOperation;
+import com.hotels.styx.client.netty.connectionpool.HttpRequestOperation;
 
 /**
  * A Factory for creating an HttpRequestOperation from an HttpRequest.

--- a/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -431,6 +431,8 @@ public final class OriginsInventory
                     .clientWorkerThreadsCount(clientWorkerThreadsCount)
                     .httpConfig(httpConfig)
                     .tlsSettings(backendService.tlsSettings().orElse(null))
+                    .metricRegistry(metricsRegistry)
+                    .responseTimeoutMillis(backendService.responseTimeoutMillis())
                     .build();
 
             return new ConnectionPoolFactory.Builder()

--- a/components/client/src/main/java/com/hotels/styx/client/Transport.java
+++ b/components/client/src/main/java/com/hotels/styx/client/Transport.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import com.hotels.styx.api.Id;
 import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.ConnectionPool;
 import com.hotels.styx.api.netty.exceptions.NoAvailableHostsException;
-import com.hotels.styx.client.netty.connectionpool.NettyConnection;
 import rx.Observable;
 
 import java.util.Optional;
@@ -31,13 +30,11 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Encapsulates a single connection to remote server which we can use to send the messages.
  */
-public class Transport {
-    private final HttpRequestOperationFactory requestOperationFactory;
+class Transport {
     private final Id appId;
     private final StyxHeaderConfig styxHeaderConfig;
 
-    public Transport(HttpRequestOperationFactory requestOperationFactory, Id appId, StyxHeaderConfig styxHeaderConfig) {
-        this.requestOperationFactory = requestOperationFactory;
+    public Transport(Id appId, StyxHeaderConfig styxHeaderConfig) {
         this.appId = appId;
         this.styxHeaderConfig = styxHeaderConfig;
     }
@@ -48,8 +45,7 @@ public class Transport {
         AtomicReference<Connection> connectionRef = new AtomicReference<>(null);
         Observable<HttpResponse> observableResponse = connection.flatMap(tConnection -> {
             connectionRef.set(tConnection);
-            Operation<NettyConnection, HttpResponse> operation = requestOperationFactory.newHttpRequestOperation(request);
-            return operation.execute((NettyConnection) tConnection)
+            return tConnection.write(request)
                     .map(response -> addOriginId(tConnection, response));
         });
 

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/CloseAfterUseConnectionDestination.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/CloseAfterUseConnectionDestination.java
@@ -21,7 +21,7 @@ import com.hotels.styx.api.client.ConnectionDestination;
 import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.client.ConnectionSettings;
 import com.hotels.styx.client.HttpRequestOperationFactory;
-import com.hotels.styx.client.netty.HttpRequestOperation;
+import com.hotels.styx.client.netty.connectionpool.HttpRequestOperation;
 import com.hotels.styx.client.netty.connectionpool.NettyConnectionFactory;
 import com.hotels.styx.client.ssl.TlsSettings;
 import rx.Observable;

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/CloseAfterUseConnectionDestination.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/CloseAfterUseConnectionDestination.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.ConnectionDestination;
 import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.client.ConnectionSettings;
+import com.hotels.styx.client.HttpRequestOperationFactory;
+import com.hotels.styx.client.netty.HttpRequestOperation;
 import com.hotels.styx.client.netty.connectionpool.NettyConnectionFactory;
 import com.hotels.styx.client.ssl.TlsSettings;
 import rx.Observable;
@@ -126,6 +128,13 @@ public class CloseAfterUseConnectionDestination implements ConnectionDestination
         private Connection.Settings connectionSettings = new ConnectionSettings(1000, 1000);
         private Connection.Factory connectionFactory;
         private TlsSettings tlsSettings;
+        private HttpRequestOperationFactory requestOperationFactory = request -> new HttpRequestOperation(
+                request,
+                null,
+                false,
+                60000,
+                false,
+                false);
 
         public Factory connectionSettings(Connection.Settings connectionSettings) {
             this.connectionSettings = connectionSettings;
@@ -149,6 +158,7 @@ public class CloseAfterUseConnectionDestination implements ConnectionDestination
                     : new NettyConnectionFactory.Builder()
                     .name("styx-client")
                     .tlsSettings(tlsSettings)
+                    .httpRequestOperationFactory(requestOperationFactory)
                     .build();
 
             return new CloseAfterUseConnectionDestination(origin, connectionSettings, connectionFactory);

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/stubs/StubConnectionFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/stubs/StubConnectionFactory.java
@@ -24,7 +24,6 @@ import com.hotels.styx.api.client.Origin;
 import rx.Observable;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 import static com.google.common.base.Objects.toStringHelper;
 
@@ -54,13 +53,8 @@ public class StubConnectionFactory implements Connection.Factory {
         }
 
         @Override
-        public <R> Observable<R> execute(Supplier<Observable<R>> operation) {
-            return operation.get();
-        }
-
-        @Override
         public Observable<HttpResponse> write(HttpRequest request) {
-            throw new IllegalStateException("Not implemented");
+            throw new UnsupportedOperationException("Not implemented");
         }
 
         @Override

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/stubs/StubConnectionFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/stubs/StubConnectionFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package com.hotels.styx.client.connectionpool.stubs;
 
 import com.eaio.uuid.UUID;
 import com.hotels.styx.api.Announcer;
+import com.hotels.styx.api.HttpRequest;
+import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.Origin;
 import rx.Observable;
@@ -54,6 +56,11 @@ public class StubConnectionFactory implements Connection.Factory {
         @Override
         public <R> Observable<R> execute(Supplier<Observable<R>> operation) {
             return operation.get();
+        }
+
+        @Override
+        public Observable<HttpResponse> write(HttpRequest request) {
+            throw new IllegalStateException("Not implemented");
         }
 
         @Override

--- a/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/BusyConnectionsStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/BusyConnectionsStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,11 +75,6 @@ public class BusyConnectionsStrategy implements LoadBalancingStrategy {
         return poolsList.stream()
                 .map(ConnectionPoolStatus::getPool)
                 .collect(toList());
-    }
-
-    @Override
-    public Iterable<ConnectionPool> snapshot() {
-        return activeOrigins.snapshot();
     }
 
     private static Comparator<ConnectionPoolStatus> byComparing(Comparator<ConnectionPoolStatus> first, Comparator<ConnectionPoolStatus>... rest) {

--- a/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/RoundRobinStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/RoundRobinStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,11 +96,6 @@ public class RoundRobinStrategy implements LoadBalancingStrategy {
         List<ConnectionPool> first = origins.subList(index, origins.size());
         List<ConnectionPool> second = origins.subList(0, index);
         return concat(first.stream(), second.stream());
-    }
-
-    @Override
-    public Iterable<ConnectionPool> snapshot() {
-        return activeOrigins.snapshot();
     }
 
     @Override

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/FlowControllingHttpContentProducer.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/FlowControllingHttpContentProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hotels.styx.client.netty;
+package com.hotels.styx.client.netty.connectionpool;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.api.netty.exceptions.ResponseTimeoutException;
+import com.hotels.styx.client.netty.ConsumerDisconnectedException;
 import com.hotels.styx.common.StateMachine;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCountUtil;
@@ -33,12 +34,12 @@ import java.util.function.LongUnaryOperator;
 
 import static com.google.common.base.Objects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.hotels.styx.client.netty.FlowControllingHttpContentProducer.ProducerState.BUFFERING;
-import static com.hotels.styx.client.netty.FlowControllingHttpContentProducer.ProducerState.BUFFERING_COMPLETED;
-import static com.hotels.styx.client.netty.FlowControllingHttpContentProducer.ProducerState.COMPLETED;
-import static com.hotels.styx.client.netty.FlowControllingHttpContentProducer.ProducerState.EMITTING_BUFFERED_CONTENT;
-import static com.hotels.styx.client.netty.FlowControllingHttpContentProducer.ProducerState.STREAMING;
-import static com.hotels.styx.client.netty.FlowControllingHttpContentProducer.ProducerState.TERMINATED;
+import static com.hotels.styx.client.netty.connectionpool.FlowControllingHttpContentProducer.ProducerState.BUFFERING;
+import static com.hotels.styx.client.netty.connectionpool.FlowControllingHttpContentProducer.ProducerState.BUFFERING_COMPLETED;
+import static com.hotels.styx.client.netty.connectionpool.FlowControllingHttpContentProducer.ProducerState.COMPLETED;
+import static com.hotels.styx.client.netty.connectionpool.FlowControllingHttpContentProducer.ProducerState.EMITTING_BUFFERED_CONTENT;
+import static com.hotels.styx.client.netty.connectionpool.FlowControllingHttpContentProducer.ProducerState.STREAMING;
+import static com.hotels.styx.client.netty.connectionpool.FlowControllingHttpContentProducer.ProducerState.TERMINATED;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static rx.internal.operators.BackpressureUtils.getAndAddRequest;

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/HttpRequestOperation.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/HttpRequestOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hotels.styx.client.netty;
+package com.hotels.styx.client.netty.connectionpool;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.HttpCookie;
@@ -23,7 +23,6 @@ import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.api.netty.exceptions.TransportLostException;
 import com.hotels.styx.client.Operation;
 import com.hotels.styx.client.OriginStatsFactory;
-import com.hotels.styx.client.netty.connectionpool.NettyConnection;
 import com.hotels.styx.common.logging.HttpRequestMessageLogger;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnectionFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnectionFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,19 @@
  */
 package com.hotels.styx.client.netty.connectionpool;
 
-import com.eaio.uuid.UUID;
 import com.google.common.net.HostAndPort;
+import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.Origin;
+import com.hotels.styx.api.metrics.MetricRegistry;
+import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.api.netty.ClientEventLoopFactory;
 import com.hotels.styx.api.netty.exceptions.OriginUnreachableException;
 import com.hotels.styx.client.ChannelOptionSetting;
 import com.hotels.styx.client.HttpConfig;
+import com.hotels.styx.client.HttpRequestOperationFactory;
+import com.hotels.styx.client.OriginStatsFactory;
+import com.hotels.styx.client.netty.HttpRequestOperation;
 import com.hotels.styx.client.netty.eventloop.PlatformAwareClientEventLoopGroupFactory;
 import com.hotels.styx.client.ssl.SslContextFactory;
 import com.hotels.styx.client.ssl.TlsSettings;
@@ -51,12 +56,25 @@ public class NettyConnectionFactory implements Connection.Factory {
     private final ClientEventLoopFactory eventLoopFactory;
     private final HttpConfig httpConfig;
     private final SslContext sslContext;
+    private final MetricRegistry metricRegistry;
+    private final HttpRequestOperationFactory httpRequestOperationFactory;
     private Bootstrap bootstrap;
 
     private NettyConnectionFactory(Builder builder) {
         this.eventLoopFactory = builder.eventLoopFactory();
         this.httpConfig = requireNonNull(builder.httpConfig);
         this.sslContext = builder.tlsSettings == null ? null : SslContextFactory.get(builder.tlsSettings);
+        this.metricRegistry = builder.metricRegistry;
+
+        this.httpRequestOperationFactory = builder.httpRequestOperationFactory != null
+                ? builder.httpRequestOperationFactory
+                : (HttpRequest request) -> new HttpRequestOperation(
+                            request,
+                            new OriginStatsFactory(metricRegistry),
+                            builder.flowControlEnabled,
+                            builder.responseTimeoutMillis,
+                            builder.requestLoggingEnabled,
+                            builder.longFormat);
     }
 
     @Override
@@ -66,7 +84,7 @@ public class NettyConnectionFactory implements Connection.Factory {
 
             channelFuture.addListener(future -> {
                 if (future.isSuccess()) {
-                    subscriber.onNext(new NettyConnection(new UUID(), origin, channelFuture.channel()));
+                    subscriber.onNext(new NettyConnection(origin, channelFuture.channel(), httpRequestOperationFactory));
                     subscriber.onCompleted();
                 } else {
                     subscriber.onError(new OriginUnreachableException(origin, future.cause()));
@@ -121,6 +139,12 @@ public class NettyConnectionFactory implements Connection.Factory {
         private int clientWorkerThreadsCount = 1;
         private HttpConfig httpConfig = defaultHttpConfig();
         private TlsSettings tlsSettings;
+        private MetricRegistry metricRegistry;
+        private int responseTimeoutMillis = 60000;
+        private boolean flowControlEnabled;
+        private boolean requestLoggingEnabled;
+        private boolean longFormat;
+        private HttpRequestOperationFactory httpRequestOperationFactory;
 
         ClientEventLoopFactory eventLoopFactory() {
             return new PlatformAwareClientEventLoopGroupFactory(name, clientWorkerThreadsCount);
@@ -170,7 +194,40 @@ public class NettyConnectionFactory implements Connection.Factory {
             return this;
         }
 
+        public Builder metricRegistry(MetricRegistry metricRegistry) {
+            this.metricRegistry = metricRegistry;
+            return this;
+        }
+
+        public Builder responseTimeoutMillis(int responseTimeoutMillis) {
+            this.responseTimeoutMillis = responseTimeoutMillis;
+            return this;
+        }
+
+        public Builder flowControlEnabled(boolean flowControlEnabled) {
+            this.flowControlEnabled = flowControlEnabled;
+            return this;
+        }
+
+        public Builder requestLoggingEnabled(boolean requestLoggingEnabled) {
+            this.requestLoggingEnabled = requestLoggingEnabled;
+            return this;
+        }
+
+        public Builder longFormat(boolean longFormat) {
+            this.longFormat = longFormat;
+            return this;
+        }
+
+        public Builder httpRequestOperationFactory(HttpRequestOperationFactory httpRequestOperationFactory) {
+            this.httpRequestOperationFactory = httpRequestOperationFactory;
+            return this;
+        }
+
         public NettyConnectionFactory build() {
+            if (metricRegistry == null) {
+                metricRegistry = new CodaHaleMetricRegistry();
+            }
             return new NettyConnectionFactory(this);
         }
     }

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnectionFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnectionFactory.java
@@ -27,7 +27,6 @@ import com.hotels.styx.client.ChannelOptionSetting;
 import com.hotels.styx.client.HttpConfig;
 import com.hotels.styx.client.HttpRequestOperationFactory;
 import com.hotels.styx.client.OriginStatsFactory;
-import com.hotels.styx.client.netty.HttpRequestOperation;
 import com.hotels.styx.client.netty.eventloop.PlatformAwareClientEventLoopGroupFactory;
 import com.hotels.styx.client.ssl.SslContextFactory;
 import com.hotels.styx.client.ssl.TlsSettings;

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagator.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hotels.styx.client.netty;
+package com.hotels.styx.client.netty.connectionpool;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.HttpCookie;

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/RequestsToOriginMetricsCollector.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/RequestsToOriginMetricsCollector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hotels.styx.client.netty;
+package com.hotels.styx.client.netty.connectionpool;
 
 import com.hotels.styx.client.applications.AggregateTimer;
 import com.hotels.styx.client.applications.OriginStats;

--- a/components/client/src/main/java/com/hotels/styx/client/stickysession/StickySessionLoadBalancingStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/stickysession/StickySessionLoadBalancingStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,10 +72,5 @@ public class StickySessionLoadBalancingStrategy implements LoadBalancingStrategy
     @Override
     public void originsInventoryStateChanged(OriginsInventorySnapshot snapshot) {
         delegate.originsInventoryStateChanged(snapshot);
-    }
-
-    @Override
-    public Iterable<ConnectionPool> snapshot() {
-        return activeOrigins.snapshot();
     }
 }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/SimpleNettyHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/SimpleNettyHttpClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@ import com.hotels.styx.api.messages.FullHttpResponse;
 import com.hotels.styx.client.connectionpool.CloseAfterUseConnectionDestination;
 import com.hotels.styx.client.connectionpool.ConnectionPoolSettings;
 import com.hotels.styx.client.connectionpool.SimpleConnectionPool;
-import com.hotels.styx.client.netty.HttpRequestOperation;
-import com.hotels.styx.client.netty.connectionpool.NettyConnection;
 import com.hotels.styx.client.ssl.TlsSettings;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
@@ -50,10 +48,8 @@ import static com.hotels.styx.support.server.UrlMatchingStrategies.urlStartingWi
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class SimpleNettyHttpClientTest {
     private HttpRequest anyRequest;
@@ -159,44 +155,38 @@ public class SimpleNettyHttpClientTest {
 
     @Test
     public void willNotSetAnyUserAgentIfNotSpecified() {
-        HttpRequestOperationFactory mockOperationFactory = mockRequestOperationFactory();
-
+        Connection mockConnection = mock(Connection.class);
         HttpClient client = new SimpleNettyHttpClient.Builder()
-                .requestOperationFactory(mockOperationFactory)
-                .connectionDestinationFactory(connectInstantlyConnectionDestinationFactory())
+                .connectionDestinationFactory(connectInstantlyConnectionDestinationFactory(mockConnection))
                 .build();
 
         client.sendRequest(anyRequest).subscribe(new TestSubscriber<>());
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
-        verify(mockOperationFactory).newHttpRequestOperation(captor.capture());
+        verify(mockConnection).write(captor.capture());
         assertThat(captor.getValue().header(USER_AGENT), isAbsent());
     }
 
     @Test
     public void setsTheSpecifiedUserAgentWhenSpecified() {
-        HttpRequestOperationFactory mockOperationFactory = mockRequestOperationFactory();
-
+        Connection mockConnection = mock(Connection.class);
         HttpClient client = new SimpleNettyHttpClient.Builder()
-                .requestOperationFactory(mockOperationFactory)
-                .connectionDestinationFactory(connectInstantlyConnectionDestinationFactory())
+                .connectionDestinationFactory(connectInstantlyConnectionDestinationFactory(mockConnection))
                 .userAgent("Styx/5.6")
                 .build();
 
         client.sendRequest(anyRequest).subscribe(new TestSubscriber<Object>());
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
-        verify(mockOperationFactory).newHttpRequestOperation(captor.capture());
+        verify(mockConnection).write(captor.capture());
         assertThat(captor.getValue().header(USER_AGENT), isValue("Styx/5.6"));
     }
 
     @Test
     public void retainsTheUserAgentStringFromTheRequest() {
-        HttpRequestOperationFactory mockOperationFactory = mockRequestOperationFactory();
-
+        Connection mockConnection = mock(Connection.class);
         HttpClient client = new SimpleNettyHttpClient.Builder()
-                .requestOperationFactory(mockOperationFactory)
-                .connectionDestinationFactory(connectInstantlyConnectionDestinationFactory())
+                .connectionDestinationFactory(connectInstantlyConnectionDestinationFactory(mockConnection))
                 .userAgent("Styx/5.6")
                 .build();
 
@@ -207,7 +197,7 @@ public class SimpleNettyHttpClientTest {
                 .subscribe(new TestSubscriber<Object>());
 
         ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
-        verify(mockOperationFactory).newHttpRequestOperation(captor.capture());
+        verify(mockConnection).write(captor.capture());
         assertThat(captor.getValue().header(USER_AGENT), isValue("Foo/Bar"));
     }
 
@@ -215,11 +205,8 @@ public class SimpleNettyHttpClientTest {
     public void requestWithNoHostOrUrlAuthorityCausesException() {
         HttpRequest request = get("/foo.txt").build();
 
-        HttpRequestOperationFactory mockOperationFactory = mockRequestOperationFactory();
-
         HttpClient client = new SimpleNettyHttpClient.Builder()
-                .requestOperationFactory(mockOperationFactory)
-                .connectionDestinationFactory(connectInstantlyConnectionDestinationFactory())
+                .connectionDestinationFactory(connectInstantlyConnectionDestinationFactory(mock(Connection.class)))
                 .build();
 
         client.sendRequest(request)
@@ -228,28 +215,18 @@ public class SimpleNettyHttpClientTest {
                 .single();
     }
 
-    private static HttpRequestOperationFactory mockRequestOperationFactory() {
-        HttpRequestOperation mockOperation = mock(HttpRequestOperation.class);
-        HttpRequestOperationFactory mockOperationFactory = mock(HttpRequestOperationFactory.class);
-        when(mockOperationFactory.newHttpRequestOperation(any(HttpRequest.class))).thenReturn(mockOperation);
-        return mockOperationFactory;
-    }
-
-    private static Connection.Factory connectInstantlyConnectionFactory() {
-        NettyConnection connection = mock(NettyConnection.class);
-        when(connection.isConnected()).thenReturn(true);
-
+    private static Connection.Factory connectInstantlyConnectionFactory(Connection mockConnection) {
         return (origin, connectionSettings) -> {
             ReplaySubject<Connection> connectionSubject = ReplaySubject.create();
-            connectionSubject.onNext(connection);
+            connectionSubject.onNext(mockConnection);
             connectionSubject.onCompleted();
             return connectionSubject;
         };
     }
 
-    private static ConnectionDestination.Factory connectInstantlyConnectionDestinationFactory() {
+    private static ConnectionDestination.Factory connectInstantlyConnectionDestinationFactory(Connection mockConnection) {
         return new SimpleConnectionPool.Factory()
-                .connectionFactory(connectInstantlyConnectionFactory())
+                .connectionFactory(connectInstantlyConnectionFactory(mockConnection))
                 .connectionPoolSettings(new ConnectionPoolSettings.Builder().build());
     }
 }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxHttpClientTest.java
@@ -36,7 +36,7 @@ import com.hotels.styx.client.applications.BackendService;
 import com.hotels.styx.client.connectionpool.ConnectionPoolSettings;
 import com.hotels.styx.client.connectionpool.SimpleConnectionPool;
 import com.hotels.styx.client.healthcheck.OriginHealthStatusMonitor;
-import com.hotels.styx.client.netty.HttpRequestOperation;
+import com.hotels.styx.client.netty.connectionpool.HttpRequestOperation;
 import com.hotels.styx.client.netty.connectionpool.NettyConnection;
 import com.hotels.styx.client.netty.connectionpool.NettyConnectionFactory;
 import com.hotels.styx.client.netty.connectionpool.StubConnectionPool;

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/FlowControllingHttpContentProducerTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/FlowControllingHttpContentProducerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hotels.styx.client.netty;
+package com.hotels.styx.client.netty.connectionpool;
 
 import com.hotels.styx.api.client.Origin;
+import com.hotels.styx.client.netty.ConsumerDisconnectedException;
+import com.hotels.styx.client.netty.connectionpool.FlowControllingHttpContentProducer;
 import com.hotels.styx.support.matchers.LoggingTestSupport;
 import com.hotels.styx.api.netty.exceptions.ResponseTimeoutException;
 import com.hotels.styx.api.netty.exceptions.TransportLostException;
@@ -34,7 +36,7 @@ import static ch.qos.logback.classic.Level.WARN;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.hotels.styx.api.client.Origin.newOriginBuilder;
 import static com.hotels.styx.support.matchers.LoggingEventMatcher.loggingEvent;
-import static com.hotels.styx.client.netty.FlowControllingHttpContentProducer.ProducerState.*;
+import static com.hotels.styx.client.netty.connectionpool.FlowControllingHttpContentProducer.ProducerState.*;
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/HttpRequestOperationTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/HttpRequestOperationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hotels.styx.client.netty;
+package com.hotels.styx.client.netty.connectionpool;
 
 import com.hotels.styx.api.HttpRequest;
+import com.hotels.styx.client.netty.connectionpool.HttpRequestOperation;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import org.testng.annotations.Test;
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagatorTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hotels.styx.client.netty;
+package com.hotels.styx.client.netty.connectionpool;
 
 import com.google.common.base.Throwables;
 import com.hotels.styx.api.HttpResponse;
@@ -22,6 +22,7 @@ import com.hotels.styx.api.netty.exceptions.ResponseTimeoutException;
 import com.hotels.styx.api.netty.exceptions.TransportLostException;
 import com.hotels.styx.client.BadHttpResponseException;
 import com.hotels.styx.client.StyxClientException;
+import com.hotels.styx.client.netty.connectionpool.NettyToStyxResponsePropagator;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
@@ -50,7 +51,7 @@ import static com.hotels.styx.api.HttpCookieAttribute.path;
 import static com.hotels.styx.api.Id.GENERIC_APP;
 import static com.hotels.styx.api.client.Origin.newOriginBuilder;
 import static com.hotels.styx.api.support.HostAndPorts.localhost;
-import static com.hotels.styx.client.netty.NettyToStyxResponsePropagator.toStyxResponse;
+import static com.hotels.styx.client.netty.connectionpool.NettyToStyxResponsePropagator.toStyxResponse;
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/RequestsToOriginMetricsCollectorTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/RequestsToOriginMetricsCollectorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hotels.styx.client.netty;
+package com.hotels.styx.client.netty.connectionpool;
 
 import com.codahale.metrics.Timer;
 import java.util.Optional;
@@ -23,6 +23,8 @@ import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.client.applications.metrics.ApplicationMetrics;
 import com.hotels.styx.client.applications.metrics.OriginMetrics;
+import com.hotels.styx.client.netty.connectionpool.NettyToStyxResponsePropagator;
+import com.hotels.styx.client.netty.connectionpool.RequestsToOriginMetricsCollector;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/StyxBackendServiceClientFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/StyxBackendServiceClientFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,12 +47,6 @@ public class StyxBackendServiceClientFactory implements BackendServiceClientFact
         RetryPolicy retryPolicy = loadService(environment.configuration(), environment, "retrypolicy.policy.factory", RetryPolicy.class)
                 .orElseGet(() -> defaultRetryPolicy(environment));
 
-        boolean requestLoggingEnabled = environment.styxConfig().get("request-logging.outbound.enabled", Boolean.class)
-                .orElse(false);
-
-        boolean longFormat = environment.styxConfig().get("request-logging.outbound.longFormat", Boolean.class)
-                .orElse(false);
-
         LoadBalancingStrategy loadBalancingStrategy = loadService(environment.configuration(),
                 environment, "loadBalancing.strategy.factory", LoadBalancingStrategy.class, originsInventory)
                 .orElseGet(() -> new RoundRobinStrategy(originsInventory));
@@ -65,11 +59,8 @@ public class StyxBackendServiceClientFactory implements BackendServiceClientFact
                 .originRestrictionCookie(environment.configuration().get("originRestrictionCookie").orElse(null))
                 .metricsRegistry(environment.metricRegistry())
                 .retryPolicy(retryPolicy)
-                .flowControlEnabled(true)
                 .enableContentValidation()
                 .rewriteRules(backendService.rewrites())
-                .requestLoggingEnabled(requestLoggingEnabled)
-                .longFormat(longFormat)
                 .originsInventory(originsInventory)
                 .build();
     }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
@@ -15,6 +15,7 @@
  */
 package com.hotels.styx.routing.handlers;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.hotels.styx.Environment;
 import com.hotels.styx.api.HttpClient;
 import com.hotels.styx.api.HttpHandler2;
@@ -33,6 +34,7 @@ import rx.Observable;
 
 import java.util.List;
 
+import static com.hotels.styx.routing.config.RoutingSupport.append;
 import static com.hotels.styx.routing.config.RoutingSupport.missingAttributeError;
 import static java.lang.String.join;
 
@@ -78,6 +80,10 @@ public class ProxyToBackend implements HttpHandler2 {
 
             boolean longFormat = environment.styxConfig().get("request-logging.outbound.longFormat", Boolean.class)
                     .orElse(false);
+
+            JsonNode origins = jsConfig
+                    .get("backend.origins", JsonNode.class)
+                    .orElseThrow(() -> missingAttributeError(configBlock, join(".", append(parents, "backend")), "origins"));
 
             NettyConnectionFactory connectionFactory = new NettyConnectionFactory.Builder()
                     .name("Styx")

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.routing.handlers;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.hotels.styx.Environment;
 import com.hotels.styx.api.HttpClient;
 import com.hotels.styx.api.HttpHandler2;
@@ -34,7 +33,6 @@ import rx.Observable;
 
 import java.util.List;
 
-import static com.hotels.styx.routing.config.RoutingSupport.append;
 import static com.hotels.styx.routing.config.RoutingSupport.missingAttributeError;
 import static java.lang.String.join;
 
@@ -72,10 +70,6 @@ public class ProxyToBackend implements HttpHandler2 {
             BackendService backendService = jsConfig
                     .get("backend", BackendService.class)
                     .orElseThrow(() ->  missingAttributeError(configBlock, join(".", parents), "backend"));
-
-            JsonNode origins = jsConfig
-                    .get("backend.origins", JsonNode.class)
-                    .orElseThrow(() -> missingAttributeError(configBlock, join(".", append(parents, "backend")), "origins"));
 
             int clientWorkerThreadsCount = environment.styxConfig().proxyServerConfig().clientWorkerThreadsCount();
 

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/LoadBalancingStrategyFactoryProviderTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/LoadBalancingStrategyFactoryProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,11 +97,6 @@ public class LoadBalancingStrategyFactoryProviderTest {
 
         @Override
         public Iterable<ConnectionPool> vote(Context context) {
-            return null;
-        }
-
-        @Override
-        public Iterable<ConnectionPool> snapshot() {
             return null;
         }
 

--- a/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/ProxyToBackendSpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/ProxyToBackendSpec.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2018 Expedia Inc.
+ * Copyright (C) 2013-2017 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,29 @@ class ProxyToBackendSpec extends FunSpec with ShouldMatchers {
     }
 
     e.getMessage should be("Routing object definition of type 'ProxyToBackend', attribute='config.config', is missing a mandatory 'backend' attribute.")
+  }
+
+  it("throws for a missing mandatory backend.origins attribute") {
+    val config = configBlock(
+      """
+        |config:
+        |    name: ProxyToBackend
+        |    type: ProxyToBackend
+        |    config:
+        |      backend:
+        |        id: "ba"
+        |        connectionPool:
+        |          maxConnectionsPerHost: 45
+        |          maxPendingConnectionsPerHost: 15
+        |        responseTimeoutMillis: 60000
+        |""".stripMargin)
+
+    val e = intercept[IllegalArgumentException] {
+      val handler = new ProxyToBackend.ConfigFactory(environment, clientFactory())
+        .build(List("config", "config").asJava, null, config)
+    }
+
+    e.getMessage should be("Routing object definition of type 'ProxyToBackend', attribute='config.config.backend', is missing a mandatory 'origins' attribute.")
   }
 
   private def configBlock(text: String) = new YamlConfig(text).get("config", classOf[RoutingConfigDefinition]).get()

--- a/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/ProxyToBackendSpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/ProxyToBackendSpec.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,29 +74,6 @@ class ProxyToBackendSpec extends FunSpec with ShouldMatchers {
     }
 
     e.getMessage should be("Routing object definition of type 'ProxyToBackend', attribute='config.config', is missing a mandatory 'backend' attribute.")
-  }
-
-  it("throws for a missing mandatory backend.origins attribute") {
-    val config = configBlock(
-      """
-        |config:
-        |    name: ProxyToBackend
-        |    type: ProxyToBackend
-        |    config:
-        |      backend:
-        |        id: "ba"
-        |        connectionPool:
-        |          maxConnectionsPerHost: 45
-        |          maxPendingConnectionsPerHost: 15
-        |        responseTimeoutMillis: 60000
-        |""".stripMargin)
-
-    val e = intercept[IllegalArgumentException] {
-      val handler = new ProxyToBackend.ConfigFactory(environment, clientFactory())
-        .build(List("config", "config").asJava, null, config)
-    }
-
-    e.getMessage should be("Routing object definition of type 'ProxyToBackend', attribute='config.config.backend', is missing a mandatory 'origins' attribute.")
   }
 
   private def configBlock(text: String) = new YamlConfig(text).get("config", classOf[RoutingConfigDefinition]).get()

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxClientSupplier.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxClientSupplier.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OriginRestrictionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OriginRestrictionSpec.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION

This allows to decouple clients from particular implementation choices.