### PR TITLE
Update Google Guava to 18.0.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/HttpCookie.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpCookie.java
@@ -16,7 +16,7 @@
 package com.hotels.styx.api;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 import java.util.Collection;
 
@@ -50,7 +50,7 @@ public final class HttpCookie {
         this.name = name;
         this.value = value;
         this.attributes = checkNotNull(attributes);
-        this.hashCode = Objects.hashCode(name, value, attributes);
+        this.hashCode = Objects.hash(name, value, attributes);
     }
 
     /**
@@ -127,7 +127,7 @@ public final class HttpCookie {
             return false;
         }
         HttpCookie other = (HttpCookie) obj;
-        return Objects.equal(name, other.name) && Objects.equal(value, other.value) && Objects.equal(attributes, other.attributes);
+        return Objects.equals(name, other.name) && Objects.equals(value, other.value) && Objects.equals(attributes, other.attributes);
     }
 
     @Override

--- a/components/api/src/main/java/com/hotels/styx/api/HttpCookieAttribute.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpCookieAttribute.java
@@ -15,7 +15,7 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,7 +36,7 @@ public final class HttpCookieAttribute {
     private HttpCookieAttribute(String name, String value) {
         this.name = checkNotNull(name);
         this.value = value;
-        this.hashCode = Objects.hashCode(name, value);
+        this.hashCode = Objects.hash(name, value);
     }
 
     /**
@@ -119,7 +119,7 @@ public final class HttpCookieAttribute {
             return false;
         }
         HttpCookieAttribute other = (HttpCookieAttribute) obj;
-        return Objects.equal(name, other.name) && Objects.equal(value, other.value);
+        return Objects.equals(name, other.name) && Objects.equals(value, other.value);
     }
 
     @Override

--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hotels.styx.api.HttpHeaderNames.CONNECTION;

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.MediaType;
 import com.hotels.styx.api.messages.FullHttpResponse;
@@ -27,11 +26,12 @@ import rx.Observable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Sets.newHashSet;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH;
@@ -319,7 +319,7 @@ public final class HttpResponse implements HttpMessage {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(request, version, status, headers, cookies);
+        return Objects.hash(request, version, status, headers, cookies);
     }
 
     @Override
@@ -331,11 +331,11 @@ public final class HttpResponse implements HttpMessage {
             return false;
         }
         HttpResponse other = (HttpResponse) obj;
-        return Objects.equal(this.request, other.request)
-                && Objects.equal(this.version, other.version)
-                && Objects.equal(this.status, other.status)
-                && Objects.equal(this.headers, other.headers)
-                && Objects.equal(this.cookies, other.cookies);
+        return Objects.equals(this.request, other.request)
+                && Objects.equals(this.version, other.version)
+                && Objects.equals(this.status, other.status)
+                && Objects.equals(this.headers, other.headers)
+                && Objects.equals(this.cookies, other.cookies);
     }
 
     /**

--- a/components/api/src/main/java/com/hotels/styx/api/Id.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Id.java
@@ -15,7 +15,7 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -48,7 +48,7 @@ public final class Id {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(value);
+        return Objects.hash(value);
     }
 
     @Override
@@ -60,6 +60,6 @@ public final class Id {
             return false;
         }
         Id other = (Id) obj;
-        return Objects.equal(this.value, other.value);
+        return Objects.equals(this.value, other.value);
     }
 }

--- a/components/api/src/main/java/com/hotels/styx/api/UrlQuery.java
+++ b/components/api/src/main/java/com/hotels/styx/api/UrlQuery.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;

--- a/components/api/src/main/java/com/hotels/styx/api/client/OriginsSnapshot.java
+++ b/components/api/src/main/java/com/hotels/styx/api/client/OriginsSnapshot.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hotels.styx.api.Id.id;
 import static com.hotels.styx.api.client.Origin.newOriginBuilder;

--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpRequest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hotels.styx.api.HttpHeaderNames.CONNECTION;

--- a/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/FullHttpResponse.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api.messages;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.HttpCookie;
 import com.hotels.styx.api.HttpHeaders;
@@ -26,9 +25,10 @@ import rx.Observable;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH;
 import static com.hotels.styx.api.HttpHeaderNames.TRANSFER_ENCODING;
@@ -171,7 +171,7 @@ public class FullHttpResponse implements FullHttpMessage {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(version, status, headers, cookies);
+        return Objects.hash(version, status, headers, cookies);
     }
 
     @Override
@@ -183,10 +183,10 @@ public class FullHttpResponse implements FullHttpMessage {
             return false;
         }
         FullHttpResponse other = (FullHttpResponse) obj;
-        return Objects.equal(this.version, other.version)
-                && Objects.equal(this.status, other.status)
-                && Objects.equal(this.headers, other.headers)
-                && Objects.equal(this.cookies, other.cookies);
+        return Objects.equals(this.version, other.version)
+                && Objects.equals(this.status, other.status)
+                && Objects.equals(this.headers, other.headers)
+                && Objects.equals(this.cookies, other.cookies);
     }
 
     /**

--- a/components/api/src/main/java/com/hotels/styx/api/messages/StreamingHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/StreamingHttpRequest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hotels.styx.api.FlowControlDisableOperator.disableFlowControl;

--- a/components/api/src/main/java/com/hotels/styx/api/messages/StreamingHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/messages/StreamingHttpResponse.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api.messages;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.ContentOverflowException;
 import com.hotels.styx.api.HttpCookie;
@@ -27,9 +26,10 @@ import rx.Observable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hotels.styx.api.FlowControlDisableOperator.disableFlowControl;
@@ -180,7 +180,7 @@ public class StreamingHttpResponse implements StreamingHttpMessage {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(version, status, headers, cookies);
+        return Objects.hash(version, status, headers, cookies);
     }
 
     @Override
@@ -192,10 +192,10 @@ public class StreamingHttpResponse implements StreamingHttpMessage {
             return false;
         }
         StreamingHttpResponse other = (StreamingHttpResponse) obj;
-        return Objects.equal(this.version, other.version)
-                && Objects.equal(this.status, other.status)
-                && Objects.equal(this.headers, other.headers)
-                && Objects.equal(this.cookies, other.cookies);
+        return Objects.equals(this.version, other.version)
+                && Objects.equals(this.status, other.status)
+                && Objects.equals(this.headers, other.headers)
+                && Objects.equals(this.cookies, other.cookies);
     }
 
     /**

--- a/components/api/src/main/java/com/hotels/styx/api/service/BackendService.java
+++ b/components/api/src/main/java/com/hotels/styx/api/service/BackendService.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hotels.styx.api.Id.GENERIC_APP;

--- a/components/api/src/main/java/com/hotels/styx/api/service/Certificate.java
+++ b/components/api/src/main/java/com/hotels/styx/api/service/Certificate.java
@@ -18,7 +18,7 @@ package com.hotels.styx.api.service;
 
 import java.util.Objects;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**

--- a/components/api/src/main/java/com/hotels/styx/api/service/ConnectionPoolSettings.java
+++ b/components/api/src/main/java/com/hotels/styx/api/service/ConnectionPoolSettings.java
@@ -20,8 +20,8 @@ import com.hotels.styx.api.client.ConnectionPool;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Objects.firstNonNull;
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Programmatically configurable connection pool settings.

--- a/components/api/src/main/java/com/hotels/styx/api/service/HealthCheckConfig.java
+++ b/components/api/src/main/java/com/hotels/styx/api/service/HealthCheckConfig.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;

--- a/components/api/src/main/java/com/hotels/styx/api/service/RewriteConfig.java
+++ b/components/api/src/main/java/com/hotels/styx/api/service/RewriteConfig.java
@@ -24,7 +24,7 @@ import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.lang.Integer.parseInt;
 import static java.util.Arrays.asList;
 import static java.util.regex.Pattern.compile;

--- a/components/api/src/main/java/com/hotels/styx/api/service/StickySessionConfig.java
+++ b/components/api/src/main/java/com/hotels/styx/api/service/StickySessionConfig.java
@@ -15,8 +15,7 @@
  */
 package com.hotels.styx.api.service;
 
