### PR TITLE
Add SENDING_RESPONSE_CLIENT_CLOSED state into HttpPipelineHandler FSM

### DIFF
--- a/components/common/src/main/java/com/hotels/styx/common/StateMachine.java
+++ b/components/common/src/main/java/com/hotels/styx/common/StateMachine.java
@@ -206,7 +206,7 @@ public final class StateMachine<S> {
 
         public Builder<S> debugTransitions(String messagePrefix) {
             return this.onStateChange((oldState, newState, event)-> {
-                LOGGER.info("{} {}: {} -> {}", new Object[] { messagePrefix, event, oldState, newState} );
+                LOGGER.info("{} {}: {} -> {}", new Object[] {messagePrefix, event, oldState, newState});
             });
         }
     }

--- a/components/common/src/main/java/com/hotels/styx/common/StateMachine.java
+++ b/components/common/src/main/java/com/hotels/styx/common/StateMachine.java
@@ -203,5 +203,11 @@ public final class StateMachine<S> {
         public StateMachine<S> build() {
             return new StateMachine<>(initialState, stateEventHandlers, inappropriateEventHandler, stateChangeListener);
         }
+
+        public Builder<S> debugTransitions(String messagePrefix) {
+            return this.onStateChange((oldState, newState, event)-> {
+                LOGGER.info("{} {}: {} -> {}", new Object[] { messagePrefix, event, oldState, newState} );
+            });
+        }
     }
 }

--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -60,6 +60,7 @@ import static com.hotels.styx.api.metrics.HttpErrorStatusListener.IGNORE_ERROR_S
 import static com.hotels.styx.api.metrics.RequestProgressListener.IGNORE_REQUEST_PROGRESS;
 import static com.hotels.styx.server.netty.connectors.HttpPipelineHandler.State.ACCEPTING_REQUESTS;
 import static com.hotels.styx.server.netty.connectors.HttpPipelineHandler.State.SENDING_RESPONSE;
+import static com.hotels.styx.server.netty.connectors.HttpPipelineHandler.State.SENDING_RESPONSE_CLIENT_CLOSED;
 import static com.hotels.styx.server.netty.connectors.HttpPipelineHandler.State.TERMINATED;
 import static com.hotels.styx.server.netty.connectors.HttpPipelineHandler.State.WAITING_FOR_RESPONSE;
 import static com.hotels.styx.server.netty.connectors.ResponseEnhancer.DO_NOT_MODIFY_RESPONSE;
@@ -145,11 +146,25 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
 
                 .transition(SENDING_RESPONSE, ResponseSentEvent.class, event -> onResponseSent(event.ctx))
                 .transition(SENDING_RESPONSE, ResponseWriteErrorEvent.class, event -> onResponseWriteError(event.ctx, event.cause))
-                .transition(SENDING_RESPONSE, ChannelInactiveEvent.class, event -> onChannelInactive())
+                .transition(SENDING_RESPONSE, ChannelInactiveEvent.class, event -> clientClosed())
                 .transition(SENDING_RESPONSE, ChannelExceptionEvent.class, event -> onChannelExceptionWhenSendingResponse(event.ctx, event.cause))
-                .transition(SENDING_RESPONSE, ResponseObservableErrorEvent.class, event -> logError(event.cause))
+                .transition(SENDING_RESPONSE, ResponseObservableErrorEvent.class, event -> logError(SENDING_RESPONSE,  event.cause))
                 .transition(SENDING_RESPONSE, ResponseObservableCompletedEvent.class, event -> SENDING_RESPONSE)
                 .transition(SENDING_RESPONSE, RequestReceivedEvent.class, event -> onPrematureRequest(event.request, event.ctx))
