### PR TITLE
Remove 5xx check from BusyConnectionsStrategy

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/BusyConnectionsStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/BusyConnectionsStrategy.java
@@ -67,7 +67,6 @@ public class BusyConnectionsStrategy implements LoadBalancingStrategy {
         shuffle(poolsList);
 
         poolsList.sort(byComparing(
-                (first, second) -> Boolean.compare(first.status5xxRate() > average5xxRate, second.status5xxRate() > average5xxRate),
                 (first, second) -> Integer.compare(first.busyConnectionCount(), second.busyConnectionCount()),
                 (first, second) -> Integer.compare(first.pendingConnectionCount(), second.pendingConnectionCount()),
                 (first, second) -> Boolean.compare(second.availableConnectionCount() > 0, first.availableConnectionCount() > 0)


### PR DESCRIPTION
Currently there is a check in BusyConnectionsStrategy for HTTP 5xx response rate. However, this check is not valid for this strategy as it is (a) out of scope and (b) created with a latency-based strategy in mind, which BCS is not.

As such it should be removed. If similar functionality is required in the future it should be implemented in a less haphazard way.