-import com.google.common.base.Objects;
-
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -71,7 +70,7 @@ public class StickySessionConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.enabled, this.timeoutSeconds);
+        return Objects.hash(this.enabled, this.timeoutSeconds);
     }
 
     @Override

--- a/components/api/src/main/java/com/hotels/styx/api/service/TlsSettings.java
+++ b/components/api/src/main/java/com/hotels/styx/api/service/TlsSettings.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import static com.google.common.base.Objects.firstNonNull;
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Collections.emptySet;
 

--- a/components/api/src/test/java/com/hotels/styx/api/SimpleEnvironment.java
+++ b/components/api/src/test/java/com/hotels/styx/api/SimpleEnvironment.java
@@ -20,7 +20,7 @@ import com.hotels.styx.api.configuration.Configuration;
 import com.hotels.styx.api.metrics.MetricRegistry;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 
-import static com.google.common.base.Objects.firstNonNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.hotels.styx.api.configuration.Configuration.EMPTY_CONFIGURATION;
 
 /**

--- a/components/client/src/main/java/com/hotels/styx/client/HttpConfig.java
+++ b/components/client/src/main/java/com/hotels/styx/client/HttpConfig.java
@@ -18,7 +18,7 @@ package com.hotels.styx.client;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import static com.google.common.base.Objects.firstNonNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 

--- a/components/client/src/main/java/com/hotels/styx/client/StyxHeaderConfig.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHeaderConfig.java
@@ -17,8 +17,9 @@ package com.hotels.styx.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import io.netty.util.AsciiString;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Contains the names for the headers that Styx will add to proxied requests/responses.
@@ -83,7 +84,7 @@ public class StyxHeaderConfig {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return toStringHelper(this)
                 .add("styxInfoHeaderName", styxInfoHeaderName)
                 .add("originIdHeaderName", originIdHeaderName)
                 .add("requestIdHeaderName", requestIdHeaderName)

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/CloseAfterUseConnectionDestination.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/CloseAfterUseConnectionDestination.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client.connectionpool;
 
-import com.google.common.base.Objects;
 import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.ConnectionDestination;
 import com.hotels.styx.api.client.Origin;
@@ -26,9 +25,10 @@ import com.hotels.styx.client.netty.connectionpool.HttpRequestOperation;
 import com.hotels.styx.client.netty.connectionpool.NettyConnectionFactory;
 import rx.Observable;
 
+import java.util.Objects;
 import java.util.function.Function;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static rx.Observable.error;
 
@@ -99,7 +99,7 @@ public class CloseAfterUseConnectionDestination implements ConnectionDestination
             return false;
         }
         CloseAfterUseConnectionDestination other = (CloseAfterUseConnectionDestination) obj;
-        return Objects.equal(this.origin, other.origin);
+        return Objects.equals(this.origin, other.origin);
     }
 
     @Override

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
@@ -18,7 +18,6 @@ package com.hotels.styx.client.connectionpool;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.SlidingWindowReservoir;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
 import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.ConnectionPool;
 import com.hotels.styx.api.client.Origin;
@@ -26,6 +25,7 @@ import org.slf4j.Logger;
 import rx.Observable;
 import rx.Subscriber;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static com.hotels.styx.client.connectionpool.ConnectionPoolStatsCounter.NULL_CONNECTION_POOL_STATS;
@@ -253,7 +253,7 @@ public class SimpleConnectionPool implements ConnectionPool, Comparable<Connecti
             return false;
         }
         SimpleConnectionPool other = (SimpleConnectionPool) obj;
-        return Objects.equal(this.origin, other.origin);
+        return Objects.equals(this.origin, other.origin);
     }
 
     @Override

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/stubs/StubConnectionFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/stubs/StubConnectionFactory.java
@@ -22,7 +22,7 @@ import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.Origin;
 import rx.Observable;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * A stub {@link Connection.Factory}.

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/FlowControllingHttpContentProducer.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/FlowControllingHttpContentProducer.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.LongUnaryOperator;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hotels.styx.client.netty.connectionpool.FlowControllingHttpContentProducer.ProducerState.BUFFERING;
 import static com.hotels.styx.client.netty.connectionpool.FlowControllingHttpContentProducer.ProducerState.BUFFERING_COMPLETED;

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/HttpRequestOperation.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/HttpRequestOperation.java
@@ -46,7 +46,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hotels.styx.api.HttpHeaderNames.COOKIE;
 import static com.hotels.styx.api.HttpHeaderNames.HOST;

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnection.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnection.java
@@ -30,7 +30,7 @@ import rx.Observable;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**

--- a/components/client/src/main/java/com/hotels/styx/client/origincommands/OriginCommand.java
+++ b/components/client/src/main/java/com/hotels/styx/client/origincommands/OriginCommand.java
@@ -19,7 +19,7 @@ import com.hotels.styx.api.Id;
 
 import java.util.Objects;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.hash;
 

--- a/components/client/src/main/java/com/hotels/styx/client/retry/RetryNTimes.java
+++ b/components/client/src/main/java/com/hotels/styx/client/retry/RetryNTimes.java
@@ -22,7 +22,7 @@ import com.hotels.styx.api.netty.exceptions.IsRetryableException;
 
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.Sets.newHashSet;
 
 /**

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/StubConnectionPool.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/StubConnectionPool.java
@@ -15,14 +15,15 @@
  */
 package com.hotels.styx.client.netty.connectionpool;
 
