### PR TITLE
Don't send response chunk for HEAD request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,16 @@ e2e-compile:
 
 ## Run system tests
 e2e-test:
-	mvn -f system-tests/pom.xml -P$(PLATFORM) scalatest:test
+	mvn -f system-tests/e2e-suite/pom.xml -P$(PLATFORM) scalatest:test
 
 ## Execute a single end-to-end (scala) test
 # Alternatively, it should be possible to run an individual e2e test
 # with following Maven command:
 #
-#  mvn -f system-tests/pom.xml scalatest:test -Dsuites='*ProxyPropertySpec'
+#  mvn -f system-tests/e2e-suite/pom.xml scalatest:test -Dsuites='*ProxyPropertySpec'
 #
 e2e-test-single:
-	mvn -f system-tests/pom.xml scalatest:test -Dsuites='${TEST}'
+	mvn -f system-tests/e2e-suite/pom.xml scalatest:test -Dsuites='${TEST}'
 
 ## Compile, test and create styx.zip
 release: clean

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyConnectorFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyConnectorFactory.java
@@ -37,8 +37,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.handler.codec.http.HttpRequestDecoder;
-import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
@@ -143,11 +142,8 @@ class ProxyConnectorFactory implements ServerConnectorFactory {
                     .addLast("idle-handler", new IdleStateHandler(serverConfig.requestTimeoutMillis(), 0, serverConfig.keepAliveTimeoutMillis(), MILLISECONDS))
                     .addLast("channel-stats", channelStatsHandler)
 
-                    // Outbound
-                    .addLast("encoder", new HttpResponseEncoder())
-
-                    // Inbound
-                    .addLast("decoder", new HttpRequestDecoder(serverConfig.maxInitialLineLength(), serverConfig.maxHeaderSize(), serverConfig.maxChunkSize(), true))
+                    // Http Server Codec
+                    .addLast("http-server-codec", new HttpServerCodec(serverConfig.maxInitialLineLength(), serverConfig.maxHeaderSize(), serverConfig.maxChunkSize(), true))
 
                     // idle-handler and timeout-handler must be before aggregator. Otherwise
                     // timeout handler cannot see the incoming HTTP chunks.


### PR DESCRIPTION
A `StyxProxySpec "should respond to HEAD with bodiless response"` is failing intermittently. The root cause is a combination of slightly incorrect usage of Netty combined with asynchronous behaviour of the e2e tests.

The test case fails because Netty `HttpResponseEncoder` leaks (to the network) an empty content chunk whenever Styx responds to a HTTP request. For example:

```
08:17:58.984 ProxySpecLog [scalatest-e2e-client-Client-Worker-0-Thread] DEBUG i.n.handler.logging.LoggingHandler - [id: 0xe3c37f78, L:/127.0.0.1:40064 - R:localhost/127.0.0.1:8080] READ: 189B
         +-------------------------------------------------+
         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+--------+-------------------------------------------------+----------------+
|00000000| 48 54 54 50 2f 31 2e 31 20 32 30 30 20 4f 4b 0d |HTTP/1.1 200 OK.|
|00000010| 0a 53 65 72 76 65 72 3a 20 4a 65 74 74 79 28 36 |.Server: Jetty(6|
|00000020| 2e 31 2e 32 36 29 0d 0a 58 2d 53 74 79 78 2d 4f |.1.26)..X-Styx-O|
|00000030| 72 69 67 69 6e 2d 49 64 3a 20 67 65 6e 65 72 69 |rigin-Id: generi|
|00000040| 63 2d 61 70 70 2d 30 31 0d 0a 56 69 61 3a 20 31 |c-app-01..Via: 1|
|00000050| 2e 31 20 73 74 79 78 0d 0a 58 2d 53 74 79 78 2d |.1 styx..X-Styx-|
|00000060| 49 6e 66 6f 3a 20 6e 6f 4a 76 6d 52 6f 75 74 65 |Info: noJvmRoute|
|00000070| 53 65 74 3b 63 63 31 64 35 37 64 33 2d 36 33 31 |Set;cc1d57d3-631|
|00000080| 38 2d 31 31 65 38 2d 38 66 31 36 2d 35 32 35 34 |8-11e8-8f16-5254|
|00000090| 30 30 37 61 36 39 35 61 0d 0a 74 72 61 6e 73 66 |007a695a..transf|
|000000a0| 65 72 2d 65 6e 63 6f 64 69 6e 67 3a 20 63 68 75 |er-encoding: chu|
|000000b0| 6e 6b 65 64 0d 0a 0d 0a 30 0d 0a 0d 0a          |nked....0....   |
+--------+-------------------------------------------------+----------------+
```

The last `0....` in above log represents the leaked content chunk. The test case fails, specifically, when the leaked chunk arrives at the receiving end (a test HTTP client at StyxProxySpec) before a test client has started decoding the response message.

- The test pass when the test client had started decoding the HTTP response *before* the leaked `0...` arrives. In this case the response is decoded correctly and the test case validation completes.

- The test fails when HTTP response decoding starts *after* the `0...` had arrived. In this case the `0...` is decoded together with the response and treated as a beginning of the next message. This causes a decoding failure due to invalid HTTP version format, and the decoder throws a Netty Channel Exception resulting in a test failure.

The `0...` is leaked to the network because Styx had separate `HttpResponseEncoder` and `HttpRequestDecoder` codecs in the channel pipeline. The separate codecs are unaware of each other and therefore the response encoder cannot know it is responding to a HEAD request. 

The fix is to use `HttpServerCodec` instead. It is aware of the HEAD response and prevents extra content chunks from being sent.
