### PR TITLE
Startup script does not fail if the order of the arguments is incorrect #125

### DIFF
--- a/distribution/bin/startup
+++ b/distribution/bin/startup
@@ -59,7 +59,7 @@ do
       STYX_ENV_FILE=$2
       shift
       ;;
-    -*)
+    *)
       echo "Unknown option: $1 ($@)"
       echo
       usage


### PR DESCRIPTION
Fixes #125 
Startup script fixed so it correctly returns an error when an argument is unknown.