### PR TITLE
Refactor OriginsInventory.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/HttpClient.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.hotels.styx.client;
 
 import com.codahale.metrics.Gauge;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -43,17 +44,20 @@ import com.hotels.styx.client.netty.connectionpool.NettyConnectionFactory;
 import com.hotels.styx.client.origincommands.DisableOrigin;
 import com.hotels.styx.client.origincommands.EnableOrigin;
 import com.hotels.styx.client.origincommands.GetOriginsInventorySnapshot;
+import com.hotels.styx.common.EventProcessor;
+import com.hotels.styx.common.QueueDrainingEventProcessor;
 import com.hotels.styx.common.StateMachine;
 import org.slf4j.Logger;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.Closeable;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.hotels.styx.client.HttpConfig.newHttpConfigBuilder;
@@ -62,8 +66,12 @@ import static com.hotels.styx.client.OriginsInventory.OriginState.DISABLED;
 import static com.hotels.styx.client.OriginsInventory.OriginState.INACTIVE;
 import static com.hotels.styx.common.StyxFutures.await;
 import static java.util.Collections.singleton;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -71,7 +79,12 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 @ThreadSafe
 public final class OriginsInventory
-        implements OriginHealthStatusMonitor.Listener, OriginsCommandsListener, ActiveOrigins, OriginsInventoryStateChangeListener.Announcer, Closeable {
+        implements OriginHealthStatusMonitor.Listener,
+        OriginsCommandsListener,
+        ActiveOrigins,
+        OriginsInventoryStateChangeListener.Announcer,
+        Closeable,
+        EventProcessor {
     private static final Logger LOG = getLogger(OriginsInventory.class);
 
     private static final HealthyEvent HEALTHY = new HealthyEvent();
@@ -79,14 +92,16 @@ public final class OriginsInventory
 
     private final Announcer<OriginsInventoryStateChangeListener> inventoryListeners = Announcer.to(OriginsInventoryStateChangeListener.class);
 
-    private final Map<Id, MonitoredOrigin> origins = new ConcurrentHashMap<>();
-
     private final EventBus eventBus;
     private final Id appId;
     private final OriginHealthStatusMonitor originHealthStatusMonitor;
     private final ConnectionPool.Factory hostConnectionPoolFactory;
     private final MetricRegistry metricRegistry;
+    private final QueueDrainingEventProcessor eventQueue;
     private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private Map<Id, MonitoredOrigin> origins = ImmutableMap.of();
+
 
     /**
      * Construct an instance.
@@ -110,79 +125,241 @@ public final class OriginsInventory
 
         this.eventBus.register(this);
         this.originHealthStatusMonitor.addOriginStatusListener(this);
+        eventQueue = new QueueDrainingEventProcessor(this, true);
     }
+
 
     @Override
     public void close() {
-        if (closed.compareAndSet(false, true)) {
-            eventBus.unregister(this);
-            origins.values().stream()
-                    .peek(MonitoredOrigin::close)
-                    .map(o -> o.connectionPool)
-                    .forEach(ConnectionPool::close);
-            originHealthStatusMonitor.stop();
-        }
-    }
-
-    public boolean closed() {
-        return closed.get();
-    }
-
-    @VisibleForTesting
-    public void addOrigins(Origin... origins) {
-        addOrigins(ImmutableSet.copyOf(origins));
+        eventQueue.submit(new CloseEvent());
     }
 
     /**
      * Registers origins with this inventory. Connection pools will be created for them and added to the "active" set,
      * they will begin being monitored, and event bus subscribers will be informed that the inventory state has changed.
      *
-     * @param origins origins to add
+     * @param newOrigins origins to add
      */
-    public void addOrigins(Set<Origin> origins) {
-        checkArgument(origins != null && !origins.isEmpty(), "origins list is null or empty");
+    public void setOrigins(Set<Origin> newOrigins) {
+        checkArgument(newOrigins != null && !newOrigins.isEmpty(), "origins list is null or empty");
+        eventQueue.submit(new SetOriginsEvent(newOrigins));
+    }
 
-        origins.forEach(origin -> {
-            MonitoredOrigin monitoredOrigin = new MonitoredOrigin(origin);
-            this.origins.put(origin.id(), monitoredOrigin);
-            LOG.info("New origin added and activated. Origin={}:{}", appId, origin.id());
-        });
+    @VisibleForTesting
+    public void setOrigins(Origin... origins) {
+        setOrigins(ImmutableSet.copyOf(origins));
     }
 
     @Override
     public void originHealthy(Origin origin) {
-        if (!(originHealthStatusMonitor instanceof NoOriginHealthStatusMonitor)) {
-            onEvent(origin, HEALTHY);
-        }
+        eventQueue.submit(new OriginHealthEvent(origin, HEALTHY));
     }
 
     @Override
     public void originUnhealthy(Origin origin) {
-        if (!(originHealthStatusMonitor instanceof NoOriginHealthStatusMonitor)) {
-            onEvent(origin, UNHEALTHY);
-        }
+        eventQueue.submit(new OriginHealthEvent(origin, UNHEALTHY));
     }
 
     @Subscribe
     @Override
     public void onCommand(EnableOrigin enableOrigin) {
-        if (enableOrigin.forApp(appId)) {
-            onEvent(enableOrigin.originId(), enableOrigin);
-        }
+        eventQueue.submit(new EnableOriginCommand(enableOrigin));
     }
 
     @Subscribe
     @Override
     public void onCommand(DisableOrigin disableOrigin) {
-        if (disableOrigin.forApp(appId)) {
-            onEvent(disableOrigin.originId(), disableOrigin);
-        }
+        eventQueue.submit(new DisableOriginCommand(disableOrigin));
     }
 
     @Subscribe
     @Override
     public void onCommand(GetOriginsInventorySnapshot getOriginsInventorySnapshot) {
         notifyStateChange();
+    }
+
+    @Override
+    public void addInventoryStateChangeListener(OriginsInventoryStateChangeListener listener) {
+        inventoryListeners.addListener(listener);
+    }
+
+    @Override
+    public void submit(Object event) {
+        if (event instanceof SetOriginsEvent) {
+            addOriginsEventHandler((SetOriginsEvent) event);
+        } else if (event instanceof OriginHealthEvent) {
+            originHealthEventHandler((OriginHealthEvent) event);
+        } else if (event instanceof EnableOriginCommand) {
+            enableOriginHandler((EnableOriginCommand) event);
+        } else if (event instanceof DisableOriginCommand) {
+            disableOriginHandler((DisableOriginCommand) event);
+        } else if (event instanceof CloseEvent) {
+            closeHandler();
+        }
+    }
+
+    private class SetOriginsEvent {
+        final Set<Origin> newOrigins;
+
+        public SetOriginsEvent(Set<Origin> newOrigins) {
+            this.newOrigins = newOrigins;
+        }
+    }
+
+    private class OriginHealthEvent {
+        final Object healthEvent;
+        final Origin origin;
+
+        public OriginHealthEvent(Origin origin, Object healthy) {
+            this.origin = origin;
+            this.healthEvent = healthy;
+        }
+    }
+
+    private class EnableOriginCommand {
+        final EnableOrigin enableOrigin;
+
+        public EnableOriginCommand(EnableOrigin enableOrigin) {
+            this.enableOrigin = enableOrigin;
+        }
+    }
+
+    private class DisableOriginCommand {
+        final DisableOrigin disableOrigin;
+
+        public DisableOriginCommand(DisableOrigin disableOrigin) {
+            this.disableOrigin = disableOrigin;
+        }
+    }
+
+    private class CloseEvent {
+
+    }
+
+    public boolean closed() {
+        return closed.get();
+    }
+
+    public void addOriginsEventHandler(SetOriginsEvent event) {
+        Set<Origin> newOrigins = event.newOrigins;
+        Map<Id, Origin> newOriginsMap = newOrigins.stream()
+                .collect(toMap(Origin::id, o -> o));
+
+        Set<Id> allOriginIds = Stream.concat(this.origins.keySet().stream(), newOriginsMap.keySet().stream())
+                .collect(toSet());
+
+        ImmutableMap.Builder<Id, MonitoredOrigin> monitoredOrigins = ImmutableMap.builder();
+        AtomicBoolean changed = new AtomicBoolean(false);
+
+        allOriginIds.forEach(
+                originId -> {
+                    Origin origin = newOriginsMap.get(originId);
+
+                    if (isNewOrigin(originId, origin)) {
+                        MonitoredOrigin monitoredOrigin = addMonitoredEndpoint(origin);
+                        monitoredOrigins.put(originId, monitoredOrigin);
+                        changed.set(true);
+                    } else if (isUpdatedOrigin(originId, origin)) {
+                        MonitoredOrigin monitoredOrigin = changeMonitoredEndpoint(origin);
+                        monitoredOrigins.put(originId, monitoredOrigin);
+                        changed.set(true);
+                    } else if (isUnchangedOrigin(originId, origin)) {
+                        LOG.info("Existing origin has been left unchanged. Origin={}:{}", appId, origin);
+                        monitoredOrigins.put(originId, this.origins.get(originId));
+                    } else if (isRemovedOrigin(originId, origin)) {
+                        removeMonitoredEndpoint(originId);
+                        changed.set(true);
+                    }
+                }
+        );
+
+        this.origins = monitoredOrigins.build();
+
+        if (changed.get()) {
+            notifyStateChange();
+        }
+    }
+
+    private void closeHandler() {
+        if (closed.compareAndSet(false, true)) {
+            origins.values().forEach(host -> removeMonitoredEndpoint(host.origin.id()));
+            this.origins = ImmutableMap.of();
+            notifyStateChange();
+            eventBus.unregister(this);
+        }
+    }
+
+    private void disableOriginHandler(DisableOriginCommand event) {
+        if (event.disableOrigin.forApp(appId)) {
+            onEvent(event.disableOrigin.originId(), event.disableOrigin);
+        }
+    }
+
+    private void enableOriginHandler(EnableOriginCommand event) {
+        if (event.enableOrigin.forApp(appId)) {
+            onEvent(event.enableOrigin.originId(), event.enableOrigin);
+        }
+    }
+
+    private void originHealthEventHandler(OriginHealthEvent event) {
+        if (event.healthEvent == HEALTHY) {
+            if (!(originHealthStatusMonitor instanceof NoOriginHealthStatusMonitor)) {
+                onEvent(event.origin, HEALTHY);
+            }
+        } else if (event.healthEvent == UNHEALTHY) {
+            if (!(originHealthStatusMonitor instanceof NoOriginHealthStatusMonitor)) {
+                onEvent(event.origin, UNHEALTHY);
+            }
+        }
+    }
+
+    private MonitoredOrigin addMonitoredEndpoint(Origin origin) {
+        MonitoredOrigin monitoredOrigin = new MonitoredOrigin(origin);
+        metricRegistry.register(monitoredOrigin.gaugeName, (Gauge<Integer>) () -> monitoredOrigin.state().gaugeValue);
+        monitoredOrigin.startMonitoring();
+        LOG.info("New origin added and activated. Origin={}:{}", appId, monitoredOrigin.origin.id());
+        return monitoredOrigin;
+    }
+
+    private MonitoredOrigin changeMonitoredEndpoint(Origin origin) {
+        MonitoredOrigin oldHost = this.origins.get(origin.id());
+        oldHost.close();
+
+        MonitoredOrigin newHost = new MonitoredOrigin(origin);
+        newHost.startMonitoring();
+
+        LOG.info("Existing origin has been updated. Origin={}:{}", appId, newHost.origin);
+        return newHost;
+    }
+
+    private void removeMonitoredEndpoint(Id originId) {
+        MonitoredOrigin host = this.origins.get(originId);
+        host.close();
+
+        LOG.info("Existing origin has been removed. Origin={}:{}", appId, host.origin.id());
+        metricRegistry.deregister(host.gaugeName);
+    }
+
+    private boolean isNewOrigin(Id originId, Origin newOrigin) {
+        return nonNull(newOrigin) && !this.origins.containsKey(originId);
+    }
+
+    private boolean isUnchangedOrigin(Id originId, Origin newOrigin) {
+        MonitoredOrigin oldOrigin = this.origins.get(originId);
+
+        return (nonNull(oldOrigin) && nonNull(newOrigin)) && oldOrigin.origin.equals(newOrigin);
+    }
+
+    private boolean isUpdatedOrigin(Id originId, Origin newOrigin) {
+        MonitoredOrigin oldOrigin = this.origins.get(originId);
+
+        return (nonNull(oldOrigin) && nonNull(newOrigin)) && !oldOrigin.origin.equals(newOrigin);
+    }
+
+    private boolean isRemovedOrigin(Id originId, Origin newOrigin) {
+        MonitoredOrigin oldOrigin = this.origins.get(originId);
+
+        return nonNull(oldOrigin) && isNull(newOrigin);
     }
 
     private void onEvent(Origin origin, Object event) {
@@ -207,6 +384,12 @@ public final class OriginsInventory
         // Do Nothing
     }
 
+    public List<Origin> origins() {
+        return origins.values().stream()
+                .map(origin -> origin.origin)
+                .collect(toList());
+    }
+
     private void notifyStateChange() {
         OriginsInventorySnapshot event = new OriginsInventorySnapshot(appId, pools(ACTIVE), pools(INACTIVE), pools(DISABLED));
         inventoryListeners.announce().originsInventoryStateChanged(event);
@@ -218,11 +401,6 @@ public final class OriginsInventory
                 .filter(origin -> origin.state().equals(state))
                 .map(origin -> origin.connectionPool)
                 .collect(toList());
-    }
-
-    @Override
-    public void addInventoryStateChangeListener(OriginsInventoryStateChangeListener listener) {
-        inventoryListeners.addListener(listener);
     }
 
     int originCount(OriginState state) {
@@ -238,13 +416,6 @@ public final class OriginsInventory
     private static class HealthyEvent {
     }
 
-    public void registerStatusGauges() {
-        origins.values().forEach(origin ->
-                metricRegistry.register(
-                        origin.gaugeName,
-                        (Gauge<Integer>) () -> origin.state().gaugeValue));
-    }
-
     private final class MonitoredOrigin {
         private final Origin origin;
         private final ConnectionPool connectionPool;
@@ -254,9 +425,6 @@ public final class OriginsInventory
         private MonitoredOrigin(Origin origin) {
             this.origin = origin;
             this.connectionPool = hostConnectionPoolFactory.create(origin);
-
-            startMonitoring();
-            notifyStateChange();
 
             this.machine = new StateMachine.Builder<OriginState>()
                     .initialState(ACTIVE)
@@ -275,7 +443,8 @@ public final class OriginsInventory
         }
 
         private void close() {
-            metricRegistry.deregister(gaugeName);
+            stopMonitoring();
+            connectionPool.close();
         }
 
         private void onStateChange(OriginState oldState, OriginState newState, Object event) {
@@ -292,11 +461,11 @@ public final class OriginsInventory
             }
         }
 
-        private void startMonitoring() {
+        void startMonitoring() {
             originHealthStatusMonitor.monitor(singleton(origin));
         }
 
-        private void stopMonitoring() {
+        void stopMonitoring() {
             originHealthStatusMonitor.stopMonitoring(singleton(origin));
         }
 
@@ -390,7 +559,7 @@ public final class OriginsInventory
 
             ConnectionPool.Factory hostConnectionPoolFactory = connectionPoolFactory(backendService.connectionPoolConfig(), httpConfig, metricsRegistry);
             OriginsInventory originsInventory = new OriginsInventory(eventBus, backendService.id(), originHealthStatusMonitor, hostConnectionPoolFactory, metricsRegistry);
-            originsInventory.addOrigins(backendService.origins());
+            originsInventory.setOrigins(backendService.origins());
 
             return originsInventory;
         }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/OriginsInventoryTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/OriginsInventoryTest.java
@@ -90,7 +90,7 @@ public class OriginsInventoryTest {
      * Setting the origins
      */
     @Test
-    public void setNewOrigins() {
+    public void startsMonitoringNewOrigins() {
         inventory.setOrigins(ORIGIN_1, ORIGIN_2);
 
         assertThat(inventory, hasActiveOrigins(2));
@@ -146,7 +146,7 @@ public class OriginsInventoryTest {
     }
 
     @Test
-    public void stopsMonitoringModifiedOrigins() {
+    public void stopsAndRestartsMonitoringModifiedOrigins() {
         Origin originV1 = newOriginBuilder("acme01.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
         Origin originV2 = newOriginBuilder("acme02.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/OriginsInventoryTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/OriginsInventoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 package com.hotels.styx.client;
 
 import com.codahale.metrics.Gauge;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.hotels.styx.api.client.ConnectionPool;
 import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.api.client.OriginsInventorySnapshot;
 import com.hotels.styx.api.client.OriginsInventoryStateChangeListener;
-import com.hotels.styx.support.matchers.LoggingTestSupport;
 import com.hotels.styx.api.metrics.MetricRegistry;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.client.connectionpool.ConnectionPoolFactory;
@@ -29,46 +29,47 @@ import com.hotels.styx.client.connectionpool.stubs.StubConnectionFactory;
 import com.hotels.styx.client.healthcheck.OriginHealthStatusMonitor;
 import com.hotels.styx.client.origincommands.DisableOrigin;
 import com.hotels.styx.client.origincommands.EnableOrigin;
+import com.hotels.styx.support.matchers.LoggingTestSupport;
 import org.hamcrest.Matcher;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import static ch.qos.logback.classic.Level.INFO;
 import static com.hotels.styx.api.Id.GENERIC_APP;
 import static com.hotels.styx.api.Id.id;
 import static com.hotels.styx.api.client.Origin.newOriginBuilder;
-import static com.hotels.styx.support.matchers.ContainsExactlyOneMatcher.containsExactlyOne;
-import static com.hotels.styx.support.matchers.IsOptional.isValue;
-import static com.hotels.styx.support.matchers.LoggingEventMatcher.loggingEvent;
 import static com.hotels.styx.api.support.HostAndPorts.localHostAndFreePort;
 import static com.hotels.styx.client.OriginsInventory.OriginState.ACTIVE;
 import static com.hotels.styx.client.OriginsInventory.OriginState.DISABLED;
 import static com.hotels.styx.client.connectionpool.ConnectionPoolSettings.defaultSettableConnectionPoolSettings;
 import static com.hotels.styx.common.testing.matcher.TransformingMatcher.hasDerivedValue;
+import static com.hotels.styx.support.matchers.ContainsExactlyOneMatcher.containsExactlyOne;
+import static com.hotels.styx.support.matchers.IsOptional.isAbsent;
+import static com.hotels.styx.support.matchers.IsOptional.isValue;
+import static com.hotels.styx.support.matchers.LoggingEventMatcher.loggingEvent;
 import static java.util.Collections.singleton;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class OriginsInventoryTest {
-    private static final Origin ORIGIN = newOriginBuilder(localHostAndFreePort()).applicationId(GENERIC_APP).id("one").build();
+    private static final Origin ORIGIN_1 = newOriginBuilder(localHostAndFreePort()).applicationId(GENERIC_APP).id("app-01").build();
+    private static final Origin ORIGIN_2 = newOriginBuilder(localHostAndFreePort()).applicationId(GENERIC_APP).id("app-02").build();
 
     private final ConnectionPool.Factory connectionFactory = connectionPoolFactory();
 
     private MetricRegistry metricRegistry;
     private LoggingTestSupport logger;
     private OriginHealthStatusMonitor monitor;
-    private InstrumentedEventBus eventBus;
+    private EventBus eventBus;
     private OriginsInventory inventory;
 
     @BeforeMethod
@@ -76,7 +77,7 @@ public class OriginsInventoryTest {
         metricRegistry = new CodaHaleMetricRegistry();
         logger = new LoggingTestSupport(OriginsInventory.class);
         monitor = mock(OriginHealthStatusMonitor.class);
-        eventBus = new InstrumentedEventBus();
+        eventBus = mock(EventBus.class);
         inventory = new OriginsInventory(eventBus, GENERIC_APP, monitor, connectionFactory, metricRegistry);
     }
 
@@ -85,129 +86,297 @@ public class OriginsInventoryTest {
         logger.stop();
     }
 
+    /*
+     * Setting the origins
+     */
     @Test
-    public void addingANewOriginWillAddToActiveSetAndInitiateTheMonitoring() {
-        inventory.addOrigins(ORIGIN);
+    public void setNewOrigins() {
+        inventory.setOrigins(ORIGIN_1, ORIGIN_2);
 
-        assertThat(inventory, hasActiveOrigins(1));
-        verify(monitor).monitor(singleton(ORIGIN));
+        assertThat(inventory, hasActiveOrigins(2));
+        verify(monitor).monitor(singleton(ORIGIN_1));
+        verify(monitor).monitor(singleton(ORIGIN_2));
 
-        inventory.registerStatusGauges();
-        assertThat(gaugeValue("origins.generic-app.one.status"), isValue(1));
+        assertThat(gaugeValue("origins.generic-app.app-01.status"), isValue(1));
+        assertThat(gaugeValue("origins.generic-app.app-02.status"), isValue(1));
+
+        verify(eventBus).post(any(OriginsInventorySnapshot.class));
     }
 
     @Test
-    public void willNotDisableOriginsNotBelongingToTheApp() {
-        inventory.addOrigins(ORIGIN);
+    public void updatesOriginPortNumber() throws Exception {
+        Origin originV1 = newOriginBuilder("acme.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
+        Origin originV2 = newOriginBuilder("acme.com", 443).applicationId(GENERIC_APP).id("acme-01").build();
 
-        inventory.onCommand(new DisableOrigin(id("some-other-app"), ORIGIN.id()));
+        inventory.setOrigins(originV1);
 
         assertThat(inventory, hasActiveOrigins(1));
+        verify(monitor).monitor(singleton(originV1));
+        assertThat(gaugeValue("origins.generic-app.acme-01.status"), isValue(1));
+        verify(eventBus).post(any(OriginsInventorySnapshot.class));
+
+        inventory.setOrigins(originV2);
+
+        assertThat(inventory, hasActiveOrigins(1));
+        verify(monitor).stopMonitoring(singleton(originV1));
+        verify(monitor).monitor(singleton(originV2));
+        assertThat(gaugeValue("origins.generic-app.acme-01.status"), isValue(1));
+        verify(eventBus, times(2)).post(any(OriginsInventorySnapshot.class));
+    }
+
+    @Test
+    public void updatesOriginHostName() throws Exception {
+        Origin originV1 = newOriginBuilder("acme01.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
+        Origin originV2 = newOriginBuilder("acme02.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
+
+        inventory.setOrigins(originV1);
+
+        assertThat(inventory, hasActiveOrigins(1));
+        verify(monitor).monitor(singleton(originV1));
+        assertThat(gaugeValue("origins.generic-app.acme-01.status"), isValue(1));
+        verify(eventBus).post(any(OriginsInventorySnapshot.class));
+
+        inventory.setOrigins(originV2);
+
+        assertThat(inventory, hasActiveOrigins(1));
+        verify(monitor).stopMonitoring(singleton(originV1));
+        verify(monitor).monitor(singleton(originV2));
+        assertThat(gaugeValue("origins.generic-app.acme-01.status"), isValue(1));
+        verify(eventBus, times(2)).post(any(OriginsInventorySnapshot.class));
+    }
+
+    @Test
+    public void stopsMonitoringModifiedOrigins() {
+        Origin originV1 = newOriginBuilder("acme01.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
+        Origin originV2 = newOriginBuilder("acme02.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
+
+        inventory.setOrigins(originV1);
+        verify(monitor).monitor(singleton(originV1));
+
+        inventory.setOrigins(originV2);
+
+        verify(monitor).stopMonitoring(singleton(originV1));
+        verify(monitor).monitor(singleton(originV2));
+    }
+
+    @Test
+    public void shutsConnectionPoolForModifiedOrigin() {
+        Origin originV1 = newOriginBuilder("acme01.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
+        Origin originV2 = newOriginBuilder("acme02.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
+        ConnectionPool.Factory connectionFactory = mock(ConnectionPool.Factory.class);
+
+        ConnectionPool pool1 = mock(ConnectionPool.class);
+        ConnectionPool pool2 = mock(ConnectionPool.class);
+
+        when(connectionFactory.create(eq(originV1))).thenReturn(pool1);
+        when(connectionFactory.create(eq(originV2))).thenReturn(pool2);
+
+        inventory = new OriginsInventory(eventBus, GENERIC_APP, monitor, connectionFactory, metricRegistry);
+
+        inventory.setOrigins(originV1);
+        verify(connectionFactory).create(eq(originV1));
+
+        inventory.setOrigins(originV2);
+        verify(connectionFactory).create(eq(originV2));
+
+        verify(pool1).close();
+    }
+
+
+    @Test
+    public void ignoresUnchangedOrigins() throws Exception {
+        inventory.setOrigins(ORIGIN_1, ORIGIN_2);
+
+        assertThat(inventory, hasActiveOrigins(2));
+        verify(monitor).monitor(singleton(ORIGIN_1));
+        verify(monitor).monitor(singleton(ORIGIN_2));
+        assertThat(gaugeValue("origins.generic-app.app-01.status"), isValue(1));
+        assertThat(gaugeValue("origins.generic-app.app-02.status"), isValue(1));
+        verify(eventBus).post(any(OriginsInventorySnapshot.class));
+
+        inventory.setOrigins(ORIGIN_1, ORIGIN_2);
+
+        assertThat(inventory, hasActiveOrigins(2));
+        verify(monitor, times(1)).monitor(singleton(ORIGIN_1));
+        verify(monitor, times(1)).monitor(singleton(ORIGIN_2));
+        verify(eventBus).post(any(OriginsInventorySnapshot.class));
+    }
+
+    @Test
+    public void removesOrigin() throws Exception {
+        inventory.setOrigins(ORIGIN_1, ORIGIN_2);
+
+        assertThat(inventory, hasActiveOrigins(2));
+        verify(monitor).monitor(singleton(ORIGIN_1));
+        verify(monitor).monitor(singleton(ORIGIN_2));
+        assertThat(gaugeValue("origins.generic-app.app-01.status"), isValue(1));
+        assertThat(gaugeValue("origins.generic-app.app-02.status"), isValue(1));
+        verify(eventBus).post(any(OriginsInventorySnapshot.class));
+
+        inventory.setOrigins(ORIGIN_2);
+
+        assertThat(inventory, hasActiveOrigins(1));
+        verify(monitor).stopMonitoring(singleton(ORIGIN_1));
+        assertThat(gaugeValue("origins.generic-app.app-01.status"), isAbsent());
+        assertThat(gaugeValue("origins.generic-app.app-02.status"), isValue(1));
+        verify(eventBus, times(2)).post(any(OriginsInventorySnapshot.class));
+    }
+
+
+    @Test
+    public void stopsMonitoringRemovedOrigins() {
+        Origin originV1 = newOriginBuilder("acme01.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
+        Origin originV2 = newOriginBuilder("acme02.com", 80).applicationId(GENERIC_APP).id("acme-02").build();
+
+        inventory.setOrigins(originV1, originV2);
+        verify(monitor).monitor(singleton(originV1));
+        verify(monitor).monitor(singleton(originV2));
+
+        inventory.setOrigins(originV1);
+
+        verify(monitor).stopMonitoring(singleton(originV2));
+    }
+
+    @Test
+    public void shutsConnectionPoolForRemovedOrigin() {
+        Origin originV1 = newOriginBuilder("acme01.com", 80).applicationId(GENERIC_APP).id("acme-01").build();
+        Origin originV2 = newOriginBuilder("acme02.com", 80).applicationId(GENERIC_APP).id("acme-02").build();
+        ConnectionPool.Factory connectionFactory = mock(ConnectionPool.Factory.class);
+
+        ConnectionPool pool1 = mock(ConnectionPool.class);
+        when(pool1.getOrigin()).thenReturn(originV1);
+
+        ConnectionPool pool2 = mock(ConnectionPool.class);
+        when(pool2.getOrigin()).thenReturn(originV2);
+
+        when(connectionFactory.create(eq(originV1))).thenReturn(pool1);
+        when(connectionFactory.create(eq(originV2))).thenReturn(pool2);
+
+        inventory = new OriginsInventory(eventBus, GENERIC_APP, monitor, connectionFactory, metricRegistry);
+
+        inventory.setOrigins(originV1, originV2);
+
+        inventory.setOrigins(originV2);
+
+        verify(pool1).close();
+    }
+
+
+
+    // TODO: Mikko: ignore any origin updates with wrong application-ID.
+
+    @Test
+    public void willNotDisableOriginsNotBelongingToTheApp() {
+        inventory.setOrigins(ORIGIN_1);
+        verify(eventBus).post(any(OriginsInventorySnapshot.class));
+
+        inventory.onCommand(new DisableOrigin(id("some-other-app"), ORIGIN_1.id()));
+
+        assertThat(inventory, hasActiveOrigins(1));
+        verify(eventBus).post(any(OriginsInventorySnapshot.class));
     }
 
     @Test
     public void willNotEnableOriginsNotBelongingToTheApp() {
-        inventory.addOrigins(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
 
-        inventory.onCommand(new DisableOrigin(ORIGIN.applicationId(), ORIGIN.id()));
-        inventory.onCommand(new EnableOrigin(id("some-other-app"), ORIGIN.id()));
+        inventory.onCommand(new DisableOrigin(ORIGIN_1.applicationId(), ORIGIN_1.id()));
+        inventory.onCommand(new EnableOrigin(id("some-other-app"), ORIGIN_1.id()));
 
         assertThat(inventory, hasNoActiveOrigins());
+        verify(eventBus, times(2)).post(any(OriginsInventorySnapshot.class));
     }
 
     @Test
     public void disablingAnOriginRemovesItFromActiveSetAndStopsHealthCheckMonitoring() {
-        inventory.addOrigins(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
 
-        inventory.onCommand(new DisableOrigin(ORIGIN.applicationId(), ORIGIN.id()));
+        inventory.onCommand(new DisableOrigin(ORIGIN_1.applicationId(), ORIGIN_1.id()));
 
         assertThat(inventory, hasNoActiveOrigins());
         assertThat(inventory, hasDisabledOrigins(1));
 
-        verify(monitor).stopMonitoring(singleton(ORIGIN));
-
-        inventory.registerStatusGauges();
-        assertThat(gaugeValue("origins.generic-app.one.status"), isValue(-1));
+        verify(monitor).stopMonitoring(singleton(ORIGIN_1));
+        assertThat(gaugeValue("origins.generic-app.app-01.status"), isValue(-1));
+        verify(eventBus, times(2)).post(any(OriginsInventorySnapshot.class));
     }
 
     @Test
     public void disablingAnOriginRemovesItFromInactiveSetAndStopsHealthCheckMonitoring() {
-        inventory.addOrigins(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
 
-        inventory.originUnhealthy(ORIGIN);
-        inventory.onCommand(new DisableOrigin(ORIGIN.applicationId(), ORIGIN.id()));
+        inventory.originUnhealthy(ORIGIN_1);
+        inventory.onCommand(new DisableOrigin(ORIGIN_1.applicationId(), ORIGIN_1.id()));
 
         assertThat(inventory, hasNoActiveOrigins());
         assertThat(inventory, hasDisabledOrigins(1));
 
-        verify(monitor).stopMonitoring(singleton(ORIGIN));
-
-        inventory.registerStatusGauges();
-        assertThat(gaugeValue("origins.generic-app.one.status"), isValue(-1));
+        verify(monitor).stopMonitoring(singleton(ORIGIN_1));
+        assertThat(gaugeValue("origins.generic-app.app-01.status"), isValue(-1));
+        verify(eventBus, times(3)).post(any(OriginsInventorySnapshot.class));
     }
 
     @Test
     public void enablingAnOriginWillReInitiateHealthCheckMonitoring() {
-        inventory.addOrigins(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
 
-        inventory.onCommand(new DisableOrigin(ORIGIN.applicationId(), ORIGIN.id()));
-        inventory.onCommand(new EnableOrigin(ORIGIN.applicationId(), ORIGIN.id()));
+        inventory.onCommand(new DisableOrigin(ORIGIN_1.applicationId(), ORIGIN_1.id()));
+        inventory.onCommand(new EnableOrigin(ORIGIN_1.applicationId(), ORIGIN_1.id()));
 
-        verify(monitor, times(2)).monitor(singleton(ORIGIN));
-
-        inventory.registerStatusGauges();
-        assertThat(gaugeValue("origins.generic-app.one.status"), isValue(0));
+        verify(monitor, times(2)).monitor(singleton(ORIGIN_1));
+        assertThat(gaugeValue("origins.generic-app.app-01.status"), isValue(0));
+        verify(eventBus, times(3)).post(any(OriginsInventorySnapshot.class));
     }
 
     @Test
     public void removesUnhealthyOriginsFromActiveSet() {
-        inventory.addOrigins(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
         assertThat(inventory, hasActiveOrigins(1));
 
-        inventory.originUnhealthy(ORIGIN);
+        inventory.originUnhealthy(ORIGIN_1);
 
         assertThat(inventory, hasNoActiveOrigins());
-
-        inventory.registerStatusGauges();
-        assertThat(gaugeValue("origins.generic-app.one.status"), isValue(0));
+        assertThat(gaugeValue("origins.generic-app.app-01.status"), isValue(0));
+        verify(eventBus, times(2)).post(any(OriginsInventorySnapshot.class));
     }
 
     @Test
     public void putsHealthyOriginsBackIntoActiveSet() {
-        inventory.addOrigins(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
         assertThat(inventory, hasActiveOrigins(1));
 
-        inventory.originUnhealthy(ORIGIN);
-        inventory.originHealthy(ORIGIN);
+        inventory.originUnhealthy(ORIGIN_1);
+        inventory.originHealthy(ORIGIN_1);
 
         assertThat(inventory, hasActiveOrigins(1));
-
-        inventory.registerStatusGauges();
-        assertThat(gaugeValue("origins.generic-app.one.status"), isValue(1));
+        assertThat(gaugeValue("origins.generic-app.app-01.status"), isValue(1));
+        verify(eventBus, times(3)).post(any(OriginsInventorySnapshot.class));
     }
 
     @Test
     public void reportingUpRepeatedlyDoesNotAffectCurrentActiveOrigins() {
-        inventory.addOrigins(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
         assertThat(inventory, hasActiveOrigins(1));
 
-        inventory.originHealthy(ORIGIN);
-        inventory.originHealthy(ORIGIN);
-        inventory.originHealthy(ORIGIN);
+        inventory.originHealthy(ORIGIN_1);
+        inventory.originHealthy(ORIGIN_1);
+        inventory.originHealthy(ORIGIN_1);
 
         assertThat(inventory, hasActiveOrigins(1));
+        verify(eventBus, times(1)).post(any(OriginsInventorySnapshot.class));
     }
 
     @Test
     public void reportingDownRepeatedlyDoesNotAffectCurrentActiveOrigins() {
-        inventory.addOrigins(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
         assertThat(inventory, hasActiveOrigins(1));
 
-        inventory.originUnhealthy(ORIGIN);
-        inventory.originUnhealthy(ORIGIN);
-        inventory.originUnhealthy(ORIGIN);
+        inventory.originUnhealthy(ORIGIN_1);
+        inventory.originUnhealthy(ORIGIN_1);
+        inventory.originUnhealthy(ORIGIN_1);
 
         assertThat(inventory, hasActiveOrigins(0));
+        verify(eventBus, times(2)).post(any(OriginsInventorySnapshot.class));
     }
 
     @Test
@@ -215,77 +384,99 @@ public class OriginsInventoryTest {
         OriginsInventoryStateChangeListener listener = mock(OriginsInventoryStateChangeListener.class);
         inventory.addInventoryStateChangeListener(listener);
 
-        inventory.addOrigins(ORIGIN);
-        inventory.originUnhealthy(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
+        inventory.originUnhealthy(ORIGIN_1);
 
         verify(listener, times(2)).originsInventoryStateChanged(any(OriginsInventorySnapshot.class));
     }
 
     @Test
     public void logsMessageWhenNewOriginIsAdded() {
-        inventory.addOrigins(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
 
-        assertThat(logger.lastMessage(), is(loggingEvent(INFO, "New origin added and activated. Origin=generic-app:one")));
+        assertThat(logger.lastMessage(), is(loggingEvent(INFO, "New origin added and activated. Origin=generic-app:app-01")));
     }
 
     @Test
     public void logsMessageWhenUnsuccessfulHealthCheckDeactivatesOrigin() {
-        inventory.addOrigins(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
 
-        inventory.originUnhealthy(ORIGIN);
-        assertThat(logger.lastMessage(), is(loggingEvent(INFO, "Origin state change: origin=\"generic-app=one\", change=\"ACTIVE->INACTIVE\"")));
+        inventory.originUnhealthy(ORIGIN_1);
+        assertThat(logger.lastMessage(), is(loggingEvent(INFO, "Origin state change: origin=\"generic-app=app-01\", change=\"ACTIVE->INACTIVE\"")));
     }
 
     @Test
     public void logsMessageWhenSuccessfulHealthCheckEventActivatesOrigin() {
-        inventory.addOrigins(ORIGIN);
-        inventory.originUnhealthy(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
+        inventory.originUnhealthy(ORIGIN_1);
 
-        inventory.originHealthy(ORIGIN);
-        assertThat(logger.lastMessage(), is(loggingEvent(INFO, "Origin state change: origin=\"generic-app=one\", change=\"INACTIVE->ACTIVE\"")));
+        inventory.originHealthy(ORIGIN_1);
+        assertThat(logger.lastMessage(), is(loggingEvent(INFO, "Origin state change: origin=\"generic-app=app-01\", change=\"INACTIVE->ACTIVE\"")));
     }
 
     @Test
     public void logsMessageOnlyOnceForOriginHealthyEvent() {
-        inventory.addOrigins(ORIGIN);
-        inventory.originUnhealthy(ORIGIN);
+        inventory.setOrigins(ORIGIN_1);
+        inventory.originUnhealthy(ORIGIN_1);
 
-        inventory.originHealthy(ORIGIN);
-        inventory.originHealthy(ORIGIN);
-        inventory.originHealthy(ORIGIN);
-        inventory.originHealthy(ORIGIN);
+        inventory.originHealthy(ORIGIN_1);
+        inventory.originHealthy(ORIGIN_1);
+        inventory.originHealthy(ORIGIN_1);
+        inventory.originHealthy(ORIGIN_1);
 
-        assertThat(logger.log(), containsExactlyOne(loggingEvent(INFO, "Origin state change: origin=\"generic-app=one\", change=\"INACTIVE->ACTIVE\"")));
+        assertThat(logger.log(), containsExactlyOne(loggingEvent(INFO, "Origin state change: origin=\"generic-app=app-01\", change=\"INACTIVE->ACTIVE\"")));
     }
 
     @Test
     public void logsMessageWhenOriginIsDisabled() {
-        inventory.addOrigins(ORIGIN);
-        inventory.onCommand(new DisableOrigin(ORIGIN.applicationId(), ORIGIN.id()));
+        inventory.setOrigins(ORIGIN_1);
+        inventory.onCommand(new DisableOrigin(ORIGIN_1.applicationId(), ORIGIN_1.id()));
 
-        assertThat(logger.lastMessage(), is(loggingEvent(INFO, "Origin state change: origin=\"generic-app=one\", change=\"ACTIVE->DISABLED\"")));
+        assertThat(logger.lastMessage(), is(loggingEvent(INFO, "Origin state change: origin=\"generic-app=app-01\", change=\"ACTIVE->DISABLED\"")));
     }
 
     @Test
     public void logsMessageWhenDisabledOriginWithHealthChecksIsEnabled() {
-        inventory.addOrigins(ORIGIN);
-        inventory.onCommand(new DisableOrigin(ORIGIN.applicationId(), ORIGIN.id()));
-        inventory.onCommand(new EnableOrigin(ORIGIN.applicationId(), ORIGIN.id()));
+        inventory.setOrigins(ORIGIN_1);
+        inventory.onCommand(new DisableOrigin(ORIGIN_1.applicationId(), ORIGIN_1.id()));
+        inventory.onCommand(new EnableOrigin(ORIGIN_1.applicationId(), ORIGIN_1.id()));
 
         assertThat(logger.lastMessage(), is(loggingEvent(INFO,
-                "Origin state change: origin=\"generic-app=one\", change=\"DISABLED->INACTIVE\"")));
+                "Origin state change: origin=\"generic-app=app-01\", change=\"DISABLED->INACTIVE\"")));
     }
 
     @Test
     public void registersToEventBusWhenCreated() {
-        assertThat(eventBus.registered, hasItem(inventory));
+        verify(eventBus).register(eq(inventory));
     }
 
     @Test
-    public void unregistersFromEventBusWhenClosed() {
+    public void stopsMonitoringAndUnregistersWhenClosed() {
+        ConnectionPool.Factory connectionFactory = mock(ConnectionPool.Factory.class);
+
+        ConnectionPool pool1 = mock(ConnectionPool.class);
+        when(pool1.getOrigin()).thenReturn(ORIGIN_1);
+
+        ConnectionPool pool2 = mock(ConnectionPool.class);
+        when(pool2.getOrigin()).thenReturn(ORIGIN_2);
+
+        when(connectionFactory.create(eq(ORIGIN_1))).thenReturn(pool1);
+        when(connectionFactory.create(eq(ORIGIN_2))).thenReturn(pool2);
+
+        inventory = new OriginsInventory(eventBus, GENERIC_APP, monitor, connectionFactory, metricRegistry);
+        inventory.setOrigins(ORIGIN_1, ORIGIN_2);
         inventory.close();
 
-        assertThat(eventBus.registered, not(hasItem(inventory)));
+        verify(monitor).stopMonitoring(eq(ImmutableSet.of(ORIGIN_1)));
+        verify(monitor).stopMonitoring(eq(ImmutableSet.of(ORIGIN_2)));
+        assertThat(gaugeValue("origins.generic-app.app-01.status"), isAbsent());
+        assertThat(gaugeValue("origins.generic-app.app-02.status"), isAbsent());
+
+        verify(pool1).close();
+        verify(pool2).close();
+
+        verify(eventBus, times(2)).post(any(OriginsInventorySnapshot.class));
+        verify(eventBus).unregister(eq(inventory));
     }
 
     private static Matcher<OriginsInventory> hasNoActiveOrigins() {
@@ -324,19 +515,4 @@ public class OriginsInventoryTest {
                 .build();
     }
 
-    private static class InstrumentedEventBus extends EventBus {
-        private final List<Object> registered = new ArrayList<>();
-
-        @Override
-        public void register(Object object) {
-            super.register(object);
-            registered.add(object);
-        }
-
-        @Override
-        public void unregister(Object object) {
-            super.unregister(object);
-            registered.remove(object);
-        }
-    }
 }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxHttpClientTest.java
@@ -479,26 +479,6 @@ public class StyxHttpClientTest {
     }
 
     @Test
-    public void shouldStopMonitoringOriginsOnClientClose() {
-        RecordingOriginHealthStatusMonitor monitor = new RecordingOriginHealthStatusMonitor();
-        OriginHealthStatusMonitor.Factory factory = (id, healthCheckConfig, supplier) -> monitor;
-
-        BackendService backendService = backendWithOrigins(SOME_ORIGIN.host().getPort());
-
-        OriginsInventory originsInventory = newOriginsInventoryBuilder(backendService)
-                .originHealthStatusMonitorFactory(factory)
-                .build();
-
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
-                .originsInventory(originsInventory)
-                .build();
-
-        originsInventory.close();
-
-        assertThat(monitor.status() == RUNNING, is(false));
-    }
-
-    @Test
     public void incrementsResponseStatusMetricsForBadResponse() throws Exception {
         requestOperationFactory = requestOpFactory(request -> just(response(BAD_REQUEST).build()));
         StyxHttpClient styxHttpClient = newStyxHttpClient(mockPool(openConnection(SOME_ORIGIN)));

--- a/components/common/src/main/java/com/hotels/styx/common/EventProcessor.java
+++ b/components/common/src/main/java/com/hotels/styx/common/EventProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/common/src/main/java/com/hotels/styx/common/StateChangeListener.java
+++ b/components/common/src/main/java/com/hotels/styx/common/StateChangeListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package com.hotels.styx.common;
 
 /**
  * Informed about state changes.
+ *
+ * @param <S> State type.
  */
 public interface StateChangeListener<S> {
     void onStateChange(S oldState, S newState, Object event);

--- a/components/common/src/main/java/com/hotels/styx/common/StateChangeListener.java
+++ b/components/common/src/main/java/com/hotels/styx/common/StateChangeListener.java
@@ -18,7 +18,7 @@ package com.hotels.styx.common;
 /**
  * Informed about state changes.
  *
- * @param <S> State type.
+ * @param <S> state type
  */
 public interface StateChangeListener<S> {
     void onStateChange(S oldState, S newState, Object event);

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/Registry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/Registry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,11 +198,17 @@ public interface Registry<T extends Identifiable> extends Supplier<Iterable<T>> 
         }
     }
 
+    /**
+     * Registry reload outcome.
+     */
     enum Outcome {
         RELOADED,
         UNCHANGED
     }
 
+    /**
+     * Result or registry reload.
+     */
     class ReloadResult {
 
         Outcome outcome;

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/Registry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/Registry.java
@@ -207,7 +207,7 @@ public interface Registry<T extends Identifiable> extends Supplier<Iterable<T>> 
     }
 
     /**
-     * Result or registry reload.
+     * Result of registry reload.
      */
     class ReloadResult {
 

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,6 @@ public class BackendServicesRouter implements HttpRouter, Registry.ChangeListene
             routes.put(backendService.path(), pipeline);
             LOG.info("added path={} current routes={}", backendService.path(), routes.keySet());
 
-            pipeline.registerStatusGauges();
         });
 
         changes.removed().forEach(backendService ->
@@ -133,10 +132,6 @@ public class BackendServicesRouter implements HttpRouter, Registry.ChangeListene
 
         public void close() {
             originsInventory.close();
-        }
-
-        public void registerStatusGauges() {
-            originsInventory.registerStatusGauges();
         }
 
         private static void handleError(HttpRequest request, Throwable throwable) {

--- a/components/proxy/src/test/scala/com/hotels/styx/routing/config/RoutingConfigParserSpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/routing/config/RoutingConfigParserSpec.scala
@@ -13,28 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2013-2017 Expedia Inc.
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+
 package com.hotels.styx.routing.config
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.hotels.styx.infrastructure.configuration.yaml.{JsonNodeConfig, YamlConfig}
+import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig
 import org.scalatest.{FunSpec, ShouldMatchers}
-
-import scala.collection.JavaConverters._
 
 
 class RoutingConfigParserSpec extends FunSpec with ShouldMatchers {


### PR DESCRIPTION
- Use QueueDrainingEventProcessor to ensure lockless consistency in face of concurrent updates.
- Improve origin state management for added/modified/removed monitored origins.