### PR TITLE
Change UUID Generator.

### DIFF
--- a/components/api/pom.xml
+++ b/components/api/pom.xml
@@ -57,8 +57,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.eaio.uuid</groupId>
-      <artifactId>uuid</artifactId>
+      <groupId>com.fasterxml.uuid</groupId>
+      <artifactId>java-uuid-generator</artifactId>
     </dependency>
 
     <dependency>

--- a/components/api/src/main/java/com/hotels/styx/api/UniqueIdSuppliers.java
+++ b/components/api/src/main/java/com/hotels/styx/api/UniqueIdSuppliers.java
@@ -15,16 +15,20 @@
  */
 package com.hotels.styx.api;
 
-import com.eaio.uuid.UUID;
+import com.fasterxml.uuid.EthernetAddress;
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.NoArgGenerator;
 
 /**
  * Useful unique id suppliers.
  */
 public final class UniqueIdSuppliers {
+    private static final NoArgGenerator TIME_BASED_GENERATOR = Generators.timeBasedGenerator(EthernetAddress.fromInterface());
+
     /**
      * A unique ID supplier which uses a UUID Version One implementation.
      */
-    public static final UniqueIdSupplier UUID_VERSION_ONE_SUPPLIER = () -> new UUID().toString();
+    public static final UniqueIdSupplier UUID_VERSION_ONE_SUPPLIER = () -> TIME_BASED_GENERATOR.generate().toString();
 
     /**
      * Returns a supplier whose {@code get()} method returns the {@code uniqueId} passed in.

--- a/components/api/src/main/java/com/hotels/styx/api/client/retrypolicy/spi/RetryPolicyFactory.java
+++ b/components/api/src/main/java/com/hotels/styx/api/client/retrypolicy/spi/RetryPolicyFactory.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.api.client.retrypolicy.spi;
 
 import com.hotels.styx.api.Environment;
-import com.hotels.styx.api.configuration.ServiceFactory;
 import com.hotels.styx.api.configuration.Configuration;
 
 /**

--- a/components/api/src/main/java/com/hotels/styx/api/service/TlsSettings.java
+++ b/components/api/src/main/java/com/hotels/styx/api/service/TlsSettings.java
@@ -159,12 +159,12 @@ public class TlsSettings {
         private List<String> cipherSuites = Collections.emptyList();
 
         /**
-         * @deprecated
          * Skips origin authentication.
          *
          * When true, styx will not attempt to authenticate backend servers.
          * It will accept any certificate presented by the origins.
          *
+         * @deprecated
          * @param trustAllCerts
          * @return
          */

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/stubs/StubConnectionFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/stubs/StubConnectionFactory.java
@@ -15,15 +15,12 @@
  */
 package com.hotels.styx.client.connectionpool.stubs;
 
-import com.eaio.uuid.UUID;
 import com.hotels.styx.api.Announcer;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.Origin;
 import rx.Observable;
-
-import java.util.Objects;
 
 import static com.google.common.base.Objects.toStringHelper;
 
@@ -46,7 +43,6 @@ public class StubConnectionFactory implements Connection.Factory {
         private final Origin origin;
         private boolean connected = true;
         private final Announcer<Listener> listeners = Announcer.to(Connection.Listener.class);
-        private final UUID uuid = new UUID();
 
         public StubConnection(Origin origin) {
             this.origin = origin;
@@ -87,29 +83,10 @@ public class StubConnectionFactory implements Connection.Factory {
         }
 
         @Override
-        public int hashCode() {
-            return Objects.hash(uuid, origin);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-            StubConnection other = (StubConnection) obj;
-            return Objects.equals(this.origin, other.origin)
-                    && Objects.equals(this.uuid, other.uuid);
-        }
-
-        @Override
         public String toString() {
             return toStringHelper(this)
                     .add("origin", origin)
                     .add("connected", connected)
-                    .add("uuid", uuid)
                     .toString();
         }
     }

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnection.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnection.java
@@ -15,9 +15,7 @@
  */
 package com.hotels.styx.client.netty.connectionpool;
 
-import com.eaio.uuid.UUID;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
 import com.google.common.net.HostAndPort;
 import com.hotels.styx.api.Announcer;
 import com.hotels.styx.api.HttpRequest;
@@ -25,6 +23,7 @@ import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.client.HttpRequestOperationFactory;
+
 import io.netty.channel.Channel;
 import io.netty.util.AttributeKey;
 import rx.Observable;
@@ -41,12 +40,12 @@ public class NettyConnection implements Connection, TimeToFirstByteListener {
     private static final AttributeKey<Object> CLOSED_BY_STYX = AttributeKey.newInstance("CLOSED_BY_STYX");
 
     private final Origin origin;
-    private final Object id;
     private final Channel channel;
     private final HttpRequestOperationFactory requestOperationFactory;
 
     private volatile long timeToFirstByteMs;
     private final Announcer<Listener> listeners = Announcer.to(Listener.class);
+
 
     /**
      * Constructs an instance with an arbitrary UUID.
@@ -57,7 +56,6 @@ public class NettyConnection implements Connection, TimeToFirstByteListener {
      */
     @VisibleForTesting
     public NettyConnection(Origin origin, Channel channel, HttpRequestOperationFactory requestOperationFactory) {
-        this.id = new UUID();
         this.origin = checkNotNull(origin);
         this.channel = checkNotNull(channel);
         this.requestOperationFactory = requestOperationFactory;
@@ -116,23 +114,6 @@ public class NettyConnection implements Connection, TimeToFirstByteListener {
     @Override
     public void notifyTimeToFirstByte(long timeToFirstByte, TimeUnit timeUnit) {
         this.timeToFirstByteMs = timeUnit.toMillis(timeToFirstByte);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(id);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        NettyConnection other = (NettyConnection) obj;
-        return Objects.equal(this.id, other.id);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -238,9 +238,9 @@
       </dependency>
 
       <dependency>
-        <groupId>com.eaio.uuid</groupId>
-        <artifactId>uuid</artifactId>
-        <version>3.2</version>
+        <groupId>com.fasterxml.uuid</groupId>
+        <artifactId>java-uuid-generator</artifactId>
+        <version>3.1.5</version>
       </dependency>
 
       <dependency>

--- a/support/test-api/src/main/java/com/hotels/styx/testapi/BackendService.java
+++ b/support/test-api/src/main/java/com/hotels/styx/testapi/BackendService.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.testapi;
 
-import com.eaio.uuid.UUID;
 import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.api.service.TlsSettings;
 
@@ -27,7 +26,9 @@ import java.util.concurrent.TimeUnit;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.hotels.styx.api.client.Origin.newOriginBuilder;
 import static com.hotels.styx.api.service.BackendService.newBackendServiceBuilder;
+
 import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toSet;
 
 /**
@@ -131,6 +132,6 @@ public class BackendService {
     }
 
     private static String newId() {
-        return new UUID().toString();
+        return randomUUID().toString();
     }
 }

--- a/support/test-api/src/main/java/com/hotels/styx/testapi/Origins.java
+++ b/support/test-api/src/main/java/com/hotels/styx/testapi/Origins.java
@@ -12,11 +12,13 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
- */
+*/
+
 package com.hotels.styx.testapi;
 
-import com.eaio.uuid.UUID;
 import com.hotels.styx.api.client.Origin;
+
+import static java.util.UUID.randomUUID;
 
 import static com.hotels.styx.api.client.Origin.newOriginBuilder;
 
@@ -46,8 +48,8 @@ public final class Origins {
      */
     public static Origin origin(String host, int port) {
         return newOriginBuilder(host, port)
-                .applicationId(new UUID().toString())
-                .id(new UUID().toString())
+                .applicationId(randomUUID().toString())
+                .id(randomUUID().toString())
                 .build();
     }
 }


### PR DESCRIPTION
The uuid generator used by Styx was dependant on Corba. This becomes a problem going forward with java9.