### PR TITLE
Allow consumer to configure styx test api server ports.

### DIFF
--- a/support/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
+++ b/support/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
@@ -190,6 +190,7 @@ public final class StyxServer {
 
         /**
          * Specifies the HTTP port for proxy server.
+         * Set port number to 0 (zero) to let Styx automatically allocate a free port number.
          *
          * @param proxyPort
          * @return this builder
@@ -201,6 +202,7 @@ public final class StyxServer {
 
         /**
          * Specifies the HTTPS port for proxy server.
+         * Set port number to 0 (zero) to let Styx automatically allocate a free port number.
          *
          * @param proxyPort
          * @return this builder
@@ -212,6 +214,7 @@ public final class StyxServer {
 
         /**
          * Specifies the HTTP port for admin server
+         * Set port number to 0 (zero) to let Styx automatically allocate a free port number.
          *
          * @param adminPort
          * @return this builder

--- a/support/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
+++ b/support/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
@@ -190,7 +190,9 @@ public final class StyxServer {
 
         /**
          * Specifies the HTTP port for proxy server.
-         * Set port number to 0 (zero) to let Styx automatically allocate a free port number.
+         *
+         * By default, Styx will automatically allocate a free port number. This happens when a port is
+         * not set a value on the builder, or it is set a value of 0 (zero).
          *
          * @param proxyPort
          * @return this builder
@@ -202,7 +204,9 @@ public final class StyxServer {
 
         /**
          * Specifies the HTTPS port for proxy server.
-         * Set port number to 0 (zero) to let Styx automatically allocate a free port number.
+         *
+         * By default, Styx will automatically allocate a free port number. This happens when a port is
+         * not set a value on the builder, or it is set a value of 0 (zero).
          *
          * @param proxyPort
          * @return this builder
@@ -214,7 +218,9 @@ public final class StyxServer {
 
         /**
          * Specifies the HTTP port for admin server
-         * Set port number to 0 (zero) to let Styx automatically allocate a free port number.
+         *
+         * By default, Styx will automatically allocate a free port number. This happens when a port is
+         * not set a value on the builder, or it is set a value of 0 (zero).
          *
          * @param adminPort
          * @return this builder

--- a/support/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
+++ b/support/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
@@ -195,7 +195,7 @@ public final class StyxServer {
          * @param proxyPort
          * @return this builder
          */
-        public Builder httpPort(int proxyPort) {
+        public Builder proxyHttpPort(int proxyPort) {
             this.proxyHttpPort = proxyPort;
             return this;
         }

--- a/support/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
+++ b/support/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
@@ -74,7 +74,7 @@ public final class StyxServer {
                 .collect(toList());
 
         StyxServerComponents config = new StyxServerComponents.Builder()
-                .styxConfig(styxConfig())
+                .styxConfig(styxConfig(builder))
                 .pluginsLoader(loader)
                 .additionalServices(ImmutableMap.of("backendServiceRegistry", new RegistryServiceAdapter(backendServicesRegistry)))
                 .build();
@@ -92,22 +92,22 @@ public final class StyxServer {
         return this;
     }
 
-    private static StyxConfig styxConfig() {
+    private static StyxConfig styxConfig(Builder builder) {
         return new StyxConfig(new MapBackedConfiguration()
-                .set("proxy", proxyServerConfig())
-                .set("admin", adminServerConfig()));
+                .set("proxy", proxyServerConfig(builder))
+                .set("admin", adminServerConfig(builder)));
     }
 
-    private static AdminServerConfig adminServerConfig() {
+    private static AdminServerConfig adminServerConfig(Builder builder) {
         return new AdminServerConfig.Builder()
-                .setHttpConnector(new HttpConnectorConfig(0))
+                .setHttpConnector(new HttpConnectorConfig(builder.adminHttpPort))
                 .build();
     }
 
-    private static ProxyServerConfig proxyServerConfig() {
+    private static ProxyServerConfig proxyServerConfig(Builder builder) {
         return new ProxyServerConfig.Builder()
-                .setHttpConnector(new HttpConnectorConfig(0))
-                .setHttpsConnector(new HttpsConnectorConfig.Builder().port(0).build())
+                .setHttpConnector(new HttpConnectorConfig(builder.proxyHttpPort))
+                .setHttpsConnector(new HttpsConnectorConfig.Builder().port(builder.proxyHttpsPort).build())
                 .build();
     }
 
@@ -184,6 +184,42 @@ public final class StyxServer {
     public static final class Builder {
         private final Map<String, com.hotels.styx.api.service.BackendService> routes = new HashMap<>();
         private final List<PluginFactoryConfig> pluginFactories = new ArrayList<>();
+        private int proxyHttpPort = 0;
+        private int adminHttpPort = 0;
+        private int proxyHttpsPort = 0;
+
+        /**
+         * Specifies the HTTP port for proxy server.
+         *
+         * @param proxyPort
+         * @return this builder
+         */
+        public Builder httpPort(int proxyPort) {
+            this.proxyHttpPort = proxyPort;
+            return this;
+        }
+
+        /**
+         * Specifies the HTTPS port for proxy server.
+         *
+         * @param proxyPort
+         * @return this builder
+         */
+        public Builder proxyHttpsPort(int proxyPort) {
+            this.proxyHttpsPort = proxyPort;
+            return this;
+        }
+
+        /**
+         * Specifies the HTTP port for admin server
+         *
+         * @param adminPort
+         * @return this builder
+         */
+        public Builder adminHttpPort(int adminPort) {
+            this.adminHttpPort = adminPort;
+            return this;
+        }
 
         /**
          * Adds a plugin to the server.

--- a/support/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
+++ b/support/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
@@ -184,9 +184,9 @@ public final class StyxServer {
     public static final class Builder {
         private final Map<String, com.hotels.styx.api.service.BackendService> routes = new HashMap<>();
         private final List<PluginFactoryConfig> pluginFactories = new ArrayList<>();
-        private int proxyHttpPort = 0;
-        private int adminHttpPort = 0;
-        private int proxyHttpsPort = 0;
+        private int proxyHttpPort;
+        private int adminHttpPort;
+        private int proxyHttpsPort;
 
         /**
          * Specifies the HTTP port for proxy server.

--- a/support/test-api/src/test/java/com/hotels/styx/testapi/StyxServerTest.java
+++ b/support/test-api/src/test/java/com/hotels/styx/testapi/StyxServerTest.java
@@ -130,7 +130,7 @@ public class StyxServerTest {
     public void startsProxyOnSpecifiedHttpPort() {
         int proxyPort = freePort();
         styxServer = new StyxServer.Builder()
-                .httpPort(proxyPort)
+                .proxyHttpPort(proxyPort)
                 .addRoute("/", originServer1.port())
                 .start();
 


### PR DESCRIPTION
Makes it possible for plugin tests to configure HTTP port numbers for the test server.
