### PR TITLE
Improve origins reload visibility

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/admin/dashboard/DashboardData.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/dashboard/DashboardData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,11 +173,6 @@ public class DashboardData {
             this.backends = stream(backendServicesRegistry.get().spliterator(), false)
                     .map(Backend::new)
                     .collect(toList());
-        }
-
-        @Override
-        public void onError(Throwable ex) {
-            // do nothing
         }
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/dashboard/DashboardDataSupplier.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/dashboard/DashboardDataSupplier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,11 +60,6 @@ public class DashboardDataSupplier implements Supplier<DashboardData>, Registry.
 
     private DashboardData updateDashboardData(Registry<BackendService> backendServices) {
         return new DashboardData(environment.metricRegistry(), backendServices, jvmRouteName, buildInfo, environment.eventBus());
-    }
-
-    @Override
-    public void onError(Throwable ex) {
-        // do nothing
     }
 
     @Override

--- a/components/proxy/src/main/java/com/hotels/styx/admin/tasks/OriginsReloadCommandHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/tasks/OriginsReloadCommandHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2017 Expedia Inc.
+ * Copyright (C) 2013-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,8 @@ public class OriginsReloadCommandHandler implements HttpHandler {
                         } else if (result.outcome() == UNCHANGED) {
                             subscriber.onNext(okResponse(format("Origins were not reloaded because %s.\n", result.message())));
                             subscriber.onCompleted();
+                        } else {
+                            subscriber.onError(mapError(result));
                         }
                     } else {
                         subscriber.onNext(errorResponse(exception));
@@ -79,6 +81,14 @@ public class OriginsReloadCommandHandler implements HttpHandler {
                     }
                     return null;
                 });
+    }
+
+    private Throwable mapError(Registry.ReloadResult result) {
+        if (result.cause().isPresent()) {
+            return new RuntimeException(result.cause().get());
+        } else {
+            return new RuntimeException("Reload failure");
+        }
     }
 
     private HttpResponse okResponse(String content) {

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/AbstractRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/AbstractRegistry.java
@@ -54,11 +54,6 @@ public abstract class AbstractRegistry<T extends Identifiable> implements Regist
         announcer.announce().onChange(changes);
     }
 
-    protected void notifyListenersOnError(Throwable cause) {
-        LOG.info("notifying about error={} to listeners={}", cause, announcer.listeners());
-        announcer.announce().onError(cause);
-    }
-
     @Override
     public Registry<T> addListener(ChangeListener<T> changeListener) {
         announcer.addListener(changeListener);

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/FileBackedRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/FileBackedRegistry.java
@@ -29,6 +29,7 @@ import static com.google.common.base.Throwables.propagate;
 import static com.google.common.hash.HashCode.fromLong;
 import static com.google.common.hash.Hashing.md5;
 import static com.google.common.io.ByteStreams.toByteArray;
+import static com.hotels.styx.infrastructure.Registry.ReloadResult.failed;
 import static com.hotels.styx.infrastructure.Registry.ReloadResult.reloaded;
 import static com.hotels.styx.infrastructure.Registry.ReloadResult.unchanged;
 import static java.lang.String.format;
@@ -79,7 +80,7 @@ public class FileBackedRegistry<T extends Identifiable> extends AbstractRegistry
                     }
                 } catch (Exception e) {
                     LOG.error("Not reloading {} as there was an error reading content", configurationFile.absolutePath(), e);
-                    throw e;
+                    return failed(format("md5-hash=%s, Reload failure.", hashCode), e);
                 }
             }
         }, newSingleThreadExecutor());

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/Registry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/Registry.java
@@ -71,10 +71,7 @@ public interface Registry<T extends Identifiable> extends Supplier<Iterable<T>> 
      * @param <T> The type of configuration referred to by this ChangeListener
      */
     interface ChangeListener<T extends Identifiable> extends EventListener {
-
         void onChange(Changes<T> changes);
-
-        void onError(Throwable ex);
     }
 
     /**

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
@@ -224,11 +224,6 @@ public class BackendServicesRouter implements HttpRouter, Registry.ChangeListene
         return new UrlRequestHealthCheck(healthCheckUri, client, metricRegistry);
     }
 
-    @Override
-    public void onError(Throwable ex) {
-        LOG.warn("Error from registry", ex);
-    }
-
     private static class ProxyToClientPipeline implements HttpHandler2 {
         private final HttpClient client;
         private final OriginsInventory originsInventory;

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistry.java
@@ -27,6 +27,8 @@ import com.hotels.styx.infrastructure.FileBackedRegistry;
 import com.hotels.styx.infrastructure.Registry;
 import com.hotels.styx.infrastructure.YamlReader;
 import com.hotels.styx.proxy.backends.file.FileChangeMonitor.FileMonitorSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -42,6 +44,7 @@ import static java.util.Objects.requireNonNull;
  * File backed {@link com.hotels.styx.client.applications.BackendService} registry.
  */
 public class FileBackedBackendServicesRegistry extends AbstractStyxService implements Registry<BackendService>, FileChangeMonitor.Listener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileBackedBackendServicesRegistry.class);
     private final FileBackedRegistry<BackendService> fileBackedRegistry;
     private final FileMonitor fileChangeMonitor;
 
