### PR TITLE
SimpleHttpClient: Use default HTTP/HTTPS ports

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/SimpleHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/SimpleHttpClient.java
@@ -84,7 +84,13 @@ public final class SimpleHttpClient implements FullHttpClient {
                             .orElseThrow(() -> new IllegalArgumentException("Cannot send request " + request + " as URL is not absolute and no HOST header is present"));
                 });
 
-        return newOriginBuilder(HostAndPort.fromString(hostAndPort)).build();
+        HostAndPort host = HostAndPort.fromString(hostAndPort);
+
+        if (host.getPortOrDefault(-1) < 0) {
+            host = host.withDefaultPort(request.isSecure() ? 443 : 80);
+        }
+
+        return newOriginBuilder(host).build();
     }
 
     /**

--- a/components/client/src/main/java/com/hotels/styx/client/SimpleHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/SimpleHttpClient.java
@@ -43,6 +43,9 @@ import static com.hotels.styx.common.CompletableFutures.fromSingleObservable;
  * A client that uses netty as transport.
  */
 public final class SimpleHttpClient implements FullHttpClient {
+    private static final int DEFAULT_HTTPS_PORT = 443;
+    private static final int DEFAULT_HTTP_PORT = 80;
+    
     private final Optional<String> userAgent;
     private final ConnectionSettings connectionSettings;
     private final int maxResponseSize;
@@ -87,7 +90,7 @@ public final class SimpleHttpClient implements FullHttpClient {
         HostAndPort host = HostAndPort.fromString(hostAndPort);
 
         if (host.getPortOrDefault(-1) < 0) {
-            host = host.withDefaultPort(request.isSecure() ? 443 : 80);
+            host = host.withDefaultPort(request.isSecure() ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT);
         }
 
         return newOriginBuilder(host).build();

--- a/components/client/src/main/java/com/hotels/styx/client/SimpleHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/SimpleHttpClient.java
@@ -45,7 +45,7 @@ import static com.hotels.styx.common.CompletableFutures.fromSingleObservable;
 public final class SimpleHttpClient implements FullHttpClient {
     private static final int DEFAULT_HTTPS_PORT = 443;
     private static final int DEFAULT_HTTP_PORT = 80;
-    
+
     private final Optional<String> userAgent;
     private final ConnectionSettings connectionSettings;
     private final int maxResponseSize;

--- a/components/client/src/test/unit/java/com/hotels/styx/client/SimpleHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/SimpleHttpClientTest.java
@@ -165,11 +165,9 @@ public class SimpleHttpClientTest {
                 .setConnectionFactory(connectionFactory)
                 .build();
 
-        await(client.sendRequest(
-                        FullHttpRequest.get("/")
-                                .header(HOST, "localhost")
-                                .build()
-                ));
+        client.sendRequest(get("/")
+                .header(HOST, "localhost")
+                .build());
 
         ArgumentCaptor<Origin> originCaptor = ArgumentCaptor.forClass(Origin.class);
         verify(connectionFactory).createConnection(originCaptor.capture(), any(Connection.Settings.class));
@@ -185,12 +183,10 @@ public class SimpleHttpClientTest {
                 .setConnectionFactory(connectionFactory)
                 .build();
 
-        await(client.sendRequest(
-                        FullHttpRequest.get("/")
-                                .secure(true)
-                                .header(HOST, "localhost")
-                                .build()
-                ));
+        client.sendRequest(get("/")
+                .secure(true)
+                .header(HOST, "localhost")
+                .build());
 
         ArgumentCaptor<Origin> originCaptor = ArgumentCaptor.forClass(Origin.class);
         verify(connectionFactory).createConnection(originCaptor.capture(), any(Connection.Settings.class));


### PR DESCRIPTION
An attempt to send a HTTP request without explicitly set port numbers, the SimpleHttpClient fails and throws an exception. Instead, it should use a default port for HTTP or HTTPS depending on the type the request.

This PR provides a fix for the above problem.
