### PR TITLE
Remove leaking Netty definition from HttpMessageSupport class.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/HttpMessageSupport.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpMessageSupport.java
@@ -15,7 +15,7 @@
  */
 package com.hotels.styx.api;
 
-import io.netty.handler.codec.http.HttpVersion;
+import com.hotels.styx.api.messages.HttpVersion;
 
 import java.util.Optional;
 
@@ -42,20 +42,6 @@ public final class HttpMessageSupport {
     }
 
     public static boolean keepAlive(HttpHeaders headers, HttpVersion version) {
-        Optional<String> connection = headers.get(CONNECTION);
-
-        if (connection.isPresent()) {
-            if (CLOSE.toString().equalsIgnoreCase(connection.get())) {
-                return false;
-            }
-            if (KEEP_ALIVE.toString().equalsIgnoreCase(connection.get())) {
-                return true;
-            }
-        }
-        return version.isKeepAliveDefault();
-    }
-
-    public static boolean keepAlive(HttpHeaders headers, com.hotels.styx.api.messages.HttpVersion version) {
         Optional<String> connection = headers.get(CONNECTION);
 
         if (connection.isPresent()) {

--- a/components/api/src/test/java/com/hotels/styx/api/HttpMessageSupportTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpMessageSupportTest.java
@@ -24,8 +24,8 @@ import static com.hotels.styx.api.HttpHeaderValues.CLOSE;
 import static com.hotels.styx.api.HttpHeaderValues.KEEP_ALIVE;
 import static com.hotels.styx.api.HttpMessageSupport.chunked;
 import static com.hotels.styx.api.HttpMessageSupport.keepAlive;
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_0;
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static com.hotels.styx.api.messages.HttpVersion.HTTP_1_0;
+import static com.hotels.styx.api.messages.HttpVersion.HTTP_1_1;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 


### PR DESCRIPTION
`HttpMessageSupport.keepAlive` had an overloaded version which used Netty types instead of styx types. Remove this ahead of 1.0 api version.
