### PR TITLE
Plugin documentation and example pom.xml for plugins reviewed.

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -9,25 +9,25 @@ Each plugin is contained within its own JAR file, located according to the confi
 ## Configuration example
 
     plugins:
-      active: rewrite
+      active: addheaders
       all:
-        - name: rewrite
+        addheaders:
           factory:
-            class: "com.hotels.styx.RewritePluginFactory"
+            class: "com.hotels.styx.ExamplePluginFactory"
             classPath: "<path-to-plugin>/plugin-examples-1.0-SNAPSHOT.jar"
           config:
-            oldUri: "/olduri"
-            newUri: "/newuri"
+            requestHeaderValue: "requestheader"
+            responseHeaderValue: "responseheader"
       
 ### Configuration example explanation
 
 * **active** contains a comma-separated list of plugin names. It is a convenience feature used to switch a plugin on and off without needing to remove its entire set of configuration.
 * **all** contains a list of configuration for all the plugins deployed with the Styx instance. Inside each list item:
-    * **name** is the name of the plugin
+    * **addheaders** is the name of the plugin
     * **factory** configures a factory object that can produce the plugin:
         * **class** contains the name of the factory class, which must extend `com.hotels.styx.api.plugins.spi.PluginFactory`
         * **classPath** provides the location of the JAR file
-    * **config** contains custom configuration for the particular plugin. Its value can be of any type. See below for how to write a custom config java class.
+    * **config** contains custom configuration for the particular plugin. Its value can be of any type. See below how to write a custom config java class.
 
 When Styx starts, it sets up the HTTP interceptor chain as follows:
 
