### PR TITLE
Remove unnecessary WARN log when SimpleHttpClient fails to connect to a remote peer.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/StyxCoreObservable.java
+++ b/components/api/src/main/java/com/hotels/styx/api/StyxCoreObservable.java
@@ -91,7 +91,7 @@ class StyxCoreObservable<T> implements StyxObservable<T> {
         return fromSingleObservable(delegate);
     }
 
-    public static <T> CompletableFuture<T> fromSingleObservable(Observable<T> observable) {
+    private static <T> CompletableFuture<T> fromSingleObservable(Observable<T> observable) {
         final CompletableFuture<T> future = new CompletableFuture<>();
         observable.single().subscribe(future::complete, future::completeExceptionally);
         return future;

--- a/components/api/src/main/java/com/hotels/styx/api/StyxCoreObservable.java
+++ b/components/api/src/main/java/com/hotels/styx/api/StyxCoreObservable.java
@@ -91,12 +91,9 @@ class StyxCoreObservable<T> implements StyxObservable<T> {
         return fromSingleObservable(delegate);
     }
 
-    private static <T> CompletableFuture<T> fromSingleObservable(Observable<T> observable) {
+    public static <T> CompletableFuture<T> fromSingleObservable(Observable<T> observable) {
         final CompletableFuture<T> future = new CompletableFuture<>();
-        observable
-                .doOnError(future::completeExceptionally)
-                .single()
-                .forEach(future::complete);
+        observable.single().subscribe(future::complete, future::completeExceptionally);
         return future;
     }
 

--- a/components/common/src/main/java/com/hotels/styx/common/CompletableFutures.java
+++ b/components/common/src/main/java/com/hotels/styx/common/CompletableFutures.java
@@ -27,14 +27,9 @@ public final class CompletableFutures {
     }
 
     // TODO: We need to substitute this in favour of Styx APIs
-    //
-    // Credit: http://www.nurkiewicz.com/2014/11/converting-between-completablefuture.html
     public static <T> CompletableFuture<T> fromSingleObservable(Observable<T> observable) {
         final CompletableFuture<T> future = new CompletableFuture<>();
-        observable
-                .doOnError(future::completeExceptionally)
-                .single()
-                .forEach(future::complete);
+        observable.single().subscribe(future::complete, future::completeExceptionally);
         return future;
     }
 


### PR DESCRIPTION
# Description

A rather long stack trace gets logged every time `SimpleHttpClient` fails to connect to a remote peer server. This PR eliminates that useless log message. The log message is especially annoying now when the `SimpleHttpClient` is used for Styx health checks.

# Root cause

The stack trace is logged from Netty `DefaultPromise` / `notifyListener0`. Its exception handler by default catches all unhandled exceptions and logs them as warning messages. In this case it catches an `rx.exceptions.OnErrorNotImplementedException` from the Rx observable framework when `SimpleHttpClient` fails to connect.

The exception is caused by Styx Rx Observable to CompletableFuture conversion routine, which doesn't subscribe to `onError` event. It does register an `doOnError` event handler, but this is not enough. The exception is emitted from `forEach(future::complete)` subscriber, which by default throws this exception for any `onError` events.
