### PR TITLE
Add power of 2 load balancing strategy.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/client/retrypolicy/spi/RetryPolicy.java
+++ b/components/api/src/main/java/com/hotels/styx/api/client/retrypolicy/spi/RetryPolicy.java
@@ -79,13 +79,6 @@ public interface RetryPolicy {
         long retryIntervalMillis();
 
         /**
-         * Returns the origin that the next retry should target.
-         *
-         * @return A {@link ConnectionPool} that the next retry should target
-         */
-        Optional<RemoteHost> nextOrigin();
-
-        /**
          * Specifies if the current outcome is to retry or not.
          *
          * @return true if the operation should be retried

--- a/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategy.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2013-2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.styx.client.loadbalancing.strategies;
+
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.hotels.styx.api.Environment;
+import com.hotels.styx.api.client.ActiveOrigins;
+import com.hotels.styx.api.client.ConnectionPool;
+import com.hotels.styx.api.client.RemoteHost;
+import com.hotels.styx.api.client.loadbalancing.spi.LoadBalancingStrategy;
+import com.hotels.styx.api.client.loadbalancing.spi.LoadBalancingStrategyFactory;
+import com.hotels.styx.api.configuration.Configuration;
+
+import java.util.List;
+import java.util.Random;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+
+
+/**
+ * A Power Of Two load balancing strategy.
+ *
+ * Randomly choose two origins, and return the one with less ongoing requests.
+ */
+public class PowerOfTwoStrategy implements LoadBalancingStrategy {
+    private ActiveOrigins activeOrigins;
+    private Random rng;
+
+    public PowerOfTwoStrategy(ActiveOrigins activeOrigins) {
+        this(activeOrigins, new Random());
+    }
+
+    @VisibleForTesting
+    PowerOfTwoStrategy(ActiveOrigins activeOrigins, Random rng) {
+        this.activeOrigins = activeOrigins;
+        this.rng = rng;
+    }
+
+    /**
+     * A load balancing strategy that favours the origin with the least response time.
+     */
+    public static class Factory implements LoadBalancingStrategyFactory {
+        @Override
+        public LoadBalancingStrategy create(Environment environment, Configuration strategyConfiguration, ActiveOrigins activeOrigins) {
+            return new PowerOfTwoStrategy(activeOrigins);
+        }
+    }
+
+    @Override
+    public Iterable<RemoteHost> vote(Context context) {
+        List<ConnectionPoolStatus> poolsList = stream(activeOrigins.snapshot().spliterator(), false)
+                .map(host -> new ConnectionPoolStatus(host, context))
+                .collect(toList());
+
+        if (poolsList.size() == 0) {
+            return ImmutableList.of();
+        }
+
+        if (poolsList.size() == 1) {
+            return ImmutableList.of(poolsList.get(0).host());
+        }
+
+        ConnectionPoolStatus poolStatus1 = choose(poolsList);
+        ConnectionPoolStatus poolStatus2 = choose(poolsList, poolStatus1);
+
+        return betterOf(poolStatus1, poolStatus2);
+    }
+
+    private Iterable<RemoteHost> betterOf(ConnectionPoolStatus poolStatus1, ConnectionPoolStatus poolStatus2) {
+        int metric1 = poolStatus1.busyConnectionCount() + poolStatus1.pendingConnectionCount();
+        int metric2 = poolStatus2.busyConnectionCount() + poolStatus2.pendingConnectionCount();
+
+        if (metric1 < metric2) {
+            return ImmutableList.of(poolStatus1.host(), poolStatus2.host());
+        } else {
+            return ImmutableList.of(poolStatus2.host(), poolStatus1.host());
+        }
+    }
+
+    private ConnectionPoolStatus choose(List<ConnectionPoolStatus> poolsList, ConnectionPoolStatus another) {
+        int i = 0;
+        ConnectionPoolStatus second = choose(poolsList);
+
+        while (i < 20 && another.host().id() == second.host.id()) {
+            second = choose(poolsList);
+            i++;
+        }
+
+        return second;
+    }
+
+    private ConnectionPoolStatus choose(List<ConnectionPoolStatus> poolsList) {
+        int index = rng.nextInt(poolsList.size());
+        return poolsList.get(index);
+    }
+
+    private static class ConnectionPoolStatus {
+        private final RemoteHost host;
+        private final int busyConnectionCount;
+        private final int pendingConnectionCount;
+
+        public ConnectionPoolStatus(RemoteHost host, Context context) {
+            this.host = host;
+            this.busyConnectionCount = host.connectionPool().stats().busyConnectionCount();
+            this.pendingConnectionCount = host.connectionPool().stats().pendingConnectionCount();
+        }
+
+        public int busyConnectionCount() {
+            return busyConnectionCount;
+        }
+
+        public int pendingConnectionCount() {
+            return pendingConnectionCount;
+        }
+
+        public ConnectionPool pool() {
+            return host.connectionPool();
+        }
+
+        public RemoteHost host() {
+            return host;
+        }
+    }
+}

--- a/components/client/src/main/java/com/hotels/styx/client/retry/RetryNTimes.java
+++ b/components/client/src/main/java/com/hotels/styx/client/retry/RetryNTimes.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client.retry;
 
-import com.hotels.styx.api.client.RemoteHost;
 import com.hotels.styx.api.client.loadbalancing.spi.LoadBalancingStrategy;
 import com.hotels.styx.api.client.retrypolicy.spi.RetryPolicy;
 import com.hotels.styx.api.netty.exceptions.IsRetryableException;
@@ -23,8 +22,6 @@ import com.hotels.styx.api.netty.exceptions.IsRetryableException;
 import java.util.Optional;
 
 import static com.google.common.base.Objects.toStringHelper;
-import static com.google.common.collect.Iterables.contains;
-import static java.util.stream.StreamSupport.stream;
 
 /**
  * A {@link RetryPolicy} that tries a configurable <code>maxAttempts</code>.
@@ -41,13 +38,6 @@ public class RetryNTimes extends AbstractRetryPolicy {
             @Override
             public long retryIntervalMillis() {
                 return deltaBackoffMillis();
-            }
-
-            @Override
-            public Optional<RemoteHost> nextOrigin() {
-                return stream(loadBalancingStrategy.vote(lbContext).spliterator(), false)
-                        .filter(origin -> !contains(context.previousOrigins(), origin))
-                        .findFirst();
             }
 
             @Override

--- a/components/client/src/main/java/com/hotels/styx/client/retry/RetryPolicies.java
+++ b/components/client/src/main/java/com/hotels/styx/client/retry/RetryPolicies.java
@@ -66,11 +66,6 @@ public final class RetryPolicies {
         }
 
         @Override
-        public Optional<RemoteHost> nextOrigin() {
-            return origin;
-        }
-
-        @Override
         public boolean shouldRetry() {
             return shouldRetry;
         }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategyTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategyTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2013-2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.styx.client.loadbalancing.strategies;
+
+import com.google.common.collect.Iterables;
+import com.hotels.styx.api.HttpClient;
+import com.hotels.styx.api.client.ActiveOrigins;
+import com.hotels.styx.api.client.ConnectionPool;
+import com.hotels.styx.api.client.Origin;
+import com.hotels.styx.api.client.RemoteHost;
+import com.hotels.styx.api.client.loadbalancing.spi.LoadBalancingStrategy;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static com.google.common.collect.Iterables.getFirst;
+import static com.hotels.styx.api.client.Origin.newOriginBuilder;
+import static com.hotels.styx.api.client.RemoteHost.remoteHost;
+import static com.hotels.styx.api.support.HostAndPorts.localHostAndFreePort;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class PowerOfTwoStrategyTest {
+    final Origin ORIGIN_ONE = newOriginBuilder(localHostAndFreePort()).id("one").build();
+    final Origin ORIGIN_TWO = newOriginBuilder(localHostAndFreePort()).id("two").build();
+    final Origin ORIGIN_THREE = newOriginBuilder(localHostAndFreePort()).id("three").build();
+    final Origin ORIGIN_FOUR = newOriginBuilder(localHostAndFreePort()).id("four").build();
+
+    private final RemoteHost HOST_ONE = remoteHost(ORIGIN_ONE, mockPool(5), mock(HttpClient.class));
+    private final RemoteHost HOST_TWO = remoteHost(ORIGIN_TWO, mockPool(6), mock(HttpClient.class));
+    private final RemoteHost HOST_THREE = remoteHost(ORIGIN_THREE, mockPool(3), mock(HttpClient.class));
+    private final RemoteHost HOST_FOUR = remoteHost(ORIGIN_FOUR, mockPool(2), mock(HttpClient.class));
+
+    List<RemoteHost> allOrigins = asList(HOST_ONE, HOST_TWO, HOST_THREE,  HOST_FOUR);
+
+    private long RNG_SEED = 5;
+
+
+    @Test
+    public void choosesBetterOfTwoRandomChoices() {
+        ActiveOrigins activeOrigins = mock(ActiveOrigins.class);
+        when(activeOrigins.snapshot()).thenReturn(allOrigins);
+
+        Random rng = new Random(RNG_SEED);
+        int first = rng.nextInt(4);
+        assert(first == 2);
+
+        int second = rng.nextInt(4);
+        assert(second == 0);
+
+        PowerOfTwoStrategy loadBalancer = new PowerOfTwoStrategy(activeOrigins, new Random(RNG_SEED));
+        Iterable<RemoteHost> chosenOne = loadBalancer.vote(mock(LoadBalancingStrategy.Context.class));
+
+        assertThat(getFirst(chosenOne, null), is(betterOf(allOrigins.get(first), allOrigins.get(second))));
+    }
+
+    @Test
+    public void choosesSoleOriginOutOfOne() {
+        ActiveOrigins activeOrigins = mock(ActiveOrigins.class);
+        when(activeOrigins.snapshot()).thenReturn(asList(HOST_ONE));
+
+        PowerOfTwoStrategy loadBalancer = new PowerOfTwoStrategy(activeOrigins, new Random(RNG_SEED));
+
+        for (int i = 0; i < 10; i++) {
+            Iterable<RemoteHost> chosenOne = loadBalancer.vote(mock(LoadBalancingStrategy.Context.class));
+            assertThat(getFirst(chosenOne, null), is(HOST_ONE));
+        }
+    }
+
+    @Test
+    public void returnsEmptyWhenNoOriginsAreAvailable() {
+        ActiveOrigins activeOrigins = mock(ActiveOrigins.class);
+        when(activeOrigins.snapshot()).thenReturn(asList());
+
+        PowerOfTwoStrategy loadBalancer = new PowerOfTwoStrategy(activeOrigins, new Random(RNG_SEED));
+        Iterable<RemoteHost> chosenOne = loadBalancer.vote(mock(LoadBalancingStrategy.Context.class));
+
+        assertThat(Iterables.size(chosenOne), is(0));
+    }
+
+    private RemoteHost betterOf(RemoteHost first, RemoteHost second) {
+        return ongoingRequests(first) < ongoingRequests(second) ? first : second;
+    }
+
+    private int ongoingRequests(RemoteHost first) {
+        ConnectionPool.Stats poolStats = first.connectionPool().stats();
+
+        return poolStats.busyConnectionCount() + poolStats.pendingConnectionCount();
+    }
+
+    private ConnectionPool mockPool(int borrowedConnections) {
+        ConnectionPool.Stats mockStats = mock(ConnectionPool.Stats.class);
+        when(mockStats.busyConnectionCount()).thenReturn(borrowedConnections, borrowedConnections, borrowedConnections);
+        when(mockStats.pendingConnectionCount()).thenReturn(0, 0, 0);
+
+        ConnectionPool mockPool = mock(ConnectionPool.class);
+        when(mockPool.stats()).thenReturn(mockStats);
+
+        return mockPool;
+    }
+
+}

--- a/components/client/src/test/unit/java/com/hotels/styx/client/retry/RetryNTimesTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/retry/RetryNTimesTest.java
@@ -25,9 +25,7 @@ import com.hotels.styx.api.netty.exceptions.IsRetryableException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.Collections;
-
-import static java.util.Collections.singleton;
+import static com.hotels.styx.api.client.RemoteHost.remoteHost;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,7 +39,6 @@ public class RetryNTimesTest {
     private RetryPolicy.Context retryPolicyContext;
     private LoadBalancingStrategy strategyMock;
     private LoadBalancingStrategy.Context strategyContextMock;
-    private RemoteHost remoteHost;
 
     @BeforeMethod
     public void setupMocks() {
@@ -50,7 +47,7 @@ public class RetryNTimesTest {
         this.retryPolicyContext = mock(RetryPolicy.Context.class);
         this.strategyMock = mock(LoadBalancingStrategy.class);
         this.strategyContextMock = mock(LoadBalancingStrategy.Context.class);
-        this.remoteHost = RemoteHost.remoteHost(mock(Origin.class), mock(ConnectionPool.class), mock(HttpClient.class));
+        RemoteHost remoteHost = remoteHost(mock(Origin.class), mock(ConnectionPool.class), mock(HttpClient.class));
 
         when(retryPolicyContext.currentRetryCount()).thenReturn(0);
         when(retryPolicyContext.lastException()).thenReturn(empty());
@@ -82,28 +79,6 @@ public class RetryNTimesTest {
                 strategyMock, strategyContextMock);
 
         assertThat(retryOutcome.shouldRetry(), equalTo(false));
-    }
-
-    @Test
-    public void shouldReturnUnfilteredOrigin() {
-        when(retryPolicyContext.previousOrigins()).thenReturn(Collections.emptyList());
-        when(strategyMock.vote(strategyContextMock)).thenReturn(singleton(remoteHost));
-
-        RetryPolicy.Outcome retryOutcome = retryNTimesPolicy.evaluate(retryPolicyContext,
-                strategyMock, strategyContextMock);
-
-        assertThat(retryOutcome.nextOrigin().get(), equalTo(remoteHost));
-    }
-
-    @Test
-    public void shouldReturnEmptyOriginList() {
-        when(retryPolicyContext.previousOrigins()).thenReturn(Collections.singleton(remoteHost));
-        when(strategyMock.vote(strategyContextMock)).thenReturn(singleton(remoteHost));
-
-        RetryPolicy.Outcome retryOutcome = retryNTimesPolicy.evaluate(retryPolicyContext,
-                strategyMock, strategyContextMock);
-
-        assertThat(retryOutcome.nextOrigin().isPresent(), equalTo(false));
     }
 
     private final static class TestException extends RuntimeException implements IsRetryableException {


### PR DESCRIPTION
Implements power of 2 load balancing strategy to styx. 

There is a know short-come in BusyConnectionStrategy: it can start favouring origins returning large quantities of quick 5xx responses. Sometimes a fault in origin may cause them to fail very early on in the business logic. This result a 5xx error being sent with a relatively low latency compared to successful requests. If such failure becomes persistent, an origin like that appears better compared to the others and therefore will receive more traffic.

A power of 2 strategy lessens this effect. This is because there is a larger element of randomness in its choice. Compare this to BusyConnectionStrategy which always chooses the "best" option.