+
+                .transition(SENDING_RESPONSE_CLIENT_CLOSED, ResponseSentEvent.class, event -> onResponseSentAfterClientClosed(event.ctx))
+                .transition(SENDING_RESPONSE_CLIENT_CLOSED, ResponseWriteErrorEvent.class, event -> onResponseWriteError(event.ctx, event.cause))
+                .transition(SENDING_RESPONSE_CLIENT_CLOSED, ChannelInactiveEvent.class, event -> {
+                    LOGGER.warn(warningMessage("Weird. This event/state was not supposed to happen."));
+                    return SENDING_RESPONSE_CLIENT_CLOSED;
+                })
+                .transition(SENDING_RESPONSE_CLIENT_CLOSED, ChannelExceptionEvent.class, event -> logError(SENDING_RESPONSE_CLIENT_CLOSED,  event.cause))
+                .transition(SENDING_RESPONSE_CLIENT_CLOSED, ResponseObservableErrorEvent.class, event -> logError(SENDING_RESPONSE_CLIENT_CLOSED, event.cause))
+                .transition(SENDING_RESPONSE_CLIENT_CLOSED, ResponseObservableCompletedEvent.class, event -> SENDING_RESPONSE_CLIENT_CLOSED)
+                .transition(SENDING_RESPONSE_CLIENT_CLOSED, RequestReceivedEvent.class, event -> {
+                    LOGGER.warn(warningMessage("Weird. This event/state was not supposed to happen."));
+                    return SENDING_RESPONSE_CLIENT_CLOSED;
+                })
 
                 .transition(TERMINATED, ChannelInactiveEvent.class, event -> TERMINATED)
 
@@ -161,9 +176,9 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
                 .build();
     }
 
-    private State logError(Throwable cause) {
+    private State logError(State state, Throwable cause) {
         httpErrorStatusListener.proxyingFailure(ongoingRequest, ongoingResponse, cause);
-        return SENDING_RESPONSE;
+        return state;
     }
 
     @VisibleForTesting
@@ -175,6 +190,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
         ACCEPTING_REQUESTS,
         WAITING_FOR_RESPONSE,
         SENDING_RESPONSE,
+        SENDING_RESPONSE_CLIENT_CLOSED,
         TERMINATED
     }
 
@@ -304,6 +320,17 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
         }
     }
 
+    private State onResponseSentAfterClientClosed(ChannelHandlerContext ctx) {
+        statsSink.onComplete(ongoingRequest.id(), ongoingResponse.status().code());
+        ongoingRequest = null;
+        ctx.close();
+        return TERMINATED;
+    }
+
+    private State clientClosed() {
+        return SENDING_RESPONSE_CLIENT_CLOSED;
+    }
+
     private State onResponseWriteError(ChannelHandlerContext ctx, Throwable cause) {
         metrics.counter("requests.cancelled.responseWriteError").inc();
         cancelSubscription();
@@ -349,7 +376,6 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
         // the exception as if a request had been received:
         return handleChannelException(ctx, cause);
     }
