### PR TITLE
Added support for Kotlin compiler.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,9 @@
     <surefire.skip.tests>false</surefire.skip.tests>
 
     <netty-transport-native-epoll.classifier />
+    <!--Kotlin -->
+    <kotlin.version>1.2.51</kotlin.version>
+    <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
   </properties>
 
   <dependencyManagement>
@@ -484,14 +487,60 @@
         </exclusions>
       </dependency>
 
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-test</artifactId>
+        <version>${kotlin.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
 
   <build>
-
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-maven-plugin</artifactId>
+          <version>${kotlin.version}</version>
+          <executions>
+            <execution>
+              <id>compile</id>
+              <phase>compile</phase>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+              <configuration>
+              <sourceDirs>
+                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+              </sourceDirs>
+            </configuration>
+
+            </execution>
+            <execution>
+              <id>test-compile</id>
+              <phase>test-compile</phase>
+              <goals>
+                <goal>test-compile</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <jvmTarget>1.8</jvmTarget>
+            <sourceDirs>
+              <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+              <sourceDir>${project.basedir}/src/test/java</sourceDir>
+            </sourceDirs>
+          </configuration>
+        </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
@@ -503,6 +552,28 @@
             <!--<showWarnings>true</showWarnings>-->
             <!--<compilerArgument>-Xlint:all</compilerArgument>-->
           </configuration>
+          <executions>
+            <!-- Replacing default-compile as it is treated specially by maven -->
+            <execution>
+              <id>default-compile</id>
+              <phase>none</phase>
+            </execution>
+            <!-- Replacing default-testCompile as it is treated specially by maven -->
+            <execution>
+              <id>default-testCompile</id>
+              <phase>none</phase>
+            </execution>
+            <execution>
+              <id>java-compile</id>
+              <phase>compile</phase>
+              <goals> <goal>compile</goal> </goals>
+            </execution>
+            <execution>
+              <id>java-test-compile</id>
+              <phase>test-compile</phase>
+              <goals> <goal>testCompile</goal> </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Added support for Kotlin compiler in the parent pom 'management' blocks.
 Specific sub-projects that want to include Kotlin should declare the dependency kotlin-stdlib-jdk8 (and kotlin-test if needed) and the kotlin-maven-plugin plugin.

We should consider adding nullability annotations to the Java code so we can have null-safe Kotlin even if most of our code base is in Java. See:  https://nklmish.wordpress.com/2017/11/01/null-safety-calling-java-from-kotlin/, https://kotlinlang.org/docs/reference/java-interop.html#nullability-annotations . I  would go for setting "Not Null by default" and then specifically annotate with @Nullable when needed.

In Java we could use these annotations to generate non null checks in runtime (as Kotlin does) via using this tool: http://traute.oss.harmonysoft.tech/