-import com.google.common.base.Objects;
 import com.hotels.styx.api.client.Connection;
 import com.hotels.styx.api.client.ConnectionPool;
 import com.hotels.styx.api.client.Origin;
 import com.hotels.styx.client.connectionpool.stubs.StubConnectionFactory;
 import rx.Observable;
 
-import static com.google.common.base.Objects.toStringHelper;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.hotels.styx.api.service.ConnectionPoolSettings.defaultConnectionPoolSettings;
 import static rx.Observable.just;
 
@@ -159,7 +160,7 @@ public class StubConnectionPool implements ConnectionPool, Comparable<Connection
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(origin, busyConnectionCount, pendingConnectionCount, timeToFirstByte);
+        return Objects.hash(origin, busyConnectionCount, pendingConnectionCount, timeToFirstByte);
     }
 
     @Override
@@ -171,10 +172,10 @@ public class StubConnectionPool implements ConnectionPool, Comparable<Connection
             return false;
         }
         StubConnectionPool other = (StubConnectionPool) obj;
-        return Objects.equal(this.origin, other.origin) &&
-                Objects.equal(this.busyConnectionCount, other.busyConnectionCount) &&
-                Objects.equal(this.pendingConnectionCount, other.pendingConnectionCount) &&
-                Objects.equal(this.timeToFirstByte, other.timeToFirstByte);
+        return Objects.equals(this.origin, other.origin) &&
+                Objects.equals(this.busyConnectionCount, other.busyConnectionCount) &&
+                Objects.equals(this.pendingConnectionCount, other.pendingConnectionCount) &&
+                Objects.equals(this.timeToFirstByte, other.timeToFirstByte);
     }
 
     @Override

