### PR TITLE
Class cast exception from FileBackedBackendServiceRegistry.Factory 

### DIFF
--- a/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistryFactoryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistryFactoryTest.java
@@ -20,13 +20,15 @@ import com.hotels.styx.StyxConfig;
 import com.hotels.styx.api.Environment;
 import com.hotels.styx.api.Id;
 import com.hotels.styx.api.Resource;
+import com.hotels.styx.api.configuration.Configuration;
+import com.hotels.styx.api.configuration.ConfigurationException;
 import com.hotels.styx.client.applications.BackendService;
 import com.hotels.styx.common.StyxFutures;
 import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static com.hotels.styx.api.io.ResourceFactory.newResource;
 import static com.hotels.styx.serviceproviders.ServiceProvision.loadService;
@@ -34,10 +36,13 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FileBackedBackendServicesRegistryFactoryTest {
     @Test
-    public void instantiatesFromYaml() throws IOException {
+    public void instantiatesFromYaml() {
         Environment environment = environment("classpath:conf/environment/backend-factory-config.yml");
 
         FileBackedBackendServicesRegistry registry = loadService(environment.configuration(), environment, "services.factories.backendServiceRegistry", FileBackedBackendServicesRegistry.class).get();
@@ -49,6 +54,28 @@ public class FileBackedBackendServicesRegistryFactoryTest {
         List<String> backendIds = ids(backendServices);
 
         assertThat(backendIds, containsInAnyOrder("backend-factory-test-origin1", "backend-factory-test-origin2"));
+    }
+
+    @Test(expectedExceptions = ConfigurationException.class, expectedExceptionsMessageRegExp = "empty .services.registry.factory.config.originsFile. config value for factory class FileBackedBackendServicesRegistry.Factory")
+    public void requiresOriginsFileToBeSet() {
+        Environment environment = new com.hotels.styx.Environment.Builder().build();
+        Configuration configuration = mockConfiguration(Optional.of(""));
+
+        new FileBackedBackendServicesRegistry.Factory().create(environment, configuration);
+    }
+
+    @Test(expectedExceptions = ConfigurationException.class, expectedExceptionsMessageRegExp = "missing .services.registry.factory.config.originsFile. config value for factory class FileBackedBackendServicesRegistry.Factory")
+    public void requiresOriginsFileToBeNonEmpty() {
+        Environment environment = new com.hotels.styx.Environment.Builder().build();
+        Configuration configuration = mockConfiguration(Optional.empty());
+
+        new FileBackedBackendServicesRegistry.Factory().create(environment, configuration);
+    }
+
+    private Configuration mockConfiguration(Optional<String> s) {
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.get(eq("originsFile"), eq(String.class))).thenReturn(s);
+        return configuration;
     }
 
     private List<String> ids(Iterable<BackendService> backendServices) {


### PR DESCRIPTION
h1. Summary

Fixes an unsuccessful attempt to cast MemoryBackedRegistry into a FileBackedBackendServicesRegistry when `originsFile` attribute was left unspecified.

h1. Details

When `originsFile` is present, but an empty string, styx fails to start with a confusing error message about illegal cast of MemoryBackedRegistry into FileBackedBackendServiceRegistry class. This happens because if `originsFile` is an empty string, a MemoryBackedRegistry was created instead. The idea presumably being that it would be possible to start styx without specifying the origins file at all.

But in that case one can simply remove the backend service from configuration.

Now we will throw an appropriate exception with a clear error message.

