### PR TITLE
Improve log messages when origin reload fails.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/service/spi/AbstractRegistry.java
+++ b/components/api/src/main/java/com/hotels/styx/api/service/spi/AbstractRegistry.java
@@ -92,7 +92,7 @@ public abstract class AbstractRegistry<T extends Identifiable> implements Regist
     public void set(Iterable<T> newObjects) throws IllegalStateException {
         ImmutableList<T> newSnapshot = ImmutableList.copyOf(newObjects);
 
-        checkState(resourceConstraint.test(newSnapshot));
+        checkState(resourceConstraint.test(newSnapshot), "Resource constraint failure");
 
         Iterable<T> oldSnapshot = snapshot.get();
         snapshot.set(newSnapshot);

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/FileBackedRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/FileBackedRegistry.java
@@ -103,7 +103,11 @@ public class FileBackedRegistry<T extends Identifiable> extends AbstractRegistry
                         return reloaded(format("%s, File reloaded.", logPrefix));
                     }
                 } catch (Exception e) {
-                    LOG.error("Not reloading {} as there was an error reading content", configurationFile.absolutePath(), e);
+                    // Eliminate unhelpful error message when resource constraint exception fails.
+                    // This is a candidate for further refactoring.
+                    if (!"Resource constraint failure".equals(e.getMessage())) {
+                        LOG.error("Not reloading {} as there was an error reading content", configurationFile.absolutePath(), e);
+                    }
                     return failed(format("%s, Reload failure.", logPrefix), e);
                 }
             }

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistry.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Objects.toStringHelper;
 import static com.google.common.base.Throwables.propagate;
@@ -47,6 +46,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 /**
  * File backed {@link BackendService} registry.
@@ -207,8 +207,8 @@ public class FileBackedBackendServicesRegistry extends AbstractStyxService imple
 
             List<List<BackendService>> duplicateApps = pathToApp.values()
                     .stream()
-                    .filter(bss -> bss.size() > 1)
-                    .collect(Collectors.toList());
+                    .filter(backends -> backends.size() > 1)
+                    .collect(toList());
 
             if (duplicateApps.size() > 0) {
                 LOGGER.error(errorMessage(duplicateApps));
@@ -226,7 +226,7 @@ public class FileBackedBackendServicesRegistry extends AbstractStyxService imple
         private static String duplicatePathsErrorForPath(List<BackendService> apps) {
             String path = apps.get(0).path();
             String appsList = apps.stream()
-                    .map(app -> format("'%s'", app.id().toString()))
+                    .map(app -> format("'%s'", app.id()))
                     .collect(joining(", "));
 
             return format("Duplicate path '%s' used for applications: %s", path, appsList);

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistry.java
@@ -33,8 +33,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Objects.toStringHelper;
 import static com.google.common.base.Throwables.propagate;
@@ -43,8 +45,8 @@ import static com.hotels.styx.api.service.spi.Registry.Outcome.FAILED;
 import static com.hotels.styx.client.applications.BackendServices.newBackendServices;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
 
 /**
  * File backed {@link BackendService} registry.
@@ -200,11 +202,34 @@ public class FileBackedBackendServicesRegistry extends AbstractStyxService imple
     static class RejectDuplicatePaths implements Predicate<Collection<BackendService>> {
         @Override
         public boolean test(Collection<BackendService> backendServices) {
-            return backendServices.stream()
-                    .collect(groupingBy(BackendService::path, counting()))
-                    .values()
+            Map<String, List<BackendService>> pathToApp = backendServices.stream()
+                    .collect(groupingBy(BackendService::path));
+
+            List<List<BackendService>> duplicateApps = pathToApp.values()
                     .stream()
-                    .noneMatch(count -> count > 1);
+                    .filter(bss -> bss.size() > 1)
+                    .collect(Collectors.toList());
+
+            if (duplicateApps.size() > 0) {
+                LOGGER.error(errorMessage(duplicateApps));
+            }
+
+            return duplicateApps.size() == 0;
+        }
+
+        private static String errorMessage(List<List<BackendService>> backendServices) {
+            return backendServices.stream()
+                    .map(RejectDuplicatePaths::duplicatePathsErrorForPath)
+                    .collect(joining(", "));
+        }
+
+        private static String duplicatePathsErrorForPath(List<BackendService> apps) {
+            String path = apps.get(0).path();
+            String appsList = apps.stream()
+                    .map(app -> format("'%s'", app.id().toString()))
+                    .collect(joining(", "));
+
+            return format("Duplicate path '%s' used for applications: %s", path, appsList);
         }
     }
 


### PR DESCRIPTION
More specifically, this PR adds a meaningful error message when origin reload fails due to multiple origins sharing the same path prefix.
