### PR TITLE
Metrics endpoint enhancement

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/MetricsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/MetricsHandler.java
@@ -74,9 +74,7 @@ public class MetricsHandler extends JsonHandler<MetricRegistry> {
 
         return metricRequest.fullMetrics()
                 ? super.handle(request)
-                : just(restrictedMetricsResponse(metricRequest)
-                .build()
-                .toStreamingResponse());
+                : just(restrictedMetricsResponse(metricRequest).build().toStreamingResponse());
     }
 
     private FullHttpResponse.Builder restrictedMetricsResponse(MetricRequest request) {

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/MetricsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/MetricsHandler.java
@@ -84,11 +84,9 @@ public class MetricsHandler extends JsonHandler<MetricRegistry> {
 
         Map<String, Metric> restricted = filter(fullMetrics, (name, metric) -> request.matchesRoot(name));
 
-        if (restricted.isEmpty()) {
-            return response(NOT_FOUND);
-        }
-
-        return search(request, restricted);
+        return restricted.isEmpty()
+                ? response(NOT_FOUND)
+                : search(request, restricted);
     }
 
     private FullHttpResponse.Builder search(MetricRequest request, Map<String, Metric> metrics) {
@@ -139,11 +137,7 @@ public class MetricsHandler extends JsonHandler<MetricRegistry> {
         }
 
         private boolean matchesRoot(String name) {
-            if (root == null || name.equals(root)) {
-                return true;
-            }
-
-            return name.startsWith(prefix);
+            return root == null || name.equals(root) || name.startsWith(prefix);
         }
 
         private boolean containsSearchTerm(String name) {

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/MetricsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/MetricsHandler.java
@@ -50,6 +50,8 @@ import static rx.Observable.just;
 public class MetricsHandler extends JsonHandler<MetricRegistry> {
     private static final Pattern SPECIFIC_METRICS_PATH_PATTERN = Pattern.compile(".*/metrics/(.+)/?");
     private static final boolean DO_NOT_SHOW_SAMPLES = false;
+    private static final String FILTER_PARAM = "filter";
+    private static final String PRETTY_PRINT_PARAM = "pretty";
 
     private final ObjectMapper metricSerialiser = new ObjectMapper()
             .registerModule(new MetricsModule(SECONDS, MILLISECONDS, DO_NOT_SHOW_SAMPLES));
@@ -119,8 +121,8 @@ public class MetricsHandler extends JsonHandler<MetricRegistry> {
 
         MetricRequest(HttpRequest request) {
             this.root = metricName(request.path()).orElse(null);
-            this.searchTerm = request.queryParam("search").orElse(null);
-            this.prettyPrint = request.queryParam("pretty").isPresent();
+            this.searchTerm = request.queryParam(FILTER_PARAM).orElse(null);
+            this.prettyPrint = request.queryParam(PRETTY_PRINT_PARAM).isPresent();
             this.prefix = root + ".";
         }
 

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/MetricsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/MetricsHandlerTest.java
@@ -83,7 +83,7 @@ public class MetricsHandlerTest {
         metricRegistry.counter("baz.bar.foo").inc(1);
         metricRegistry.counter("foo.baz.a").inc(1);
 
-        FullHttpResponse response = waitForResponse(handler.handle(get("/admin/metrics?search=bar").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/admin/metrics?filter=bar").build()));
         assertThat(response.status(), is(OK));
         assertThat(response.bodyAs(UTF_8), is("{" +
                 "\"baz.bar.foo\":{\"count\":1}," +
@@ -100,7 +100,7 @@ public class MetricsHandlerTest {
         metricRegistry.counter("foo.baz.a").inc(1);
         metricRegistry.counter("foo.baz.a.bar").inc(1);
 
-        FullHttpResponse response = waitForResponse(handler.handle(get("/admin/metrics/foo?search=bar").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/admin/metrics/foo?filter=bar").build()));
         assertThat(response.status(), is(OK));
         assertThat(response.bodyAs(UTF_8), is("{" +
                 "\"foo.bar.a\":{\"count\":1}," +
@@ -114,7 +114,7 @@ public class MetricsHandlerTest {
         metricRegistry.counter("foo.bar.a").inc(1);
         metricRegistry.counter("foo.bar.b").inc(1);
 
-        FullHttpResponse response = waitForResponse(handler.handle(get("/admin/metrics?search=notpresent").build()));
+        FullHttpResponse response = waitForResponse(handler.handle(get("/admin/metrics?filter=notpresent").build()));
         assertThat(response.status(), is(OK));
         assertThat(response.bodyAs(UTF_8), is("{}"));
     }

--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -21,6 +21,15 @@ For example `http://<styx-host>/admin/metrics/requests.response` would return
     requests.response.status.2xx
     ...
     
+## Searching Metrics for string
+
+To see all metrics containing a given string, a query parameter can be provided.
+This works with both specific metric roots and the set of all metrics:
+
+`http://<styx-host>/admin/metrics?search=<term>`
+
+`http://<styx-host>/admin/metrics/<metric-name>?search=<term>`
+
     
 ## Metrics Grouping
 

--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -23,12 +23,14 @@ For example `http://<styx-host>/admin/metrics/requests.response` would return
     
 ## Searching Metrics for string
 
-To see all metrics containing a given string, a query parameter can be provided.
-This works with both specific metric roots and the set of all metrics:
+Use a `filter` query parameter to filter for metrics names matching a given string. 
+For example `filter=count` only shows metrics whose name contains `count`. The filtering is applied to the results of the metrics query.
 
-`http://<styx-host>/admin/metrics?search=<term>`
+Examples where `term` is the string you want to filter for:
 
-`http://<styx-host>/admin/metrics/<metric-name>?search=<term>`
+`http://<styx-host>/admin/metrics?filter=<term>`
+
+`http://<styx-host>/admin/metrics/<metric-name>?filter=<term>`
 
     
 ## Metrics Grouping


### PR DESCRIPTION
Implementing issue #208 

I've extended the scope a little - rather than only looking at the start of the metric name for a search term, we're looking anywhere in the string.

This is more useful as someone looking for general metrics may know what word they need to find in the metric name, but not the root location.

Note: This does not remove the ability to restrict metrics to a certain root name.