### PR TITLE
Call System.exit() when StyxServer.createServer() fails

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -68,10 +68,10 @@ public final class StyxServer extends AbstractService {
     }
 
     public static void main(String[] args) {
-        StyxServer styxServer = createStyxServer(args);
-        getRuntime().addShutdownHook(new Thread(() -> styxServer.stopAsync().awaitTerminated()));
-
         try {
+            StyxServer styxServer = createStyxServer(args);
+            getRuntime().addShutdownHook(new Thread(() -> styxServer.stopAsync().awaitTerminated()));
+
             styxServer.startAsync().awaitRunning();
         } catch (Throwable cause) {
             LOG.error("Error in Styx server startup.", cause);

--- a/components/proxy/src/test/java/com/hotels/styx/StyxServerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/StyxServerTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import rx.Observable;
 
+import java.lang.reflect.Field;
 import java.util.List;
 
 import static ch.qos.logback.classic.Level.ERROR;
@@ -151,6 +152,34 @@ public class StyxServerTest {
         } finally {
             stopIfRunning(styxServer);
         }
+    }
+
+    private Runtime captureSystemExit(Runnable block) {
+        try {
+            Runtime originalRuntime = Runtime.getRuntime();
+            Field runtimeField = Runtime.class.getDeclaredField("currentRuntime");
+            Runtime mockRuntime = mock(Runtime.class);
+
+            try {
+                runtimeField.setAccessible(true);
+                runtimeField.set(Runtime.class, mockRuntime);
+                block.run();
+            } finally {
+                runtimeField.set(Runtime.class, originalRuntime);
+                runtimeField.setAccessible(false);
+            }
+
+            return mockRuntime;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void systemExitIsCalledWhenCreateStyxServerFails() {
+        Runtime runtime = captureSystemExit(() -> StyxServer.main(new String[0]));
+        verify(runtime).exit(1);
+
     }
 
     private static StyxServer styxServerWithPlugins(NamedPlugin... plugins) {

--- a/components/proxy/src/test/java/com/hotels/styx/StyxServerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/StyxServerTest.java
@@ -159,7 +159,6 @@ public class StyxServerTest {
             Runtime originalRuntime = Runtime.getRuntime();
             Field runtimeField = Runtime.class.getDeclaredField("currentRuntime");
             Runtime mockRuntime = mock(Runtime.class);
-
             try {
                 runtimeField.setAccessible(true);
                 runtimeField.set(Runtime.class, mockRuntime);
@@ -179,7 +178,6 @@ public class StyxServerTest {
     public void systemExitIsCalledWhenCreateStyxServerFails() {
         Runtime runtime = captureSystemExit(() -> StyxServer.main(new String[0]));
         verify(runtime).exit(1);
-
     }
 
     private static StyxServer styxServerWithPlugins(NamedPlugin... plugins) {


### PR DESCRIPTION
When StyxServer.createServer() failed, we were not invoking System.exit(). This meant the JVM would not terminate if non daemon threads were started during this call to `StyxServer.createServer()`, which is happening during the initialization of some plugins.
