### PR TITLE
Serialise `cipherSuites` attribute of TlsSettings.

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/ssl/TlsSettings.java
+++ b/components/client/src/main/java/com/hotels/styx/client/ssl/TlsSettings.java
@@ -101,6 +101,11 @@ public class TlsSettings {
         return protocols;
     }
 
+    @JsonProperty("cipherSuites")
+    public List<String> cipherSuites() {
+        return this.cipherSuites;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -138,9 +143,6 @@ public class TlsSettings {
                 trustStorePath, Arrays.hashCode(trustStorePassword), protocols, cipherSuites);
     }
 
-    public List<String> cipherSuites() {
-        return this.cipherSuites;
-    }
 
     /**
      * The builder for SSL settings.

--- a/components/client/src/test/unit/java/com/hotels/styx/client/ssl/TlsSettingsTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/ssl/TlsSettingsTest.java
@@ -49,6 +49,7 @@ public class TlsSettingsTest {
                 .sslProvider("JDK")
                 .trustStorePassword("bar")
                 .protocols(ImmutableList.of("TLSv1.2"))
+                .cipherSuites(ImmutableList.of("TLS_RSA_WITH_AES_128_CBC_SHA"))
                 .build();
 
         String result = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(tlsSettings);
@@ -60,6 +61,8 @@ public class TlsSettingsTest {
         // trustStorePath is platform dependent - thus match only until the root path:
         assertThat(result, containsString("\"trustStorePath\" : \"/"));
         assertThat(result, containsString("\"trustStorePassword\" : \"bar"));
+
+        assertThat(result, containsString("TLS_RSA_WITH_AES_128_CBC_SHA"));
     }
 
     @Test


### PR DESCRIPTION
CipherSuites attribute of TlsSettings block for backend services is not serialised. As a result it doesn't show up in the admin interface. This PR fixes the issue.
