### PR TITLE
Rename message converters between full & streaming variants.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -320,7 +320,7 @@ public class HttpRequest implements StreamingHttpMessage {
         return new Builder(this);
     }
 
-    public StyxObservable<FullHttpRequest> toFullHttpRequest(int maxContentBytes) {
+    public StyxObservable<FullHttpRequest> toFullRequest(int maxContentBytes) {
         CompositeByteBuf byteBufs = compositeBuffer();
 
         return new StyxCoreObservable<>(

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -142,7 +142,7 @@ public class HttpResponse implements StreamingHttpMessage {
         return status.code() >= 300 && status.code() < 400;
     }
 
-    public StyxObservable<FullHttpResponse> toFullHttpResponse(int maxContentBytes) {
+    public StyxObservable<FullHttpResponse> toFullResponse(int maxContentBytes) {
         CompositeByteBuf byteBufs = compositeBuffer();
 
         Observable<FullHttpResponse> delegate = ((StyxCoreObservable<ByteBuf>) body)

--- a/components/api/src/test/java/com/hotels/styx/api/FullHttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/FullHttpRequestTest.java
@@ -78,7 +78,7 @@ public class FullHttpRequestTest {
                 header("HeaderName", "HeaderValue")));
         assertThat(streaming.cookies(), contains(cookie("CookieName", "CookieValue")));
 
-        String body = streaming.toFullHttpRequest(0x10000)
+        String body = streaming.toFullRequest(0x10000)
                 .asCompletableFuture()
                 .get()
                 .bodyAs(UTF_8);
@@ -258,7 +258,7 @@ public class FullHttpRequestTest {
                 .body(StyxObservable.of(content))
                 .build();
 
-        FullHttpRequest fullRequest = original.toFullHttpRequest(100)
+        FullHttpRequest fullRequest = original.toFullRequest(100)
                 .asCompletableFuture()
                 .get();
 

--- a/components/api/src/test/java/com/hotels/styx/api/FullHttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/FullHttpResponseTest.java
@@ -77,7 +77,7 @@ public class FullHttpResponseTest {
                 header("HeaderName", "HeaderValue")));
         assertThat(streaming.cookies(), contains(cookie("CookieName", "CookieValue")));
 
-        String body = streaming.toFullHttpResponse(0x100000)
+        String body = streaming.toFullResponse(0x100000)
                 .asCompletableFuture()
                 .get()
                 .bodyAs(UTF_8);
@@ -469,7 +469,7 @@ public class FullHttpResponseTest {
                 .body(StyxObservable.of(content))
                 .build();
 
-        original.toFullHttpResponse(100)
+        original.toFullResponse(100)
                 .asCompletableFuture()
                 .get();
 

--- a/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
@@ -17,10 +17,8 @@ package com.hotels.styx.api;
 
 import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import rx.Observable;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
@@ -70,7 +68,7 @@ public class HttpRequestTest {
                 .addCookie("CookieName", "CookieValue")
                 .build();
 
-        FullHttpRequest full = streamingRequest.toFullHttpRequest(0x1000)
+        FullHttpRequest full = streamingRequest.toFullRequest(0x1000)
                 .asCompletableFuture()
                 .get();
 
@@ -85,7 +83,7 @@ public class HttpRequestTest {
 
     @Test(dataProvider = "emptyBodyRequests")
     public void encodesToStreamingHttpRequestWithEmptyBody(HttpRequest streamingRequest) throws Exception {
-        FullHttpRequest full = streamingRequest.toFullHttpRequest(0x1000)
+        FullHttpRequest full = streamingRequest.toFullRequest(0x1000)
                 .asCompletableFuture()
                 .get();
 
@@ -417,7 +415,7 @@ public class HttpRequestTest {
 
         HttpRequest streaming = new HttpRequest.Builder(original).build();
 
-        HttpRequest shouldMatchOriginal = streaming.toFullHttpRequest(0x100)
+        HttpRequest shouldMatchOriginal = streaming.toFullRequest(0x100)
                 .asCompletableFuture()
                 .get()
                 .toStreamingRequest();

--- a/components/api/src/test/java/com/hotels/styx/api/HttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpResponseTest.java
@@ -65,7 +65,7 @@ public class HttpResponseTest {
                 .body(body("foo", "bar"))
                 .build();
 
-        FullHttpResponse full = response.toFullHttpResponse(0x1000)
+        FullHttpResponse full = response.toFullResponse(0x1000)
                 .asCompletableFuture()
                 .get();
 
@@ -79,7 +79,7 @@ public class HttpResponseTest {
 
     @Test(dataProvider = "emptyBodyResponses")
     public void encodesToFullHttpResponseWithEmptyBody(HttpResponse response) throws Exception {
-        FullHttpResponse full = response.toFullHttpResponse(0x1000)
+        FullHttpResponse full = response.toFullResponse(0x1000)
                 .asCompletableFuture()
                 .get();
 

--- a/components/api/src/test/java/com/hotels/styx/api/http/handlers/StaticBodyHttpHandlerTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/http/handlers/StaticBodyHttpHandlerTest.java
@@ -35,7 +35,7 @@ public class StaticBodyHttpHandlerTest {
         StaticBodyHttpHandler handler = new StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, "foo", UTF_8);
 
         HttpResponse response = handler.handle(get("/").build(), MOCK_CONTEXT).asCompletableFuture().get();
-        FullHttpResponse fullResponse = response.toFullHttpResponse(1024)
+        FullHttpResponse fullResponse = response.toFullResponse(1024)
                 .asCompletableFuture()
                 .get();
 

--- a/components/api/src/test/java/com/hotels/styx/api/service/spi/AbstractStyxServiceTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/service/spi/AbstractStyxServiceTest.java
@@ -43,7 +43,7 @@ public class AbstractStyxServiceTest {
 
         FullHttpResponse response =
                 service.adminInterfaceHandlers().get("status").handle(get, MOCK_CONTEXT)
-                        .flatMap(r -> r.toFullHttpResponse(1024))
+                        .flatMap(r -> r.toFullResponse(1024))
                 .asCompletableFuture()
                 .get();
 

--- a/components/client/src/main/java/com/hotels/styx/client/healthcheck/UrlRequestHealthCheck.java
+++ b/components/client/src/main/java/com/hotels/styx/client/healthcheck/UrlRequestHealthCheck.java
@@ -64,7 +64,7 @@ public class UrlRequestHealthCheck implements OriginHealthCheckFunction {
         HttpRequest request = newHealthCheckRequestFor(origin);
 
         client.sendRequest(request)
-                .flatMap(response -> toRxObservable(response.toFullHttpResponse(1024 * 100)))
+                .flatMap(response -> toRxObservable(response.toFullResponse(1024 * 100)))
                 .subscribe(response -> {
                     if (response.status().equals(OK)) {
                         responseCallback.originStateResponse(HEALTHY);

--- a/components/client/src/test/unit/java/com/hotels/styx/client/SimpleNettyHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/SimpleNettyHttpClientTest.java
@@ -70,7 +70,7 @@ public class SimpleNettyHttpClientTest {
         withOrigin(HTTP, port -> {
             FullHttpResponse response =
                     await(fromRxObservable(httpClient().sendRequest(httpRequest(port)))
-                            .flatMap(r -> r.toFullHttpResponse(MAX_LENGTH))
+                            .flatMap(r -> r.toFullResponse(MAX_LENGTH))
                             .asCompletableFuture());
 
             assertThat(response.status(), is(OK));
@@ -81,7 +81,7 @@ public class SimpleNettyHttpClientTest {
     public void sendsHttps() throws IOException {
         withOrigin(HTTPS, port -> {
             FullHttpResponse response = httpsClient().sendRequest(httpsRequest(port))
-                    .flatMap(r -> toRxObservable(r.toFullHttpResponse(MAX_LENGTH)))
+                    .flatMap(r -> toRxObservable(r.toFullResponse(MAX_LENGTH)))
                     .toBlocking()
                     .single();
 
@@ -93,7 +93,7 @@ public class SimpleNettyHttpClientTest {
     public void cannotSendHttpsWhenConfiguredForHttp() throws IOException {
         withOrigin(HTTPS, port -> {
             FullHttpResponse response = httpClient().sendRequest(httpsRequest(port))
-                    .flatMap(r -> toRxObservable(r.toFullHttpResponse(MAX_LENGTH)))
+                    .flatMap(r -> toRxObservable(r.toFullResponse(MAX_LENGTH)))
                     .toBlocking()
                     .single();
 
@@ -105,7 +105,7 @@ public class SimpleNettyHttpClientTest {
     public void cannotSendHttpWhenConfiguredForHttps() throws IOException {
         withOrigin(HTTP, port -> {
             FullHttpResponse response = httpsClient().sendRequest(httpRequest(port))
-                    .flatMap(r -> toRxObservable(r.toFullHttpResponse(MAX_LENGTH)))
+                    .flatMap(r -> toRxObservable(r.toFullResponse(MAX_LENGTH)))
                     .toBlocking()
                     .single();
 
@@ -213,7 +213,7 @@ public class SimpleNettyHttpClientTest {
                 .build();
 
         client.sendRequest(request)
-                .flatMap(r -> toRxObservable(r.toFullHttpResponse(MAX_LENGTH)))
+                .flatMap(r -> toRxObservable(r.toFullResponse(MAX_LENGTH)))
                 .toBlocking()
                 .single();
     }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/PluginToggleHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/PluginToggleHandler.java
@@ -166,7 +166,7 @@ public class PluginToggleHandler implements HttpHandler {
     }
 
     private static StyxObservable<PluginEnabledState> requestedNewState(HttpRequest request) {
-        return request.toFullHttpRequest(MAX_CONTENT_SIZE)
+        return request.toFullRequest(MAX_CONTENT_SIZE)
                 .map(fullRequest -> fullRequest.bodyAs(UTF_8))
                 .map(PluginToggleHandler::parseToBoolean)
                 .map(PluginEnabledState::fromBoolean);

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/StatusHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/StatusHandler.java
@@ -46,7 +46,7 @@ public class StatusHandler implements HttpHandler {
     @Override
     public StyxObservable<HttpResponse> handle(HttpRequest request, HttpInterceptor.Context context) {
         return handler.handle(request, context)
-                .flatMap(response -> response.toFullHttpResponse(0xffffff))
+                .flatMap(response -> response.toFullResponse(0xffffff))
                 .map(response ->
                         response.newBuilder()
                                 .contentType(PLAIN_TEXT_UTF_8)

--- a/support/api-testsupport/src/main/java/com/hotels/styx/support/api/BlockingObservables.java
+++ b/support/api-testsupport/src/main/java/com/hotels/styx/support/api/BlockingObservables.java
@@ -50,13 +50,13 @@ public final class BlockingObservables {
 
     public static FullHttpResponse waitForResponse(StyxObservable<HttpResponse> responseObs) {
         return futureGetAndPropagate(responseObs
-                .flatMap(response -> response.toFullHttpResponse(120*1024))
+                .flatMap(response -> response.toFullResponse(120*1024))
                 .asCompletableFuture());
     }
 
     public static FullHttpResponse waitForResponse(Observable<HttpResponse> responseObs) {
         return responseObs
-                .flatMap(response -> toRxObservable(response.toFullHttpResponse(120*1024)))
+                .flatMap(response -> toRxObservable(response.toFullResponse(120*1024)))
                 .toBlocking()
                 .single();
     }

--- a/support/api-testsupport/src/main/java/com/hotels/styx/support/api/HttpMessageBodies.java
+++ b/support/api-testsupport/src/main/java/com/hotels/styx/support/api/HttpMessageBodies.java
@@ -41,13 +41,13 @@ public final class HttpMessageBodies {
     }
 
     public static String bodyAsString(HttpRequest message) {
-        return await(message.toFullHttpRequest(0x100000)
+        return await(message.toFullRequest(0x100000)
                 .asCompletableFuture())
                 .bodyAs(UTF_8);
     }
 
     public static String bodyAsString(HttpResponse message) {
-        return await(message.toFullHttpResponse(0x100000)
+        return await(message.toFullResponse(0x100000)
                 .asCompletableFuture())
                 .bodyAs(UTF_8);
     }

--- a/support/api-testsupport/src/main/java/com/hotels/styx/support/api/matchers/HttpResponseBodyMatcher.java
+++ b/support/api-testsupport/src/main/java/com/hotels/styx/support/api/matchers/HttpResponseBodyMatcher.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.support.api.matchers;
 
-import com.hotels.styx.api.FullHttpResponse;
 import com.hotels.styx.api.HttpResponse;
 import org.hamcrest.Description;
 import org.hamcrest.Factory;
@@ -48,12 +47,12 @@ public class HttpResponseBodyMatcher<T extends HttpResponse> extends TypeSafeMat
 
     @Override
     public boolean matchesSafely(T actual) {
-        return matcher.matches(await(actual.toFullHttpResponse(0x100000).asCompletableFuture()).bodyAs(UTF_8));
+        return matcher.matches(await(actual.toFullResponse(0x100000).asCompletableFuture()).bodyAs(UTF_8));
     }
 
     @Override
     protected void describeMismatchSafely(T item, Description mismatchDescription) {
-        mismatchDescription.appendText("content was '" + await(item.toFullHttpResponse(0x100000).asCompletableFuture()).bodyAs(UTF_8) + "'");
+        mismatchDescription.appendText("content was '" + await(item.toFullResponse(0x100000).asCompletableFuture()).bodyAs(UTF_8) + "'");
     }
 
     @Override

--- a/system-tests/e2e-suite/src/test/java/com/hotels/styx/plugins/AggregationTesterPlugin.java
+++ b/system-tests/e2e-suite/src/test/java/com/hotels/styx/plugins/AggregationTesterPlugin.java
@@ -31,7 +31,7 @@ public class AggregationTesterPlugin implements Plugin {
     public StyxObservable<HttpResponse> intercept(HttpRequest request, Chain chain) {
         return chain.proceed(request)
                 .flatMap(response ->
-                        response.toFullHttpResponse(maxContentBytes)
+                        response.toFullResponse(maxContentBytes)
                         .map(fullHttpResponse ->
                                 fullHttpResponse.newBuilder()
                                         .addHeader("test_plugin", "yes")

--- a/system-tests/e2e-suite/src/test/java/com/hotels/styx/plugins/ContentCutoffPlugin.java
+++ b/system-tests/e2e-suite/src/test/java/com/hotels/styx/plugins/ContentCutoffPlugin.java
@@ -31,7 +31,7 @@ public class ContentCutoffPlugin implements Plugin {
     public StyxObservable<HttpResponse> intercept(HttpRequest request, Chain chain) {
         return chain.proceed(request)
                 .flatMap(response ->
-                        response.toFullHttpResponse(1024)
+                        response.toFullResponse(1024)
                                 .map(fullHttpResponse -> {
                                     LOGGER.info("Throw away response body={}", fullHttpResponse.bodyAs(UTF_8));
                                     return response;

--- a/system-tests/e2e-suite/src/test/java/com/hotels/styx/plugins/ContentDecodeFailurePlugin.java
+++ b/system-tests/e2e-suite/src/test/java/com/hotels/styx/plugins/ContentDecodeFailurePlugin.java
@@ -36,7 +36,7 @@ public class ContentDecodeFailurePlugin implements Plugin {
     @Override
     public StyxObservable<HttpResponse> intercept(HttpRequest request, Chain chain) {
         return chain.proceed(request)
-                .flatMap(response -> response.toFullHttpResponse(maxContentBytes))
+                .flatMap(response -> response.toFullResponse(maxContentBytes))
                 .map(fullResponse -> fullResponse.newBuilder()
                         .header("ContentDecodeFailurePlugin", "yes")
                         .header("bytes_aggregated", fullResponse.body().length)

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxClientSupplier.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxClientSupplier.scala
@@ -59,7 +59,7 @@ trait StyxClientSupplier {
                      maxSize: Int = 1024 * 1024, timeout: Duration = 30.seconds): FullHttpResponse = {
     doRequest(request, debug = debug)
       .doOnNext(response => if (debug) println("StyxClientSupplier: received response for: " + request.url().path()))
-      .flatMap(response => toRxObservable(response.toFullHttpResponse(maxSize)))
+      .flatMap(response => toRxObservable(response.toFullResponse(maxSize)))
       .timeout(timeout)
       .toBlocking
       .first
@@ -71,7 +71,7 @@ trait StyxClientSupplier {
                                maxSize: Int = 1024 * 1024, timeout: Duration = 30.seconds): FullHttpResponse = {
     toScalaObservable(client.sendRequest(request))
       .doOnNext(response => if (debug) println("StyxClientSupplier: received response for: " + request.url().path()))
-      .flatMap(response => toRxObservable(response.toFullHttpResponse(maxSize)))
+      .flatMap(response => toRxObservable(response.toFullResponse(maxSize)))
       .timeout(timeout)
       .toBlocking
       .first

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/MockOriginServer.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/MockOriginServer.java
@@ -50,7 +50,6 @@ import static com.google.common.base.Optional.absent;
 import static com.hotels.styx.servers.WiremockResponseConverter.toStyxResponse;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
-import com.hotels.styx.api.HttpRequest;
 
 public final class MockOriginServer {
     private static final Logger LOGGER = LoggerFactory.getLogger(MockOriginServer.class);
@@ -122,7 +121,7 @@ public final class MockOriginServer {
 
     private static HttpHandler newHandler(String originId, RequestHandler wireMockHandler) {
         return (httpRequest, ctx) ->
-                httpRequest.toFullHttpRequest(MAX_CONTENT_LENGTH)
+                httpRequest.toFullRequest(MAX_CONTENT_LENGTH)
                         .map(fullRequest -> {
                             LOGGER.info("{} received: {}\n{}", new Object[]{originId, fullRequest.url(), fullRequest.body()});
                             return fullRequest;
@@ -232,7 +231,7 @@ public final class MockOriginServer {
 
     private static HttpHandler newHandler(RequestHandler wireMockHandler) {
         return (httpRequest, ctx) ->
-                httpRequest.toFullHttpRequest(MAX_CONTENT_LENGTH)
+                httpRequest.toFullRequest(MAX_CONTENT_LENGTH)
                         .map(fullRequest -> {
                             LOGGER.info("Received: {}\n{}", new Object[]{fullRequest.url(), fullRequest.body()});
                             return fullRequest;

--- a/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/servers/MockOriginServerTest.java
+++ b/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/servers/MockOriginServerTest.java
@@ -119,7 +119,7 @@ public class MockOriginServerTest {
 
     private FullHttpResponse send(HttpClient client, HttpRequest request) {
         return await(fromRxObservable(client.sendRequest(request))
-                .flatMap(req -> req.toFullHttpResponse(10*1024))
+                .flatMap(req -> req.toFullResponse(10*1024))
                 .asCompletableFuture());
     }
 

--- a/system-tests/example-styx-plugin/src/main/java/loadtest/plugins/AsyncRequestContentDecoderPluginFactory.java
+++ b/system-tests/example-styx-plugin/src/main/java/loadtest/plugins/AsyncRequestContentDecoderPluginFactory.java
@@ -44,7 +44,7 @@ public class AsyncRequestContentDecoderPluginFactory implements PluginFactory {
 
         @Override
         public StyxObservable<HttpResponse> intercept(HttpRequest request, Chain chain) {
-            return request.toFullHttpRequest(config.maxContentLength())
+            return request.toFullRequest(config.maxContentLength())
                             .flatMap(fullHttpRequest -> StyxObservable.from(asyncOperation(config.delayMillis())))
                             .map(outcome -> request.newBuilder().header("X-Outcome", outcome.result()))
                             .flatMap(x -> chain.proceed(request));

--- a/system-tests/example-styx-plugin/src/main/java/loadtest/plugins/AsyncResponseContentDecoderPluginFactory.java
+++ b/system-tests/example-styx-plugin/src/main/java/loadtest/plugins/AsyncResponseContentDecoderPluginFactory.java
@@ -52,7 +52,7 @@ public class AsyncResponseContentDecoderPluginFactory implements PluginFactory {
         @Override
         public StyxObservable<HttpResponse> intercept(HttpRequest request, Chain chain) {
             return chain.proceed(request)
-                    .flatMap(response ->  response.toFullHttpResponse(this.maxContentLength))
+                    .flatMap(response ->  response.toFullResponse(this.maxContentLength))
                     .flatMap(fullResponse -> StyxObservable.from(asyncEvent(this.delayMillis))
                             .map(x -> fullResponse))
                     .map(FullHttpResponse::toStreamingResponse);

--- a/system-tests/example-styx-plugin/src/main/java/testgrp/TestPlugin.java
+++ b/system-tests/example-styx-plugin/src/main/java/testgrp/TestPlugin.java
@@ -61,7 +61,7 @@ public class TestPlugin implements Plugin {
         Function<ByteBuf, String> byteBufStringFunction = byteBuf -> byteBuf.toString(Charsets.UTF_8);
 
         return chain.proceed(newRequest)
-                .flatMap(response -> response.toFullHttpResponse(1 * 1024 * 1024))
+                .flatMap(response -> response.toFullResponse(1 * 1024 * 1024))
                 .map(response ->
                         response.newBuilder()
                                 .header(X_HCOM_PLUGINS_HEADER, header)


### PR DESCRIPTION
To keep the naming consistent between streaming and full messages:
- rename `toFullHttpRequest` to `toFullRequest`
- rename `toFullHttpResponse` to `toFullResponse`