--- a/components/proxy/src/main/java/com/hotels/styx/AggregatedConfiguration.java
+++ b/components/proxy/src/main/java/com/hotels/styx/AggregatedConfiguration.java
@@ -20,7 +20,7 @@ import com.hotels.styx.api.configuration.ConversionException;
 
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**

--- a/components/proxy/src/main/java/com/hotels/styx/StartupConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StartupConfig.java
@@ -15,12 +15,12 @@
  */
 package com.hotels.styx;
 
-import com.google.common.base.Objects;
 import com.hotels.styx.api.Resource;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.hotels.styx.api.io.ResourceFactory.newResource;
@@ -97,7 +97,7 @@ public final class StartupConfig {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return toStringHelper(this)
                 .add(STYX_HOME_VAR_NAME, styxHome)
                 .add(CONFIG_FILE_LOCATION_VAR_NAME, configFileLocation)
                 .add(LOGBACK_CONFIG_LOCATION_VAR_NAME, logConfigLocation)

--- a/components/proxy/src/main/java/com/hotels/styx/Version.java
+++ b/components/proxy/src/main/java/com/hotels/styx/Version.java
@@ -25,7 +25,7 @@ import java.io.Reader;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.lang.Integer.parseInt;
 import static org.slf4j.LoggerFactory.getLogger;
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerConfig.java
@@ -25,7 +25,7 @@ import com.hotels.styx.server.netty.NettyServerConfig;
 import java.time.Duration;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.firstNonNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 /**
  * xConfigurations for the Admin Server.

--- a/components/proxy/src/main/java/com/hotels/styx/applications/BackendServices.java
+++ b/components/proxy/src/main/java/com/hotels/styx/applications/BackendServices.java
@@ -17,7 +17,6 @@ package com.hotels.styx.applications;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.hotels.styx.api.Id;
 import com.hotels.styx.api.client.Origin;
@@ -26,9 +25,10 @@ import com.hotels.styx.api.service.BackendService;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getFirst;
 import static com.hotels.styx.api.client.Origin.newOriginBuilder;
@@ -162,6 +162,6 @@ public final class BackendServices implements Iterable<BackendService> {
             return false;
         }
         BackendServices other = (BackendServices) obj;
-        return Objects.equal(this.backendServices, other.backendServices);
+        return Objects.equals(this.backendServices, other.backendServices);
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteConfig.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistry.java
@@ -40,7 +40,7 @@ import java.util.function.Predicate;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.AUTO_CLOSE_SOURCE;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Throwables.propagate;
 import static com.hotels.styx.api.io.ResourceFactory.newResource;
 import static com.hotels.styx.api.service.spi.Registry.Outcome.FAILED;

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/PluginsMetadata.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/PluginsMetadata.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hotels.styx.common.Pair.pair;

--- a/components/proxy/src/main/java/com/hotels/styx/spi/config/ServiceFactoryConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/spi/config/ServiceFactoryConfig.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/components/proxy/src/main/java/com/hotels/styx/spi/config/SpiExtension.java
+++ b/components/proxy/src/main/java/com/hotels/styx/spi/config/SpiExtension.java
@@ -21,12 +21,12 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.base.Objects;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Throwables.propagate;
 import static java.util.Objects.requireNonNull;
 
@@ -85,7 +85,7 @@ public class SpiExtension {
             return false;
         }
         SpiExtension other = (SpiExtension) obj;
-        return Objects.equal(this.factory, other.factory);
+        return Objects.equals(this.factory, other.factory);
     }
 
     @Override

--- a/components/proxy/src/main/java/com/hotels/styx/spi/config/SpiExtensionFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/spi/config/SpiExtensionFactory.java
@@ -16,9 +16,10 @@
 package com.hotels.styx.spi.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
-import static com.google.common.base.Objects.toStringHelper;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -45,7 +46,7 @@ public class SpiExtensionFactory {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(factoryClass, classPath);
+        return Objects.hash(factoryClass, classPath);
     }
 
     @Override
@@ -57,8 +58,8 @@ public class SpiExtensionFactory {
             return false;
         }
         SpiExtensionFactory other = (SpiExtensionFactory) obj;
-        return Objects.equal(this.factoryClass, other.factoryClass)
-                && Objects.equal(this.classPath, other.classPath);
+        return Objects.equals(this.factoryClass, other.factoryClass)
+                && Objects.equals(this.classPath, other.classPath);
     }
 
     @Override

--- a/components/proxy/src/test/java/com/hotels/styx/infrastructure/configuration/yaml/JsonTreeTraversalTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/infrastructure/configuration/yaml/JsonTreeTraversalTest.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.base.Objects;
 import com.hotels.styx.support.matchers.IsOptional;
 import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
@@ -34,9 +33,10 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.hotels.styx.infrastructure.configuration.yaml.JsonTreeTraversal.traverseJsonTree;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -111,13 +111,13 @@ public class JsonTreeTraversalTest {
         protected boolean matchesSafely(PathElement item) {
             if (item instanceof ArrayIndex) {
                 ArrayIndex arrayIndex = (ArrayIndex) item;
-                return Objects.equal(arrayIndex.index(), expected);
+                return Objects.equals(arrayIndex.index(), expected);
             }
 
             if (item instanceof ObjectField) {
                 ObjectField objectField = (ObjectField) item;
 
-                return Objects.equal(objectField.name(), expected);
+                return Objects.equals(objectField.name(), expected);
             }
 
             return false;

--- a/components/proxy/src/test/java/com/hotels/styx/infrastructure/configuration/yaml/YamlConfigurationTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/infrastructure/configuration/yaml/YamlConfigurationTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.hotels.styx.infrastructure.configuration.ConfigurationSource.configSource;
 import static com.hotels.styx.infrastructure.configuration.yaml.YamlConfigurationFormat.YAML;
 import static com.hotels.styx.support.matchers.IsOptional.isAbsent;

--- a/components/server/src/main/java/com/hotels/styx/server/HttpConnectorConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpConnectorConfig.java
@@ -16,7 +16,10 @@
 package com.hotels.styx.server;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Http Connector config.
@@ -57,13 +60,13 @@ public class HttpConnectorConfig implements ConnectorConfig {
             return false;
         }
         final HttpConnectorConfig other = (HttpConnectorConfig) obj;
-        return Objects.equal(this.port, other.port);
+        return Objects.equals(this.port, other.port);
     }
 
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return toStringHelper(this)
                 .add("port", port)
                 .toString();
     }

--- a/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
@@ -18,15 +18,15 @@ package com.hotels.styx.server;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.common.Joiners;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.hotels.styx.api.io.ResourceFactory.newResource;
@@ -90,7 +90,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
 
     @Override
     public int hashCode() {
-        return 31 * super.hashCode() + Objects.hashCode(sslProvider, certificateFile, certificateKeyFile, sessionTimeoutMillis, sessionCacheSize, protocols);
+        return 31 * super.hashCode() + Objects.hash(sslProvider, certificateFile, certificateKeyFile, sessionTimeoutMillis, sessionCacheSize, protocols);
     }
 
     @Override
@@ -105,12 +105,12 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
             return false;
         }
         HttpsConnectorConfig other = (HttpsConnectorConfig) obj;
-        return Objects.equal(this.sslProvider, other.sslProvider)
-                && Objects.equal(this.certificateFile, other.certificateFile)
-                && Objects.equal(this.certificateKeyFile, other.certificateKeyFile)
-                && Objects.equal(this.sessionTimeoutMillis, other.sessionTimeoutMillis)
-                && Objects.equal(this.sessionCacheSize, other.sessionCacheSize)
-                && Objects.equal(this.protocols, other.protocols);
+        return Objects.equals(this.sslProvider, other.sslProvider)
+                && Objects.equals(this.certificateFile, other.certificateFile)
+                && Objects.equals(this.certificateKeyFile, other.certificateKeyFile)
+                && Objects.equals(this.sessionTimeoutMillis, other.sessionTimeoutMillis)
+                && Objects.equals(this.sessionCacheSize, other.sessionCacheSize)
+                && Objects.equals(this.protocols, other.protocols);
     }
 
     @Override

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerBuilder.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerBuilder.java
@@ -29,7 +29,7 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.firstNonNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newCopyOnWriteArrayList;

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerConfig.java
@@ -26,8 +26,7 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Objects.firstNonNull;
-
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.lang.Math.max;
 import static java.lang.Runtime.getRuntime;
 import static java.lang.String.format;

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <netty-tcnative.classifier>linux-x86_64</netty-tcnative.classifier>
 
     <!-- General Versions -->
-    <guava.version>16.0.1</guava.version>
+    <guava.version>18.0</guava.version>
     <guice.version>3.0</guice.version>
     <jackson.version>2.7.5</jackson.version>
     <jackson.dataformat.version>2.5.1</jackson.dataformat.version>

--- a/support/api-testsupport/src/main/java/com/hotels/styx/support/api/SimpleEnvironment.java
+++ b/support/api-testsupport/src/main/java/com/hotels/styx/support/api/SimpleEnvironment.java
@@ -21,7 +21,7 @@ import com.hotels.styx.api.configuration.Configuration;
 import com.hotels.styx.api.metrics.MetricRegistry;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 
-import static com.google.common.base.Objects.firstNonNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.hotels.styx.api.configuration.Configuration.EMPTY_CONFIGURATION;
 
 /**

--- a/support/testsupport/src/main/java/com/hotels/styx/support/matchers/IsOptional.java
+++ b/support/testsupport/src/main/java/com/hotels/styx/support/matchers/IsOptional.java
@@ -15,11 +15,11 @@
  */
 package com.hotels.styx.support.matchers;
 
-import com.google.common.base.Objects;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -49,7 +49,7 @@ public final class IsOptional<T> extends TypeSafeMatcher<Optional<? extends T>> 
      * Checks that the passed Option is Some and that the contains value matches
      * {@code value} based on {@code Objects.equal}
      *
-     * @see Objects#equal(Object, Object)
+     * @see Objects#equals(Object, Object)
      */
     public static <T> IsOptional<T> isValue(T value) {
         return new IsOptional<>(value);
@@ -104,7 +104,7 @@ public final class IsOptional<T> extends TypeSafeMatcher<Optional<? extends T>> 
         if (!someExpected) {
             return !item.isPresent();
         } else if (expected.isPresent()) {
-            return item.isPresent() && Objects.equal(item.get(), expected.get());
+            return item.isPresent() && Objects.equals(item.get(), expected.get());
         } else if (matcher.isPresent()) {
             return item.isPresent() && matcher.get().matches(item.get());
         } else {


### PR DESCRIPTION
Upgrade to Google Guava v 18.

Also: 
1. Substitute Guava `Objects.hashCode` & `Objects.equals` to use equivalent from `java.util.Objects`.
2. Use `toStringHelper` and `firstNonNull` from Guava `MoreObjects`.
