### PR TITLE
Cookie names are case sensitive.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -516,7 +516,7 @@ public final class HttpResponse implements HttpMessage {
          */
         public Builder removeCookie(String name) {
             cookies.stream()
-                    .filter(cookie -> cookie.name().equalsIgnoreCase(name))
+                    .filter(cookie -> cookie.name().equals(name))
                     .findFirst()
                     .ifPresent(cookie -> cookies.remove(cookie));
 


### PR DESCRIPTION
This makes response.removeCookie() match request.removeCookie()