@@ -72,9 +72,9 @@ For details of styx configuration file please refer to [User Guide](user-guide.m
 ## Developing a plugin
 A plugin project can be started by using one of examples in `examples` submodule. All plugins share the same skeleton of a project, containing a:
 
-* main/java/testgrp/RewritePlugin.java - The plugin's main class which extends the Plugin interface, and most notably implements the `intercept(HttpRequest, Chain)` method.
-* main/java/testgrp/RewritePluginConfig.java - A class that represents plugin configuration, as it appears in styx_conf.yml.
-* main/java/testgrp/RewritePluginFactory.java - A class that implements PluginFactory interface, responsible for instantiating the plugin.
+* main/java/com/hotels/styx/ExamplePlugin.java - The plugin's main class which extends the Plugin interface, and most notably implements the `intercept(HttpRequest, Chain)` method.
+* main/java/com/hotels/styx/ExamplePluginConfig.java - A class that represents plugin configuration, as it appears in styx_conf.yml.
+* main/java/com/hotels/styx/ExamplePluginFactory.java - A class that implements PluginFactory interface, responsible for instantiating the plugin.
 
 Some additional examples can be found in `system-tests/example-styx-plugin` directory in a project repository. 
 There are examples of plugins providing simple examples of how to:
@@ -83,8 +83,8 @@ There are examples of plugins providing simple examples of how to:
 
 ### Plugin class
 A Styx plugin must implement a Plugin interface, which extends from HttpInterceptor interface. Thus every Styx plugin
-is an HttpInterceptor. As name suggests, HttpInterceptor have ability to intercept and transform, or perform some other
-action, as HTTP traffic being proxied through. The interceptors are organised linearly in a specific order to form a 
+is an HttpInterceptor. As the name suggests, HttpInterceptor(s) can intercept and transform, or perform some other
+action,  HTTP traffic as it is being proxied through. The interceptors are organised linearly in a specific order to form a 
 pipeline. Styx injects the HTTP request to the head of the pipeline. Each interceptor then processes the request in 
 turn until the request reaches to the tail of the pipeline. After that the request is proxied out to the destination 
 origins. Once the response arrives, Styx injects the HTTP response, conversely, to the tail of the pipeline. The response 
@@ -132,8 +132,6 @@ acceptable to perform blocking operations in `create()` until plugin is ready to
 files or querying remote servers, such as Redis. However use this capability judiciously. Plugins are loaded serially,
 and initialisation time for the full plugin chain will add up. Future versions of Styx may offer proper lifecycle management.
  
-### Tests
-Blank plugin example provides blank integration test that will start up an instance of StyxServer running your plugin.
 
 ### Running a plugin
 To build a single jar with dependencies, please execute maven command `mvn -Pstyx clean package`. 

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -36,38 +36,7 @@ When Styx starts, it sets up the HTTP interceptor chain as follows:
 3. It loads the plugin factory class, specified by factory.class attribute. 
 4. It instantiates the plugin by calling the plugin factory create method, passing in the Styx Environment object.
 
-### Custom config
 
-The custom config can be any type. It could be a simple type such as `java.lang.String` or a custom class developed as part of the plugin. It could also be a list or map of simple of custom classes.
-
-Here is an example of how a custom config class can be written in java. Note the use of `com.fasterxml.jackson.annotation.JsonProperty` to tell the YAML parser how to construct your class.
-The properties of your custom classes can be instances of custom classes themselves. 
-
-    import com.fasterxml.jackson.annotation.JsonProperty;
-    
-        public class RewritePluginConfig {
-        private final String oldUri;
-        private final String newUri;
-
-        public RewritePluginConfig(
-                @JsonProperty("oldUri") String oldUri,
-                @JsonProperty("newUri") String newUri) {
-            this.oldUri = oldUri;
-            this.newUri = newUri;
-        }
-
-        public String oldUri() {
-            return oldUri;
-        }
-
-        public String newUri() {
-            return newUri;
-        }
-    }    
-
-Note that the custom class does not have to be named in the YAML at all. It is simply accessed via the method `com.hotels.styx.api.plugins.spi.PluginFactory.Environment.pluginConfig`
-As long as the class passed to that method has properties matching the YAML, it can be loaded.
-For details of styx configuration file please refer to [User Guide](user-guide.md) section. 
 
 ## Developing a plugin
 A plugin project can be started by using one of examples in `examples` submodule. All plugins share the same skeleton of a project, containing a:
@@ -137,6 +106,39 @@ and initialisation time for the full plugin chain will add up. Future versions o
 To build a single jar with dependencies, please execute maven command `mvn -Pstyx clean package`. 
 This single jar can be referenced in a styx configuration file. All the details regarding running styx server with 
 additional plugins locally can be found in [User Guide](user-guide.md) section. 
+
+### Custom config
+
+The custom config can be any type. It could be a simple type such as `java.lang.String` or a custom class developed as part of the plugin. It could also be a list or map of simple of custom classes.
+
+Here is an example of how a custom config class can be written in java. Note the use of `com.fasterxml.jackson.annotation.JsonProperty` to tell the YAML parser how to construct your class.
+The properties of your custom classes can be instances of custom classes themselves.
+
+    import com.fasterxml.jackson.annotation.JsonProperty;
+
+        public class RewritePluginConfig {
+        private final String oldUri;
+        private final String newUri;
+
+        public RewritePluginConfig(
+                @JsonProperty("oldUri") String oldUri,
+                @JsonProperty("newUri") String newUri) {
+            this.oldUri = oldUri;
+            this.newUri = newUri;
+        }
+
+        public String oldUri() {
+            return oldUri;
+        }
+
+        public String newUri() {
+            return newUri;
+        }
+    }
+
+Note that the custom class does not have to be named in the YAML at all. It is simply accessed via the method `com.hotels.styx.api.plugins.spi.PluginFactory.Environment.pluginConfig`
+As long as the class passed to that method has properties matching the YAML, it can be loaded.
+For details of styx configuration file please refer to [User Guide](user-guide.md) section.
 
 ## Development best practices
 To ensure that plugins are correct, perform well and are maintainable, best practices must be followed. 

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -1,8 +1,8 @@
 # Plugins
 
 Styx has a plugin-based architecture that allows each Styx instance to be deployed with a suite of independently-developed plugins configured as desired by the deployment process.
-Plugins, implemented in any JVM language, can be used to transform HTTP requests and responses as they are being proxied through. This makes it easy to extend Styx with custom business 
-logic with familiar Java based technologies. In this document we describe how to implement such business logic in Styx plugins.
+Plugins can be used to transform HTTP requests and responses as they are being proxied through. This makes it easy to extend Styx with custom business
+logic with familiar Java-based technologies. In this document we describe how to implement such business logic in Styx plugins.
 
 Each plugin is contained within its own JAR file, located according to the configuration specified in the Styx config files.
 

--- a/plugin-examples/pom.xml
+++ b/plugin-examples/pom.xml
@@ -8,36 +8,25 @@
   <groupId>com.hotels.styx</groupId>
   <artifactId>plugin-examples</artifactId>
   <name>Styx proxy plugin examples</name>
-  <version>0.0.1-SNAPSHOt</version>
+  <version>0.0.1-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.source>1.8</java.source>
-    <java.target>1.8</java.target>
-    <java.testSource>1.8</java.testSource>
-    <java.testTarget>1.8</java.testTarget>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
 
     <!-- Styx Version -->
-    <styx.version>0.7.491</styx.version>
-
-    <!-- General Versions -->
-    <guava.version>16.0.1</guava.version>
-    <metrics.version>3.1.0</metrics.version>
-
-    <!-- Testing Versions -->
-    <hamcrest.all.version>1.3</hamcrest.all.version>
+    <styx.version>0.7-SNAPSHOT</styx.version>
+    <rxjava.version>1.1.6</rxjava.version>
+    <!--Testing-->
     <testng.version>6.8</testng.version>
 
     <!-- apache plugin versions and configurations, please sort alphabetically -->
     <maven-compiler-plugin.version>3.0</maven-compiler-plugin.version>
-    <maven-failsafe-plugin.version>2.13</maven-failsafe-plugin.version>
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
     <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
     <maven-surefire-plugin.version>2.16</maven-surefire-plugin.version>
-
-    <!-- non apache plugin versions and configurations, please sort alphabetically -->
-    <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
   </properties>
 
 
@@ -45,19 +34,15 @@
     <dependency>
       <groupId>com.hotels.styx</groupId>
       <artifactId>styx-api</artifactId>
-      <version>${project.version}</version>
+      <version>${styx.version}</version>
+      <!-- The dependency is explicitlu needed only during compile time, styx is already available in the runtime-->
+      <scope>provided</scope>
     </dependency>
-
-    <!-- RxJava -->
     <dependency>
       <groupId>io.reactivex</groupId>
       <artifactId>rxjava</artifactId>
       <version>${rxjava.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -78,74 +63,19 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>${build-helper-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>add-it-source</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>src/it/java</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>${maven-resources-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>add-it-resources</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/it-classes</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>src/it/resources</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
-      <!-- In this case the maven-compiler-plugin must be located after the build-helper-maven-plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <source>${java.source}</source>
-          <target>${java.target}</target>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
         </configuration>
-
-        <executions>
-          <execution>
-            <id>compile-integration-test</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <configuration>
-              <testIncludes>
-                <testInclude>**/*IT.java</testInclude>
-              </testIncludes>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -153,7 +83,6 @@
         <artifactId>maven-jar-plugin</artifactId>
         <version>${maven-jar-plugin.version}</version>
       </plugin>
-
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -209,33 +138,13 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${maven-failsafe-plugin.version}</version>
-            <configuration>
-              <testSourceDirectory>src/it/java</testSourceDirectory>
-              <testClassesDirectory>${project.build.directory}/it-classes</testClassesDirectory>
-            </configuration>
-            <executions>
-              <execution>
-                <id>integration-test</id>
-                <goals>
-                  <goal>integration-test</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>verify</id>
-                <goals>
-                  <goal>verify</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
           </plugin>
 
+          <!-- We use the Shade plugin to bundle all the plugin dependencies together and ensure classloader-level
+          isolation for different plugins.
+          This sample plugin does not have any external dependencies.
+          -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
@@ -251,6 +160,8 @@
                   <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                   <outputDirectory>${pluginsDir}</outputDirectory>
                   <!--
+                  Since we are creating a single shaded JAR, signed JARs will not be valid anymore. To avoid this issue,
+                  we just remove the signature files in the JARs.
                   For filters, see:
                   http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
                   -->

--- a/plugin-examples/src/main/resources/styx_conf/styx_conf.yml
+++ b/plugin-examples/src/main/resources/styx_conf/styx_conf.yml
@@ -14,5 +14,5 @@ plugins:
         class: "${groupId}.ExamplePluginFactory"
         classPath: "/plugins/${artifactId}-${version}.jar"
       config:
-        requestHeaderValue: "/olduri"
-        responseHeaderValue: "/newuri"
+        myRequestHeader: "requestheader"
+        myResponseHeader: "responseheader"


### PR DESCRIPTION
 * Plugin documentation updated to use the latest version of the schema for the configuration of plugins.
* Simplified the pom.xml in the plugin example.
* Changed the scope of the styx-api dependency in the plugin pom,  so styx JARs (and third party dependencies such as guava or rxjava) are not bundled with the plugin.