-
 
     private State handleChannelException(ChannelHandlerContext ctx, Throwable cause) {
         if (!isIoException(cause)) {

--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -154,17 +154,9 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
 
                 .transition(SENDING_RESPONSE_CLIENT_CLOSED, ResponseSentEvent.class, event -> onResponseSentAfterClientClosed(event.ctx))
                 .transition(SENDING_RESPONSE_CLIENT_CLOSED, ResponseWriteErrorEvent.class, event -> onResponseWriteError(event.ctx, event.cause))
-                .transition(SENDING_RESPONSE_CLIENT_CLOSED, ChannelInactiveEvent.class, event -> {
-                    LOGGER.warn(warningMessage("Weird. This event/state was not supposed to happen."));
-                    return SENDING_RESPONSE_CLIENT_CLOSED;
-                })
                 .transition(SENDING_RESPONSE_CLIENT_CLOSED, ChannelExceptionEvent.class, event -> logError(SENDING_RESPONSE_CLIENT_CLOSED,  event.cause))
                 .transition(SENDING_RESPONSE_CLIENT_CLOSED, ResponseObservableErrorEvent.class, event -> logError(SENDING_RESPONSE_CLIENT_CLOSED, event.cause))
                 .transition(SENDING_RESPONSE_CLIENT_CLOSED, ResponseObservableCompletedEvent.class, event -> SENDING_RESPONSE_CLIENT_CLOSED)
-                .transition(SENDING_RESPONSE_CLIENT_CLOSED, RequestReceivedEvent.class, event -> {
-                    LOGGER.warn(warningMessage("Weird. This event/state was not supposed to happen."));
-                    return SENDING_RESPONSE_CLIENT_CLOSED;
-                })
 
                 .transition(TERMINATED, ChannelInactiveEvent.class, event -> TERMINATED)
 

--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -146,7 +146,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
 
                 .transition(SENDING_RESPONSE, ResponseSentEvent.class, event -> onResponseSent(event.ctx))
                 .transition(SENDING_RESPONSE, ResponseWriteErrorEvent.class, event -> onResponseWriteError(event.ctx, event.cause))
-                .transition(SENDING_RESPONSE, ChannelInactiveEvent.class, event -> clientClosed())
+                .transition(SENDING_RESPONSE, ChannelInactiveEvent.class, event -> SENDING_RESPONSE_CLIENT_CLOSED)
                 .transition(SENDING_RESPONSE, ChannelExceptionEvent.class, event -> onChannelExceptionWhenSendingResponse(event.ctx, event.cause))
                 .transition(SENDING_RESPONSE, ResponseObservableErrorEvent.class, event -> logError(SENDING_RESPONSE,  event.cause))
                 .transition(SENDING_RESPONSE, ResponseObservableCompletedEvent.class, event -> SENDING_RESPONSE)
@@ -325,10 +325,6 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
         ongoingRequest = null;
         ctx.close();
         return TERMINATED;
-    }
-
-    private State clientClosed() {
-        return SENDING_RESPONSE_CLIENT_CLOSED;
     }
 
     private State onResponseWriteError(ChannelHandlerContext ctx, Throwable cause) {

--- a/components/server/src/test/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandlerTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandlerTest.java
@@ -807,28 +807,6 @@ public class HttpPipelineHandlerTest {
         assertThat(handler.state(), is(TERMINATED));
     }
 
-//    @Test
-//    public void channelInactiveEventInSendingResponseState() throws Exception {
-//        // In Sending Response state,
-//        // The inbound TCP connection gets closes
-//
-//        CompletableFuture<Void> future = new CompletableFuture<>();
-//        HttpPipelineHandler adapter = handlerWithMocks().responseEnhancer(DO_NOT_MODIFY_RESPONSE).responseWriterFactory(responseWriterFactory(future)).build();
-//
-//        adapter.channelActive(ctx);
-//        adapter.channelRead0(ctx, request);
-//        responseObservable.onNext(response);
-//        assertThat(adapter.state(), is(SENDING_RESPONSE));
-//        assertThat(future.isCompletedExceptionally(), is(false));
-//
-//        adapter.channelInactive(ctx);
-//
-//        assertThat(future.isCompletedExceptionally(), is(true));
-//        assertThat(responseUnsubscribed.get(), is(true));
-//        verify(statsCollector).onTerminate(request.id());
-//        assertThat(adapter.state(), is(TERMINATED));
-//    }
-
     @Test
     public void ioExceptionInSendingResponseState() throws Exception {
         // In Sending Response state,

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxClientSupplier.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxClientSupplier.scala
@@ -20,7 +20,7 @@ import com.hotels.styx.api.messages.FullHttpResponse
 import com.hotels.styx.api.{HttpClient, HttpRequest, HttpResponse}
 import com.hotels.styx.client.HttpConfig.newHttpConfigBuilder
 import com.hotels.styx.client.HttpRequestOperationFactory.Builder.httpRequestOperationFactoryBuilder
-import com.hotels.styx.client.connectionpool.CloseAfterUseConnectionDestination.Factory
+import com.hotels.styx.client.connectionpool.CloseAfterUseConnectionDestination
 import com.hotels.styx.client.netty.connectionpool.NettyConnectionFactory
 import com.hotels.styx.client.{ConnectionSettings, SimpleNettyHttpClient}
 import rx.lang.scala.JavaConversions.toScalaObservable
@@ -33,7 +33,7 @@ trait StyxClientSupplier {
   val FIVE_SECONDS: Int = 5 * 1000
 
   val client: HttpClient = new SimpleNettyHttpClient.Builder()
-    .connectionDestinationFactory(new Factory()
+    .connectionDestinationFactory(new CloseAfterUseConnectionDestination.Factory()
       .connectionSettings(new ConnectionSettings(1000))
       .connectionFactory(new NettyConnectionFactory.Builder()
         .name("scalatest-e2e-client")

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OriginCancellationMetrics.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OriginCancellationMetrics.scala
@@ -15,6 +15,7 @@
  */
 package com.hotels.styx.proxy
 
+import com.hotels.styx.api.HttpRequest.Builder.get
 import com.hotels.styx.api.messages.HttpResponseStatus.OK
 import com.hotels.styx.support.configuration.{ConnectionPoolSettings, HttpBackend, Origins}
 import com.hotels.styx.support.{NettyOrigins, TestClientSupport}
@@ -59,7 +60,7 @@ class OriginCancellationMetrics extends FunSpec
           HttpHeader(CONTENT_LENGTH, "0")
         ))
 
-      val request = api.HttpRequest.Builder.get(styxServer.routerURL("/OriginCancellationMetrics/1")).build()
+      val request = get(styxServer.routerURL("/OriginCancellationMetrics/1")).build()
       val response = decodedRequest(request)
       response.status() should be(OK)
 
@@ -73,7 +74,7 @@ class OriginCancellationMetrics extends FunSpec
           HttpHeader(CONTENT_LENGTH, "0")
         ))
 
-      val request = api.HttpRequest.Builder.get(styxServer.routerURL("/OriginCancellationMetrics/2")).build()
+      val request = get(styxServer.routerURL("/OriginCancellationMetrics/2")).build()
       val response = decodedRequest(request)
       response.status() should be(BAD_GATEWAY)
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OutstandingRequestsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/OutstandingRequestsSpec.scala
@@ -117,7 +117,8 @@ class OutstandingRequestsSpec extends FunSpec
 
       client.disconnect()
 
-      eventually(timeout(2 seconds)) {
+      // Eventually times out as per responseTimeout configuration:
+      eventually(timeout(4 seconds)) {
         styxServer.metricsSnapshot.count("requests.outstanding").get should be(0)
       }
     }


### PR DESCRIPTION
## Problem Description

Improve HttpPipelineHandler FSM to make it more predictable especially for some end to end tests.

There is a following scenario which sometimes causes intermittent e2e failures:

1. Test client sends a request to Styx.
2. Styx HTTP pipeline delivers a response in response observable `onNext` event. 
3. Styx sends the response.
4. Client receives the response in full, and closes the TCP connection.
5. Styx HttpPipelineHandler sees the `channelInactive` event *prior to* response observable `onCompleted` event.
6. Styx treats this as a failed response (even if from client's point of view it was successful)
7. Test case assertions fail.

Mostly this affects only those e2e tests whose assertions are based on observing changes in metrics. This has never caused any concern in production environments, where the incoming TCP connections tend to be pooled anyway.

## The Fix

To remedy this situation, I have added a new SENDING_RESPON/SE_CLIENT_CLOSED state which allows HttpPipelineHandler to wait for `onComplete` from the response observable. If `onComplete` is seen the response is treated as success. Otherwise it is treated as failure.