### PR TITLE
Improve warning message regarding idle persistent connections.

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyConnectorFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyConnectorFactory.java
@@ -214,7 +214,7 @@ class ProxyConnectorFactory implements ServerConnectorFactory {
                     IdleStateEvent e = (IdleStateEvent) evt;
                     if (e.state() == ALL_IDLE && !httpTransactionOngoing) {
                         if (ctx.channel().isActive()) {
-                            LOGGER.warn("Closing suspected leaked connection={}", ctx.channel().remoteAddress());
+                            LOGGER.warn("Closing an idle persistent connection={}", ctx.channel().remoteAddress());
                             ctx.close();
                             idleConnectionClosed.update(1);
                         }

--- a/docs/user-guide/configure-overview.md
+++ b/docs/user-guide/configure-overview.md
@@ -43,6 +43,10 @@ using environment variables with the same name as the property.
       maxChunkSize: 8192
       maxContentLength: 65536
 
+
+      # A timeout for idle persistent connections, in milliseconds.
+      keepAliveTimeoutMillis: 12000
+
       # Time in milliseconds Styx Proxy Service waits for an incoming request from client
       # before replying with 408 Request Timeout.
       requestTimeoutMillis: 12000


### PR DESCRIPTION
The existing warning message when closing idle persistent connections is misleading. This PR provides more informative warning message.

Also, this PR adds the `keepAliveTimeoutMillis` configuration parameter in end-user documentation.
