### PR TITLE
OriginStatsFactory instantiation moved upper in hierarchy.

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/HttpRequestOperation.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/HttpRequestOperation.java
@@ -170,9 +170,10 @@ public class HttpRequestOperation implements Operation<NettyConnection, HttpResp
         Origin origin = nettyConnection.getOrigin();
         Channel channel = nettyConnection.channel();
         channel.pipeline().addLast(IDLE_HANDLER_NAME, new IdleStateHandler(0, 0, responseTimeoutMillis, MILLISECONDS));
-        if (originStatsFactory.isPresent()) {
-            channel.pipeline().addLast(RequestsToOriginMetricsCollector.NAME, new RequestsToOriginMetricsCollector(originStatsFactory.get().originStats(origin)));
-        }
+        originStatsFactory.ifPresent(
+                originStatsFactory -> channel.pipeline()
+                        .addLast(RequestsToOriginMetricsCollector.NAME,
+                                new RequestsToOriginMetricsCollector(originStatsFactory.originStats(origin))));
         channel.pipeline().addLast(
                 NettyToStyxResponsePropagator.NAME,
                 new NettyToStyxResponsePropagator(observer, origin, flowControlEnabled, responseTimeoutMillis, MILLISECONDS, request));

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/HttpRequestMessageLoggerTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/HttpRequestMessageLoggerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/common/src/main/java/com/hotels/styx/common/logging/HttpRequestMessageLogger.java
+++ b/components/common/src/main/java/com/hotels/styx/common/logging/HttpRequestMessageLogger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
@@ -21,6 +21,7 @@ import com.hotels.styx.api.HttpHandler2;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
+import com.hotels.styx.client.OriginStatsFactory;
 import com.hotels.styx.client.OriginsInventory;
 import com.hotels.styx.client.applications.BackendService;
 import com.hotels.styx.client.netty.connectionpool.NettyConnectionFactory;
@@ -89,12 +90,14 @@ public class BackendServicesRouter implements HttpRouter, Registry.ChangeListene
             boolean longFormat = environment.styxConfig().get("request-logging.outbound.longFormat", Boolean.class)
                     .orElse(false);
 
+            OriginStatsFactory originStatsFactory = new OriginStatsFactory(environment.metricRegistry());
+
             NettyConnectionFactory connectionFactory = new NettyConnectionFactory.Builder()
                     .name("Styx")
                     .clientWorkerThreadsCount(clientWorkerThreadsCount)
                     .tlsSettings(backendService.tlsSettings().orElse(null))
                     .flowControlEnabled(true)
-                    .metricRegistry(environment.metricRegistry())
+                    .originStatsFactory(originStatsFactory)
                     .responseTimeoutMillis(backendService.responseTimeoutMillis())
                     .requestLoggingEnabled(requestLoggingEnabled)
                     .longFormat(longFormat)
@@ -105,6 +108,7 @@ public class BackendServicesRouter implements HttpRouter, Registry.ChangeListene
                     .version(environment.buildInfo().releaseVersion())
                     .eventBus(environment.eventBus())
                     .metricsRegistry(environment.metricRegistry())
+                    .originStatsFactory(originStatsFactory)
                     .connectionFactory(connectionFactory)
                     .build();
 


### PR DESCRIPTION
After refactoring instances of a class mentioned above are created much more
often without a purpose, they can be shared across origins inventory.