### PR TITLE
Issue with the changes to include a default origins file

### DIFF
--- a/distribution/conf/default.yml
+++ b/distribution/conf/default.yml
@@ -57,7 +57,7 @@ services:
   factories:
     backendServiceRegistry:
       class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry$Factory"
-      config: {originsFile: "${STYX_HOME:classpath:}/conf/origins.yml"}
+      config: {originsFile: "${originsFile:classpath:conf/origins.yml}"}
 #    graphite:
 #      enabled: false
 #      class: "com.hotels.styx.metrics.reporting.graphite.GraphiteReporterServiceFactory"


### PR DESCRIPTION
To bundle styx with the required plugins and origins,  styx users typically define a new styx config file that imports (with the `include` directive) the standard "default.yml" but redefining the property "originsFile"  to specify a new origins file - as well as including the plugin configuration.  

When addressing #110 , we removed the  ${originsFile}  variable in the " backendServiceRegistry: originsFile" configuration block, and thus we removed the possibility of re-defining the originsFile from an external file. 

This PR should fix the issue.