### PR TITLE
Fix intermittently failing e2e test: ExpiringConnectionSpec.  

### DIFF
--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/ExpiringConnectionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/ExpiringConnectionSpec.scala
@@ -76,8 +76,10 @@ class ExpiringConnectionSpec extends FunSpec
 
     assertThat(response1.status(), is(OK))
 
-    styxServer.metricsSnapshot.gauge(s"origins.appOne.generic-app-01.connectionspool.available-connections").get should be(1)
-    styxServer.metricsSnapshot.gauge(s"origins.appOne.generic-app-01.connectionspool.connections-closed").get should be(0)
+    eventually(timeout(2.seconds)) {
+      styxServer.metricsSnapshot.gauge(s"origins.appOne.generic-app-01.connectionspool.available-connections").get should be(1)
+      styxServer.metricsSnapshot.gauge(s"origins.appOne.generic-app-01.connectionspool.connections-closed").get should be(0)
+    }
 
     Thread.sleep(1000)
 


### PR DESCRIPTION
Enclose metric-based assertions in an eventually block.