@@ -80,7 +83,8 @@ public class FileBackedBackendServicesRegistry extends AbstractStyxService imple
 
     @Override
     public CompletableFuture<ReloadResult> reload() {
-        return this.fileBackedRegistry.reload();
+        return this.fileBackedRegistry.reload()
+                .thenApply(outcome -> logReloadAttempt("Admin Interface", outcome));
     }
 
     @Override
@@ -98,9 +102,7 @@ public class FileBackedBackendServicesRegistry extends AbstractStyxService imple
             return x;
         }
         return this.fileBackedRegistry.reload()
-                .thenAccept(result -> {
-                    // Swallow the result
-                });
+                .thenAccept(result -> logReloadAttempt("Initial load", result));
     }
 
     @Override
@@ -115,7 +117,19 @@ public class FileBackedBackendServicesRegistry extends AbstractStyxService imple
 
     @Override
     public void fileChanged() {
-        this.fileBackedRegistry.reload();
+        this.fileBackedRegistry.reload()
+                .thenApply(outcome -> logReloadAttempt("File Monitor", outcome));
+    }
+
+    private ReloadResult logReloadAttempt(String reason, ReloadResult outcome) {
+        String fileName = this.fileBackedRegistry.fileName();
+        if (outcome.outcome() == Outcome.RELOADED || outcome.outcome() == Outcome.UNCHANGED) {
+            LOGGER.info("Backend services reloaded. reason='{}', {}, file='{}'", new Object[]{reason, outcome.message(), fileName});
+        } else if (outcome.outcome() == Outcome.FAILED) {
+            LOGGER.error("Backend services reload failed. reason='{}', {}, file='{}'",
+                    new Object[]{reason, outcome.message(), fileName, outcome.cause().get()});
+        }
+        return outcome;
     }
 
     /**

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileChangeMonitor.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileChangeMonitor.java
@@ -82,6 +82,12 @@ class FileChangeMonitor implements FileMonitor {
         }
     }
 
+    public void stop() {
+        if (monitoredTask != null) {
+            monitoredTask.cancel(true);
+        }
+    }
+
     private Runnable detectFileChangesTask(Listener listener) {
         return () -> {
             if (!exists(monitoredFile)) {

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileChangeMonitorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileChangeMonitorTest.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.proxy.backends.file;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -26,6 +25,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static ch.qos.logback.classic.Level.INFO;
 import static com.google.common.io.Files.createTempDir;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -36,10 +36,11 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.slf4j.LoggerFactory.getLogger;
 
 
 public class FileChangeMonitorTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FileChangeMonitorTest.class);
+    private static final Logger LOGGER = getLogger(FileChangeMonitorTest.class);
 
     private File tempDir;
     private Path monitoredFile;
@@ -53,6 +54,7 @@ public class FileChangeMonitorTest {
         write(monitoredFile, "content-v0");
         listener = mock(FileChangeMonitor.Listener.class);
         monitor = new FileChangeMonitor(monitoredFile.toString(), 250, MILLISECONDS);
+        ((ch.qos.logback.classic.Logger) getLogger(FileChangeMonitor.class)).setLevel(INFO);
     }
 
     @AfterMethod

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileChangeMonitorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileChangeMonitorTest.java
@@ -59,6 +59,7 @@ public class FileChangeMonitorTest {
 
     @AfterMethod
     public void tearDown() throws Exception {
+        monitor.stop();
         try {
             delete(monitoredFile);
         } catch (java.nio.file.NoSuchFileException cause) {

--- a/system-tests/e2e-suite/src/test/resources/conf/logback/logback-debug-stdout.xml
+++ b/system-tests/e2e-suite/src/test/resources/conf/logback/logback-debug-stdout.xml
@@ -8,6 +8,7 @@
 
   <logger name="org.apache" level="WARN"/>
   <logger name="io.netty" level="WARN"/>
+  <logger name="com.hotels.styx.proxy.backends.file.FileChangeMonitor" level="INFO"/>
 
   <root level="DEBUG">
     <appender-ref ref="CONSOLE"/>

--- a/system-tests/e2e-suite/src/test/resources/conf/logback/logback-suppress-errors.xml
+++ b/system-tests/e2e-suite/src/test/resources/conf/logback/logback-suppress-errors.xml
@@ -9,6 +9,7 @@
   <logger name="org.apache" level="WARN"/>
   <logger name="io.netty" level="WARN"/>
   <logger name="com.hotels.styx.api.metrics.HttpErrorStatusCauseLogger" level="OFF"/>
+  <logger name="com.hotels.styx.proxy.backends.file.FileChangeMonitor" level="INFO"/>
 
   <root level="INFO">
     <appender-ref ref="CONSOLE"/>

--- a/system-tests/e2e-suite/src/test/resources/conf/logback/logback.xml
+++ b/system-tests/e2e-suite/src/test/resources/conf/logback/logback.xml
@@ -8,6 +8,7 @@
 
   <logger name="org.apache" level="WARN"/>
   <logger name="io.netty" level="WARN"/>
+  <logger name="com.hotels.styx.proxy.backends.file.FileChangeMonitor" level="INFO"/>
 
   <root level="INFO">
     <appender-ref ref="CONSOLE"/>

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/OriginsReloadCommandSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/OriginsReloadCommandSpec.scala
@@ -19,8 +19,8 @@ import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.nio.file.{Files, Paths}
 
 import com.google.common.io.Files.createTempDir
-import com.hotels.styx.api.HttpRequest
-import com.hotels.styx.api.messages.HttpResponseStatus.BAD_REQUEST
+import com.hotels.styx.api.HttpRequest.Builder.post
+import com.hotels.styx.api.messages.HttpResponseStatus.INTERNAL_SERVER_ERROR
 import com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry
 import com.hotels.styx.support.ResourcePaths.fixturesHome
 import com.hotels.styx.support.configuration._
@@ -44,7 +44,7 @@ class OriginsReloadCommandSpec extends FunSpec
   val styxOriginsFile = Paths.get(tempDir.toString, "origins.yml")
   var styxServer: StyxServer = _
 
-  it("Responds with BAD_REQUEST when the origins cannot be read") {
+  it("Responds with INTERNAL_SERVER_ERROR when the origins cannot be read") {
     val fileBasedBackendsRegistry = FileBackedBackendServicesRegistry.create(styxOriginsFile.toString)
     styxServer = StyxConfig().startServer(fileBasedBackendsRegistry)
 
@@ -52,8 +52,8 @@ class OriginsReloadCommandSpec extends FunSpec
 
     Files.copy(originsNok, styxOriginsFile, REPLACE_EXISTING)
 
-    val resp = decodedRequest(HttpRequest.Builder.post(styxServer.adminURL("/admin/tasks/origins/reload")).build())
-    resp.status() should be(BAD_REQUEST)
+    val resp = decodedRequest(post(styxServer.adminURL("/admin/tasks/origins/reload")).build())
+    resp.status() should be(INTERNAL_SERVER_ERROR)
 
     BackendService.fromJava(fileBasedBackendsRegistry.get().asScala.head) should be(
       BackendService(


### PR DESCRIPTION
Improve logging messages when the origins file is reloaded:
- md5 code of the loaded file
- modification time of the loaded file
- The cause of the reload: Initial load, admin interface request, or automatically detected change.
