### PR TITLE
Add a minimalistic origins file so the server can be run using the default.yml included in the distribution

### DIFF
--- a/distribution/conf/default.yml
+++ b/distribution/conf/default.yml
@@ -57,7 +57,7 @@ services:
   factories:
     backendServiceRegistry:
       class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry$Factory"
-      config: {originsFile: "${originsFile:}"}
+      config: {originsFile: "${STYX_HOME:classpath:}/conf/origins.yml"}
 #    graphite:
 #      enabled: false
 #      class: "com.hotels.styx.metrics.reporting.graphite.GraphiteReporterServiceFactory"

--- a/distribution/conf/origins.yml
+++ b/distribution/conf/origins.yml
@@ -1,0 +1,13 @@
+# See origins/origins-default.yaml for explanation of config format
+---
+- id: "app"
+  path: "/"
+  connectionPool:
+    maxConnectionsPerHost: 45
+    maxPendingConnectionsPerHost: 15
+    socketTimeoutMillis: 120000
+    connectTimeoutMillis: 1000
+    pendingConnectionTimeoutMillis: 8000
+  responseTimeoutMillis: 60000
+  origins:
+  - { id: "app1", host: "localhost:9090" }


### PR DESCRIPTION
Add a minimalistic origins file so Styx can be run using the default.yml config, as when following the quickstart guide for the first time.