### PR TITLE
Tidy up cookies API

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/cookies/RequestCookie.java
+++ b/components/api/src/main/java/com/hotels/styx/api/cookies/RequestCookie.java
@@ -15,13 +15,14 @@
  */
 package com.hotels.styx.api.cookies;
 
-import com.google.common.base.Objects;
+
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -49,7 +50,7 @@ public final class RequestCookie {
         requireNonNull(value, "value cannot be null");
         this.name = name;
         this.value = value;
-        this.hashCode = Objects.hashCode(name, value);
+        this.hashCode = Objects.hash(name, value);
     }
 
     /**
@@ -142,7 +143,7 @@ public final class RequestCookie {
             return false;
         }
         RequestCookie other = (RequestCookie) obj;
-        return Objects.equal(name, other.name) && Objects.equal(value, other.value);
+        return Objects.equals(name, other.name) && Objects.equals(value, other.value);
     }
 
     @Override

--- a/components/api/src/main/java/com/hotels/styx/api/cookies/ResponseCookie.java
+++ b/components/api/src/main/java/com/hotels/styx/api/cookies/ResponseCookie.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Objects.toStringHelper;
 import static io.netty.handler.codec.http.cookie.Cookie.UNDEFINED_MAX_AGE;
 import static java.util.Objects.hash;
 import static java.util.Objects.requireNonNull;
@@ -224,20 +223,21 @@ public final class ResponseCookie {
 
     @Override
     public int hashCode() {
-        return hash(name, value, domain, maxAge, path, httpOnly, secure);
+        return hashCode;
     }
 
     @Override
     public String toString() {
-        return toStringHelper(this)
-                .add("name", name)
-                .add("value", value)
-                .add("domain", domain)
-                .add("maxAge", maxAge)
-                .add("path", path)
-                .add("httpOnly", httpOnly)
-                .add("secure", secure)
-                .toString();
+        final StringBuilder sb = new StringBuilder("ResponseCookie{");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", value='").append(value).append('\'');
+        sb.append(", domain='").append(domain).append('\'');
+        sb.append(", maxAge=").append(maxAge);
+        sb.append(", path='").append(path).append('\'');
+        sb.append(", httpOnly=").append(httpOnly);
+        sb.append(", secure=").append(secure);
+        sb.append('}');
+        return sb.toString();
     }
 
     /**

--- a/components/api/src/main/java/com/hotels/styx/api/cookies/ResponseCookie.java
+++ b/components/api/src/main/java/com/hotels/styx/api/cookies/ResponseCookie.java
@@ -228,16 +228,15 @@ public final class ResponseCookie {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ResponseCookie{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", value='").append(value).append('\'');
-        sb.append(", domain='").append(domain).append('\'');
-        sb.append(", maxAge=").append(maxAge);
-        sb.append(", path='").append(path).append('\'');
-        sb.append(", httpOnly=").append(httpOnly);
-        sb.append(", secure=").append(secure);
-        sb.append('}');
-        return sb.toString();
+        return "ResponseCookie{"
+                + "name='" + name + '\''
+                + ", value='" + value + '\''
+                + ", domain='" + domain + '\''
+                + ", maxAge=" + maxAge
+                + ", path='" + path + '\''
+                + ", httpOnly=" + httpOnly
+                + ", secure=" + secure
+                + '}';
     }
 
     /**

--- a/components/api/src/main/java/com/hotels/styx/api/cookies/ServerCookieEncoder.java
+++ b/components/api/src/main/java/com/hotels/styx/api/cookies/ServerCookieEncoder.java
@@ -52,15 +52,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * </pre>
  *
  */
-public final class ServerCookieEncoder extends CookieEncoder {
-
-    /**
-     * Strict encoder that validates that name and value chars are in the valid scope
-     * defined in RFC6265, and (for methods that accept multiple cookies) that only
-     * one cookie is encoded with any given name. (If multiple cookies have the same
-     * name, the last one is the one that is encoded.)
-     */
-    public static final ServerCookieEncoder STRICT = new ServerCookieEncoder(true);
+final class ServerCookieEncoder extends CookieEncoder {
 
     /**
      * Lax instance that doesn't validate name and value, and that allows multiple


### PR DESCRIPTION
- Use `java.util.Objects` instead of Guava.
- Replace Guava-generated toString method.
- Restrict visibility of `ServerCookieEncoder` class