### PR TITLE
Implements #143: Add map types to schema

### DIFF
--- a/components/common/src/main/java/com/hotels/styx/config/schema/Schema.java
+++ b/components/common/src/main/java/com/hotels/styx/config/schema/Schema.java
@@ -211,7 +211,7 @@ public class Schema {
         private final FieldValue elementType;
 
         MapField(FieldValue elementType) {
-            this.elementType = elementType;
+            this.elementType = requireNonNull(elementType);
         }
 
         public FieldValue elementType() {

--- a/components/common/src/main/java/com/hotels/styx/config/schema/Schema.java
+++ b/components/common/src/main/java/com/hotels/styx/config/schema/Schema.java
@@ -106,7 +106,8 @@ public class Schema {
         INTEGER,
         BOOLEAN,
         OBJECT,
-        LIST
+        LIST,
+        MAP;
     }
 
     /**
@@ -161,6 +162,10 @@ public class Schema {
                 return FieldType.LIST;
             }
 
+            if (this instanceof MapField) {
+                return FieldType.MAP;
+            }
+
             throw new IllegalStateException("Unknown field type: " + this.getClass() + " " + this);
         }
     }
@@ -197,6 +202,21 @@ public class Schema {
             return elementType;
         }
 
+    }
+
+    /**
+     * Map schema field type.
+     */
+    public static class MapField extends FieldValue {
+        private final FieldValue elementType;
+
+        MapField(FieldValue elementType) {
+            this.elementType = elementType;
+        }
+
+        public FieldValue elementType() {
+            return elementType;
+        }
     }
 
     /**

--- a/components/common/src/main/java/com/hotels/styx/config/schema/SchemaDsl.java
+++ b/components/common/src/main/java/com/hotels/styx/config/schema/SchemaDsl.java
@@ -205,6 +205,16 @@ public final class SchemaDsl {
     }
 
     /**
+     * Map schema field type.
+     *
+     * A map declares a JSON object type whose field names are treated as
+     * arbitrary (string) keys associated with some elementary or object type.
+     */
+    public static Schema.FieldValue map(Schema.FieldValue elementType) {
+        return new Schema.MapField(elementType);
+    }
+
+    /**
      * A directive to mark the object layout as `opaque`.
      *
      * @return an OpaqueSchema directive

--- a/components/proxy/src/main/java/com/hotels/styx/ServerConfigSchema.java
+++ b/components/proxy/src/main/java/com/hotels/styx/ServerConfigSchema.java
@@ -26,11 +26,12 @@ import static com.hotels.styx.config.schema.SchemaDsl.bool;
 import static com.hotels.styx.config.schema.SchemaDsl.field;
 import static com.hotels.styx.config.schema.SchemaDsl.integer;
 import static com.hotels.styx.config.schema.SchemaDsl.list;
+import static com.hotels.styx.config.schema.SchemaDsl.map;
 import static com.hotels.styx.config.schema.SchemaDsl.object;
-import static com.hotels.styx.config.schema.SchemaDsl.optional;
 import static com.hotels.styx.config.schema.SchemaDsl.opaque;
-import static com.hotels.styx.config.schema.SchemaDsl.string;
+import static com.hotels.styx.config.schema.SchemaDsl.optional;
 import static com.hotels.styx.config.schema.SchemaDsl.schema;
+import static com.hotels.styx.config.schema.SchemaDsl.string;
 import static com.hotels.styx.config.validator.DocumentFormat.newDocument;
 
 final class ServerConfigSchema {
@@ -126,14 +127,19 @@ final class ServerConfigSchema {
             .rootSchema(schema(
                     field("proxy", object(PROXY_CONNECTOR_CONFIG)),
                     field("admin", object(ADMIN_CONNECTOR_CONFIG)),
-                    field("services", object(opaque())),
+                    field("services", object(
+                            field("factories", map(object(opaque())))
+                    )),
                     optional("url", object(URL_ENCODING_CONFIG)),
                     optional("request-logging", object(REQUEST_LOGGING_CONFIG)),
                     optional("styxHeaders", object(STYX_HEADERS_CONFIG)),
                     optional("include", string()),
                     optional("retrypolicy", object(opaque())),
                     optional("loadBalancing", object(opaque())),
-                    optional("plugins", object(opaque())),
+                    optional("plugins", object(
+                            optional("active", string()),
+                            optional("all", map(object(opaque())))
+                    )),
                     optional("jvmRouteName", string()),
                     optional("originRestrictionCookie", string()),
                     optional("responseInfoHeaderFormat", string()),

--- a/components/proxy/src/test/scala/com/hotels/styx/ServerConfigSchemaSpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/ServerConfigSchemaSpec.scala
@@ -174,38 +174,6 @@ class ServerConfigSchemaSpec extends FunSpec with ShouldMatchers {
       )) should be(Optional.empty())
     }
 
-    it("Accepts 'plugins' field - but does not validate") {
-      validateServerConfiguration(yamlConfig(
-        minimalConfig
-          +
-          """
-            |plugins:
-            |  active: plugA, plugB
-            |  all:
-            |    plugA:
-            |      x
-            |    plugB:
-            |      y
-          """.stripMargin
-      )) should be(Optional.empty())
-    }
-
-    it("Accepts 'logFormat' field as a STRING") {
-      validateServerConfiguration(yamlConfig(
-        minimalConfig
-          +
-          """
-            |plugins:
-            |  active: plugA, plugB
-            |  all:
-            |    plugA:
-            |      x
-            |    plugB:
-            |      y
-          """.stripMargin
-      )) should be(Optional.empty())
-    }
-
     it("Accepts 'styxHeaders' field as an OBJECT") {
       validateServerConfiguration(yamlConfig(
         minimalConfig

--- a/components/proxy/src/test/scala/com/hotels/styx/ServerConfigSchemaSpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/ServerConfigSchemaSpec.scala
@@ -99,18 +99,18 @@ class ServerConfigSchemaSpec extends FunSpec with ShouldMatchers {
     it("Accepts 'jvmRouteName' field as a STRING") {
       validateServerConfiguration(yamlConfig(
         minimalConfig
-        +
-        """
-          |jvmRouteName: 'instance-01'
-        """.stripMargin
+          +
+          """
+            |jvmRouteName: 'instance-01'
+          """.stripMargin
       )) should be(Optional.empty())
 
       validateServerConfiguration(yamlConfig(
         minimalConfig
-        +
-        """
-          |jvmRouteName: 101
-        """.stripMargin
+          +
+          """
+            |jvmRouteName: 101
+          """.stripMargin
       )) should be(Optional.of("Unexpected field type. Field 'jvmRouteName' should be STRING, but it is INTEGER"))
     }
 
@@ -350,6 +350,36 @@ class ServerConfigSchemaSpec extends FunSpec with ShouldMatchers {
           |      config: {originsFile: "${originsFile:classpath:conf/origins.yml}"}
         """.stripMargin)) should be(Optional.empty())
     }
+  }
+
+  describe("Plugins configuration") {
+    it("Accepts plugins.active as string") {
+      validateServerConfiguration(yamlConfig(
+        minimalConfig +
+          """
+            |plugins:
+            |  active: xyz
+            |""".stripMargin))
+    }
+
+    it("Accepts an absent plugins.active field") {
+      validateServerConfiguration(yamlConfig(
+        minimalConfig +
+          """
+            |plugins:
+            |  all: xyz
+            |""".stripMargin))
+    }
+
+    it("Accepts an plugins.all as an opaque object") {
+      validateServerConfiguration(yamlConfig(
+        minimalConfig +
+          """
+            |plugins:
+            |  all: xyz
+            |""".stripMargin))
+    }
+
   }
 
   private def minimalConfig =


### PR DESCRIPTION
Implements configuration schema support for `map` types.

Map of integers:

```
        DocumentFormat validator = newDocument()
                .rootSchema(schema(
                        field("parent", map(
                                object(
                                        field("x", integer()),
                                        field("y", integer())
                                )))
                ))
                .build();
```

Map of list of objects:

```
        newDocument()
                .rootSchema(schema(
                        field("myList", list(
                           object(
                               field("a", integer()), 
                               field("b", integer()))))
                ))
                .build()
                .validateObject(root);
```


Also adds `plugins` and `services` to styx server config schema as maps.