### PR TITLE
Fix broken startup

### DIFF
--- a/distribution/conf/env-development/styx-config.yml
+++ b/distribution/conf/env-development/styx-config.yml
@@ -11,9 +11,4 @@ proxy:
       cipherSuites:
         - TLS_RSA_WITH_AES_128_GCM_SHA256
 
-services:
-  factories:
-    graphite:
-      enabled: false
-
 originsFile: ${STYX_HOME:classpath:}/conf/env-development/origins.yml

--- a/distribution/conf/env-perf-local/styx-config.yml
+++ b/distribution/conf/env-perf-local/styx-config.yml
@@ -11,9 +11,4 @@ proxy:
       cipherSuites:
         - TLS_RSA_WITH_AES_128_GCM_SHA256
 
-services:
-  factories:
-    graphite:
-      enabled: false
-
 originsFile: ${STYX_HOME:classpath:}/conf/env-perf-local/origins.yml


### PR DESCRIPTION
Due to changes in how the services are started up, we can no longer have incomplete service config.