### PR TITLE
Fixes #152: GraphiteReporter retries connection to the server too often.

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporter.java
@@ -36,14 +36,12 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A reporter which publishes metric values to a Graphite server.
- * <p>
- * This reporter is <b>not</b> thread safe and is intended for use within a single thread.
  *
  * @see <a href="http://graphite.wikidot.com/">Graphite - Scalable Realtime Graphing</a>
  */
 public class GraphiteReporter extends ScheduledReporter {
     /**
-     * Returns a new {@link Builder} fGor {@link GraphiteReporter}.
+     * Returns a new {@link Builder} for {@link GraphiteReporter}.
      *
      * @param registry the registry to report
      * @return a {@link Builder} instance for a {@link GraphiteReporter}
@@ -179,14 +177,14 @@ public class GraphiteReporter extends ScheduledReporter {
 
     private final LoadingCache<String, MeteredPrefixes> meteredPrefixes = CacheBuilder.newBuilder().build(new CacheLoader<String, MeteredPrefixes>() {
         @Override
-        public MeteredPrefixes load(String name) throws Exception {
+        public MeteredPrefixes load(String name) {
             return new MeteredPrefixes(name);
         }
     });
 
     private final LoadingCache<String, TimerPrefixes> timerPrefixes = CacheBuilder.newBuilder().build(new CacheLoader<String, TimerPrefixes>() {
         @Override
-        public TimerPrefixes load(String name) throws Exception {
+        public TimerPrefixes load(String name) {
             return new TimerPrefixes(name);
         }
     });

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporter.java
@@ -14,6 +14,7 @@ import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.graphite.GraphiteSender;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
@@ -26,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import static com.codahale.metrics.Clock.defaultClock;
 import static com.codahale.metrics.MetricFilter.ALL;
 import static com.codahale.metrics.MetricRegistry.name;
-import static com.google.common.cache.CacheBuilder.newBuilder;
 import static com.hotels.styx.metrics.reporting.graphite.IoRetry.tryTimes;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -161,35 +161,35 @@ public class GraphiteReporter extends ScheduledReporter {
     private final Clock clock;
     private final String prefix;
 
-    private final LoadingCache<String, String> counterPrefixes = newBuilder().build(new CacheLoader<String, String>() {
+    private final LoadingCache<String, String> counterPrefixes = CacheBuilder.newBuilder().build(new CacheLoader<String, String>() {
         @Override
         public String load(String name) {
             return prefix(name, "count");
         }
     });
 
-    private final LoadingCache<String, String> gaugePrefixes = newBuilder().build(new CacheLoader<String, String>() {
+    private final LoadingCache<String, String> gaugePrefixes = CacheBuilder.newBuilder().build(new CacheLoader<String, String>() {
         @Override
         public String load(String name) {
             return prefix(name);
         }
     });
 
-    private final LoadingCache<String, HistogramPrefixes> histogramPrefixes = newBuilder().build(new CacheLoader<String, HistogramPrefixes>() {
+    private final LoadingCache<String, HistogramPrefixes> histogramPrefixes = CacheBuilder.newBuilder().build(new CacheLoader<String, HistogramPrefixes>() {
         @Override
         public HistogramPrefixes load(String name) {
             return new HistogramPrefixes(name);
         }
     });
 
-    private final LoadingCache<String, MeteredPrefixes> meteredPrefixes = newBuilder().build(new CacheLoader<String, MeteredPrefixes>() {
+    private final LoadingCache<String, MeteredPrefixes> meteredPrefixes = CacheBuilder.newBuilder().build(new CacheLoader<String, MeteredPrefixes>() {
         @Override
         public MeteredPrefixes load(String name) {
             return new MeteredPrefixes(name);
         }
     });
 
-    private final LoadingCache<String, TimerPrefixes> timerPrefixes = newBuilder().build(new CacheLoader<String, TimerPrefixes>() {
+    private final LoadingCache<String, TimerPrefixes> timerPrefixes = CacheBuilder.newBuilder().build(new CacheLoader<String, TimerPrefixes>() {
         @Override
         public TimerPrefixes load(String name) {
             return new TimerPrefixes(name);

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/IOAction.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/IOAction.java
@@ -1,0 +1,32 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.metrics.reporting.graphite;
+
+import java.io.IOException;
+
+/**
+ * Interface to represent an Action/Procedure (it has no input parameters and returns nothing) which can throw an IOException.
+ */
+@FunctionalInterface
+public interface IOAction {
+    /**
+     * Executes the defined I/O-related Action.
+     *
+     * @throws IOException if an I/O error occurs.
+     */
+    void run() throws IOException;
+}
+

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/IoRetry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/IoRetry.java
@@ -15,6 +15,7 @@
  */
 package com.hotels.styx.metrics.reporting.graphite;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
@@ -23,17 +24,38 @@ import java.util.function.Consumer;
 
 import static java.lang.String.format;
 
-class IoRetry {
+/**
+ * Generic retry class for tasks that perform I/O.
+ */
+final class IoRetry {
 
     @FunctionalInterface
     public interface IoRunnable {
         void run() throws IOException;
     }
 
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(GraphiteReporter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GraphiteReporter.class);
 
-    public static void tryTimes(int times, IoRunnable task, Consumer<Exception> onError)
-            throws UncheckedIOException {
+    /**
+     * Executes the provided {@code task} retrying up to {@code times} times if an {@code IOException} is thrown.
+     * <p>
+     * This method executes a {@code task} which can throw an {@code IOException}. If the exception is thrown,
+     * the {@code onError} block will be executed and the {@code task} retried up to {@code times} times. If the
+     * limit of retries is reached, the method will return an {@code UncheckedIOException} encapsulating the {@code IOException}.
+     *
+     * @param times        positive integer defining the number of times the {@code task} will be retried.
+     * @param task         block that can throw an {@code IOException}
+     * @param errorHandler block to be executed whan an {@code IOException} occurs.
+     * @throws UncheckedIOException     wrapper around the original {@code IOException} thrown by {@code task}
+     *                                  when the limit of retries is reached.
+     * @throws IllegalArgumentException if {@code times} is less than 1.
+     */
+    public static void tryTimes(int times, IoRunnable task, Consumer<IOException> errorHandler)
+            throws UncheckedIOException, IllegalArgumentException {
+
+        if (times < 1) {
+            throw new IllegalArgumentException("The number of retries should be a positive integer. It was " + times);
+        }
         int retries = 0;
 
         while (true) {
@@ -41,11 +63,7 @@ class IoRetry {
                 task.run();
                 return;
             } catch (IOException e) {
-                try {
-                    onError.accept(e);
-                } catch (Exception onErrorException) {
-                    LOGGER.warn("OnError block for I/O operation failed: " + e.getLocalizedMessage(), e);
-                }
+                onError(errorHandler, e);
                 if (++retries == times) {
                     throw new UncheckedIOException(
                             format("Operation failed after %d retries: %s", times, e.getMessage()),
@@ -53,6 +71,17 @@ class IoRetry {
                 }
             }
         }
+    }
+
+    private static void onError(Consumer<IOException> consumer, IOException failure) {
+        try {
+            consumer.accept(failure);
+        } catch (Exception e) {
+            LOGGER.warn("OnError block for I/O operation failed: " + e.getLocalizedMessage(), e);
+        }
+    }
+
+    private IoRetry() {
     }
 
 }

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/IoRetry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/IoRetry.java
@@ -1,0 +1,58 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.metrics.reporting.graphite;
+
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.Consumer;
+
+import static java.lang.String.format;
+
+class IoRetry {
+
+    @FunctionalInterface
+    public interface IoRunnable {
+        void run() throws IOException;
+    }
+
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(GraphiteReporter.class);
+
+    public static void tryTimes(int times, IoRunnable task, Consumer<Exception> onError)
+            throws UncheckedIOException {
+        int retries = 0;
+
+        while (true) {
+            try {
+                task.run();
+                return;
+            } catch (IOException e) {
+                try {
+                    onError.accept(e);
+                } catch (Exception onErrorException) {
+                    LOGGER.warn("OnError block for I/O operation failed: " + e.getLocalizedMessage(), e);
+                }
+                if (++retries == times) {
+                    throw new UncheckedIOException(
+                            format("Operation failed after %d retries: %s", times, e.getMessage()),
+                            e);
+                }
+            }
+        }
+    }
+
+}

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/IoRetry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/IoRetry.java
@@ -29,11 +29,6 @@ import static java.lang.String.format;
  */
 final class IoRetry {
 
-    @FunctionalInterface
-    public interface IoRunnable {
-        void run() throws IOException;
-    }
-
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphiteReporter.class);
 
     /**
@@ -50,7 +45,7 @@ final class IoRetry {
      *                                  when the limit of retries is reached.
      * @throws IllegalArgumentException if {@code times} is less than 1.
      */
-    public static void tryTimes(int times, IoRunnable task, Consumer<IOException> errorHandler)
+    public static void tryTimes(int times, IOAction task, Consumer<IOException> errorHandler)
             throws UncheckedIOException, IllegalArgumentException {
 
         if (times < 1) {

--- a/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterTest.java
@@ -149,7 +149,7 @@ public class GraphiteReporterTest {
 
 
     @Test
-    public void initConnectRetriesOnFailure() throws Exception {
+    public void initConnectionRetriesOnFailure() throws Exception {
 
         doThrow(new UnknownHostException("UNKNOWN-HOST")).when(graphite).connect();
         try {

--- a/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterTest.java
@@ -66,6 +66,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
 
 public class GraphiteReporterTest {
     private static final long TIMESTAMP = 1000198;
@@ -154,10 +155,10 @@ public class GraphiteReporterTest {
         doThrow(new UnknownHostException("UNKNOWN-HOST")).when(graphite).connect();
         try {
             reporter.initConnection();
+            fail("Should have thrown an exception");
         } catch (UncheckedIOException e) {
+            verify(graphite, times(MAX_RETRIES)).connect();
         }
-
-        verify(graphite, times(MAX_RETRIES)).connect();
     }
 
     @Test

--- a/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/IoRetryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/IoRetryTest.java
@@ -1,3 +1,18 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 package com.hotels.styx.metrics.reporting.graphite;
 
 import org.testng.annotations.BeforeMethod;

--- a/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/IoRetryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/IoRetryTest.java
@@ -21,7 +21,6 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-import static com.hotels.styx.metrics.reporting.graphite.IoRetry.IoRunnable;
 import static com.hotels.styx.metrics.reporting.graphite.IoRetry.tryTimes;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,11 +35,11 @@ import static org.testng.Assert.fail;
 
 public class IoRetryTest {
 
-    private IoRunnable task;
+    private IOAction task;
 
     @BeforeMethod
     public void createMock() {
-        task = mock(IoRunnable.class);
+        task = mock(IOAction.class);
     }
 
     @Test
@@ -76,8 +75,8 @@ public class IoRetryTest {
             tryTimes(3, task, null);
             fail("An exception should have been thrown");
         } catch (NullPointerException e) {
+            verify(task, times(1)).run();
         }
-        verify(task, times(1)).run();
     }
 
 
@@ -88,8 +87,9 @@ public class IoRetryTest {
             tryTimes(0, task, null);
             fail("An exception should have been thrown");
         } catch (IllegalArgumentException e) {
+            verify(task, times(0)).run();
         }
-        verify(task, times(0)).run();
+
     }
 
 }

--- a/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/IoRetryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/IoRetryTest.java
@@ -1,0 +1,69 @@
+package com.hotels.styx.metrics.reporting.graphite;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static com.hotels.styx.metrics.reporting.graphite.IoRetry.IoRunnable;
+import static com.hotels.styx.metrics.reporting.graphite.IoRetry.tryTimes;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.fail;
+
+
+public class IoRetryTest {
+
+    private IoRunnable task;
+
+    @BeforeMethod
+    public void initialize() {
+        task = mock(IoRunnable.class);
+    }
+
+    @Test
+    public void runOnceIfNoErrors() throws IOException {
+        tryTimes(2, task, null);
+        verify(task).run();
+    }
+
+    @Test
+    public void retryUpToMaxTimesForIoException() throws IOException {
+        doThrow(new IOException()).when(task).run();
+        try {
+            tryTimes(3, task, (e) -> assertThat(e, is(instanceOf(IOException.class))));
+            fail("An exception should have been thrown");
+        } catch (UncheckedIOException e) {
+            assertThat(e.getMessage(), containsString("Operation failed after"));
+        }
+        verify(task, times(3)).run();
+    }
+
+
+    @Test
+    public void retryOnlyOnceIfSingleError() throws IOException {
+        doThrow(new IOException()).doNothing().when(task).run();
+        tryTimes(3, task, (e) -> assertThat(e, is(instanceOf(IOException.class))));
+        verify(task, times(2)).run();
+    }
+
+    @Test
+    public void noRetriesForOtherExceptions() throws IOException {
+        doThrow(new IllegalArgumentException()).doNothing().when(task).run();
+        try {
+            tryTimes(3, task, null);
+            fail("An exception should have been thrown");
+        } catch (IllegalArgumentException e) {
+        }
+        verify(task, times(1)).run();
+    }
+
+
+}

--- a/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/IoRetryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/IoRetryTest.java
@@ -23,7 +23,6 @@ import java.io.UncheckedIOException;
 
 import static com.hotels.styx.metrics.reporting.graphite.IoRetry.IoRunnable;
 import static com.hotels.styx.metrics.reporting.graphite.IoRetry.tryTimes;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -39,7 +38,7 @@ public class IoRetryTest {
     private IoRunnable task;
 
     @BeforeMethod
-    public void initialize() {
+    public void createMock() {
         task = mock(IoRunnable.class);
     }
 
@@ -56,7 +55,7 @@ public class IoRetryTest {
             tryTimes(3, task, (e) -> assertThat(e, is(instanceOf(IOException.class))));
             fail("An exception should have been thrown");
         } catch (UncheckedIOException e) {
-            assertThat(e.getMessage(), containsString("Operation failed after"));
+            assertThat(e.getMessage(), is("Operation failed after 3 retries: Could not connect"));
         }
         verify(task, times(3)).run();
     }


### PR DESCRIPTION
 -  Connection will be retried for a fixed number of times (5) before aborting the reporting process. 
 -  Connection will be opened/closed in each scheduled reporting process.
