### PR TITLE
Allow custom plugin loader injection

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
@@ -141,8 +141,8 @@ public class StyxServerComponents {
             return plugins(env -> list);
         }
 
-        @VisibleForTesting
-        Builder plugins(PluginsLoader pluginsLoader) {
+
+        public Builder plugins(PluginsLoader pluginsLoader) {
             this.pluginsLoader = requireNonNull(pluginsLoader);
             return this;
         }


### PR DESCRIPTION
The PR addresses the following issue.

## The problem
We want the ability to use a custom `PluginsLoader` that is not sourced from the yaml configs.

## Detailed description
Right now the method that allow  injecting a custom `PluginsLoader` in the styx system is package private

https://github.com/HotelsDotCom/styx/blob/41238747919cbe7acf937b6268bfd94aa935a240/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java#L144-L148

## Acceptance criteria
• A developer should be able to inject a custom `PluginsLoader` when building a styx server