### PR TITLE
Add HttpInterceptorContext to styx-test-api.

### DIFF
--- a/support/api-testsupport/src/main/java/com/hotels/styx/server/HttpInterceptorContext.java
+++ b/support/api-testsupport/src/main/java/com/hotels/styx/server/HttpInterceptorContext.java
@@ -1,0 +1,46 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.server;
+
+import com.hotels.styx.api.HttpInterceptor;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ *
+ * TODO: This is duplicated from the `server` package so that plugin tests are able
+ * to pass in a context for the `handle` method.
+ *
+ * ConcurrentHashMap backed implementation of HttpInterceptor.Context.
+ */
+public final class HttpInterceptorContext implements HttpInterceptor.Context {
+    private final Map<String, Object> context = new ConcurrentHashMap<>();
+
+    @Override
+    public void add(String key, Object value) {
+        context.put(key, value);
+    }
+
+    @Override
+    public <T> T get(String key, Class<T> clazz) {
+        return (T) context.get(key);
+    }
+
+    public static HttpInterceptorContext create() {
+        return new HttpInterceptorContext();
+    }
+}


### PR DESCRIPTION
Adds the HttpInterceptorContext to Styx test API, so that the plugins can create instances for testing purposes.
