### PR TITLE
Fix issue #86: Reload of backend service id change. 

### DIFF
--- a/components/client/src/test/unit/java/com/hotels/styx/client/loadbalancing/strategies/BusyConnectionsStrategyTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/loadbalancing/strategies/BusyConnectionsStrategyTest.java
@@ -1,5 +1,5 @@
 /**
-w * Copyright (C) 2013-2018 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
@@ -93,6 +93,8 @@ public class BackendServicesRouter implements HttpRouter, Registry.ChangeListene
 
     @Override
     public void onChange(Registry.Changes<BackendService> changes) {
+        changes.removed().forEach(backendService -> routes.remove(backendService.path()).close());
+
         concat(changes.added(), changes.updated()).forEach(backendService -> {
 
             ProxyToClientPipeline pipeline = routes.get(backendService.path());
@@ -162,10 +164,6 @@ public class BackendServicesRouter implements HttpRouter, Registry.ChangeListene
             LOG.info("added path={} current routes={}", backendService.path(), routes.keySet());
 
         });
-
-        changes.removed().forEach(backendService ->
-                routes.remove(backendService.path())
-                        .close());
     }
 
     private HttpClient newClientHandler(BackendService backendService, OriginsInventory originsInventory, OriginStatsFactory originStatsFactory) {

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/BackendServicesRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/BackendServicesRouterTest.java
@@ -178,11 +178,25 @@ public class BackendServicesRouterTest {
     }
 
     @Test
+    public void removesExistingServicesBeforeAddingNewOnes() {
+        BackendServicesRouter router = new BackendServicesRouter(serviceClientFactory, environment);
+        router.onChange(added(appB()));
+
+        router.onChange(new Registry.Changes.Builder<BackendService>()
+                .added(newBackendServiceBuilder(appB()).id("X").build())
+                .removed(appB())
+                .build());
+
+        HttpRequest request = get("/appB/").build();
+        Optional<HttpHandler2> route = router.route(request);
+        assertThat(proxyTo(route, request).header(ORIGIN_ID_DEFAULT), isValue("X"));
+    }
+
+    @Test
     public void updatesRoutesOnBackendServicesChange() {
         BackendServicesRouter router = new BackendServicesRouter(serviceClientFactory, environment);
 
         HttpRequest request = get("/appB/").build();
-
 
         router.onChange(added(appB()));
 


### PR DESCRIPTION
The BackendServicesRouter now retains the origins without losing them.

Note that this is a quick stop gap. In this fix the path prefix in question momentarily 
disappears from the routing table. Going forward we will refactor the code around 
reloading origins to accommodate Consul, Serf etc. based backend services providers. 
We will then revisit this code to ensure that path prefix remains continuously in the 
routing table.
