### PR TITLE
Fixes #222: A memory leak in DashboardData.

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/admin/dashboard/DashboardData.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/dashboard/DashboardData.java
@@ -175,9 +175,7 @@ public class DashboardData {
         }
 
         private List<Backend> updateBackendsFromRegistry() {
-            if (this.backends != null) {
-                this.backends.forEach(Backend::unregister);
-            }
+            unregister();
 
             return stream(backendServicesRegistry.get().spliterator(), false)
                     .map(Backend::new)
@@ -185,7 +183,9 @@ public class DashboardData {
         }
 
         void unregister() {
-            backends.forEach(Backend::unregister);
+            if (backends != null) {
+                backends.forEach(Backend::unregister);
+            }
         }
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/dashboard/DashboardDataSupplier.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/dashboard/DashboardDataSupplier.java
@@ -59,6 +59,10 @@ public class DashboardDataSupplier implements Supplier<DashboardData>, Registry.
     }
 
     private DashboardData updateDashboardData(Registry<BackendService> backendServices) {
+        if (this.data != null) {
+            this.data.unregister();
+        }
+
         return new DashboardData(environment.metricRegistry(), backendServices, jvmRouteName, buildInfo, environment.eventBus());
     }
 

--- a/components/proxy/src/test/java/com/hotels/styx/admin/dashboard/DashboardDataTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/dashboard/DashboardDataTest.java
@@ -297,7 +297,6 @@ public class DashboardDataTest {
 
     @Test
     public void unsubscribesFromEventBus() {
-
         EventBus eventBus = mock(EventBus.class);
         MemoryBackedRegistry<BackendService> backendServicesRegistry = new MemoryBackedRegistry<>();
         backendServicesRegistry.add(application("app", origin("app-01", "localhost", 9090)));
@@ -310,7 +309,7 @@ public class DashboardDataTest {
 
         dashbaord.unregister();
 
-        verify(eventBus, times(4)).register(any(DashboardData.Origin.class));
+        verify(eventBus, times(4)).unregister(any(DashboardData.Origin.class));
     }
 
 

--- a/components/proxy/src/test/java/com/hotels/styx/admin/dashboard/DashboardDataTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/dashboard/DashboardDataTest.java
@@ -48,7 +48,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DashboardDataTest {
@@ -291,6 +294,25 @@ public class DashboardDataTest {
         assertThat(connectionsPool.busy(), is(234));
         assertThat(connectionsPool.pending(), is(345));
     }
+
+    @Test
+    public void unsubscribesFromEventBus() {
+
+        EventBus eventBus = mock(EventBus.class);
+        MemoryBackedRegistry<BackendService> backendServicesRegistry = new MemoryBackedRegistry<>();
+        backendServicesRegistry.add(application("app", origin("app-01", "localhost", 9090)));
+        backendServicesRegistry.add(application("test", origin("test-01", "localhost", 9090)));
+
+        DashboardData dashbaord = new DashboardData(metricRegistry, backendServicesRegistry, "styx-prod1-presentation-01", new Version("releaseTag"), eventBus);
+
+        // Twice for each backend. One during backend construction, another from BackendServicesRegistry listener callback.
+        verify(eventBus, times(4)).register(any(DashboardData.Origin.class));
+
+        dashbaord.unregister();
+
+        verify(eventBus, times(4)).register(any(DashboardData.Origin.class));
+    }
+
 
     // makes the generics explicit for the compiler (to avoid having a cast every time () -> value is used).
     private <T> Gauge<T> gauge(T value) {


### PR DESCRIPTION
Fixes #222, a memory leak in dashboard data supplier.

The leak was caused by `DashobardData.Origin` objects being continuously registered to the message bus, but never unregistered.
