### PR TITLE
#235 - Removed unused method

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/StyxHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHttpClient.java
@@ -77,7 +77,7 @@ public final class StyxHttpClient implements HttpClient {
     private final StickySessionConfig stickySessionConfig;
 
     private StyxHttpClient(Builder builder) {
-        this.id = requireNonNull(builder.applicationId);
+        this.id = requireNonNull(builder.backendServiceId);
 
         this.stickySessionConfig = requireNonNull(builder.stickySessionConfig);
 
@@ -107,8 +107,8 @@ public final class StyxHttpClient implements HttpClient {
      *
      * @return a new builder
      */
-    public static Builder newHttpClientBuilder(Id applicationId) {
-        return new Builder(applicationId);
+    public static Builder newHttpClientBuilder(Id backendServiceId) {
+        return new Builder(backendServiceId);
     }
 
     private static boolean isError(HttpResponseStatus status) {
@@ -335,7 +335,7 @@ public final class StyxHttpClient implements HttpClient {
      */
     public static class Builder {
 
-        private final Id applicationId;
+        private final Id backendServiceId;
         private MetricRegistry metricsRegistry = new CodaHaleMetricRegistry();
         private List<RewriteRule> rewriteRules = emptyList();
         private RetryPolicy retryPolicy = new RetryNTimes(3);
@@ -345,8 +345,8 @@ public final class StyxHttpClient implements HttpClient {
         private String originsRestrictionCookieName;
         private StickySessionConfig stickySessionConfig = stickySessionDisabled();
 
-        public Builder(Id applicationId) {
-            this.applicationId = requireNonNull(applicationId);
+        public Builder(Id backendServiceId) {
+            this.backendServiceId = requireNonNull(backendServiceId);
         }
 
         public Builder stickySessionConfig(StickySessionConfig stickySessionConfig) {
@@ -396,7 +396,6 @@ public final class StyxHttpClient implements HttpClient {
             }
             return new StyxHttpClient(this);
         }
-
 
     }
 }

--- a/components/client/src/main/java/com/hotels/styx/client/StyxHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHttpClient.java
@@ -350,6 +350,7 @@ public final class StyxHttpClient implements HttpClient {
         public Builder stickySessionConfig(StickySessionConfig stickySessionConfig) {
             this.stickySessionConfig = requireNonNull(stickySessionConfig);
             return this;
+        }
 
         public Builder metricsRegistry(MetricRegistry metricsRegistry) {
             this.metricsRegistry = requireNonNull(metricsRegistry);

--- a/components/client/src/main/java/com/hotels/styx/client/StyxHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHttpClient.java
@@ -99,9 +99,6 @@ public final class StyxHttpClient implements HttpClient {
         return sendRequest(rewriteUrl(request), new ArrayList<>(), 0);
     }
 
-    public boolean isHttps() {
-        return backendService.tlsSettings().isPresent();
-    }
 
     /**
      * Create a new builder.

--- a/components/client/src/main/java/com/hotels/styx/client/StyxHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHttpClient.java
@@ -96,7 +96,6 @@ public final class StyxHttpClient implements HttpClient {
         this.originsRestrictionCookieName = builder.originsRestrictionCookieName;
     }
 
-
     @Override
     public Observable<HttpResponse> sendRequest(HttpRequest request) {
         return sendRequest(rewriteUrl(request), new ArrayList<>(), 0);
@@ -190,7 +189,6 @@ public final class StyxHttpClient implements HttpClient {
         } else {
             return Observable.error(cause);
         }
-
     }
 
     private static final class RetryPolicyContext implements RetryPolicy.Context {
@@ -352,7 +350,6 @@ public final class StyxHttpClient implements HttpClient {
         public Builder stickySessionConfig(StickySessionConfig stickySessionConfig) {
             this.stickySessionConfig = requireNonNull(stickySessionConfig);
             return this;
-
 
         public Builder metricsRegistry(MetricRegistry metricsRegistry) {
             this.metricsRegistry = requireNonNull(metricsRegistry);

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/HttpClientSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/HttpClientSpec.scala
@@ -74,7 +74,7 @@ class HttpClientSpec extends FunSuite with BeforeAndAfterAll with ShouldMatchers
       .responseTimeoutMillis(responseTimeout)
       .build()
 
-    client = newHttpClientBuilder(backendService)
+    client = newHttpClientBuilder(backendService.id())
       .loadBalancer(busyConnectionStrategy(activeOrigins(backendService)))
       .build
   }

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/RetryHandlingSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/RetryHandlingSpec.scala
@@ -126,7 +126,7 @@ class RetryHandlingSpec extends FunSuite with BeforeAndAfterAll with Matchers wi
       .origins(unhealthyOriginOne, unhealthyOriginTwo, unhealthyOriginThree, healthyOriginTwo)
       .build()
 
-    val client: StyxHttpClient = newHttpClientBuilder(backendService)
+    val client: StyxHttpClient = newHttpClientBuilder(backendService.id)
       .retryPolicy(new RetryNTimes(3))
       .loadBalancer(stickySessionStrategy(activeOrigins(backendService)))
       .build
@@ -139,7 +139,7 @@ class RetryHandlingSpec extends FunSuite with BeforeAndAfterAll with Matchers wi
     val backendService = new BackendService.Builder()
       .origins(unhealthyOriginOne, unhealthyOriginTwo, unhealthyOriginThree)
       .build()
-    val client: StyxHttpClient = newHttpClientBuilder(backendService)
+    val client: StyxHttpClient = newHttpClientBuilder(backendService.id)
       .loadBalancer(stickySessionStrategy(activeOrigins(backendService)))
       .retryPolicy(new RetryNTimes(2))
       .build
@@ -155,7 +155,7 @@ class RetryHandlingSpec extends FunSuite with BeforeAndAfterAll with Matchers wi
       .stickySessionConfig(StickySessionEnabled)
       .build()
 
-    val client: StyxHttpClient = newHttpClientBuilder(backendService)
+    val client: StyxHttpClient = newHttpClientBuilder(backendService.id)
       .retryPolicy(new RetryNTimes(3))
       .loadBalancer(stickySessionStrategy(activeOrigins(backendService)))
       .build

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/StickySessionSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/StickySessionSpec.scala
@@ -98,7 +98,7 @@ class StickySessionSpec extends FunSuite with BeforeAndAfter with ShouldMatchers
   def stickySessionStrategy(activeOrigins: ActiveOrigins) = new StickySessionLoadBalancingStrategy(activeOrigins, roundRobinStrategy(activeOrigins))
 
   test("Responds with sticky session cookie when STICKY_SESSION_ENABLED=true") {
-    val client = newHttpClientBuilder(backendService)
+    val client = newHttpClientBuilder(backendService.id)
       .loadBalancer(stickySessionStrategy(activeOrigins(backendService)))
       .build
 
@@ -116,7 +116,7 @@ class StickySessionSpec extends FunSuite with BeforeAndAfter with ShouldMatchers
   }
 
   test("Responds without sticky session cookie when sticky session is not enabled") {
-    val client: StyxHttpClient = newHttpClientBuilder(backendService)
+    val client: StyxHttpClient = newHttpClientBuilder(backendService.id)
       .loadBalancer(roundRobinStrategy(activeOrigins(backendService)))
       .build
 
@@ -129,7 +129,7 @@ class StickySessionSpec extends FunSuite with BeforeAndAfter with ShouldMatchers
   }
 
   test("Routes to origins indicated by sticky session cookie.") {
-    val client: StyxHttpClient = newHttpClientBuilder(backendService)
+    val client: StyxHttpClient = newHttpClientBuilder(backendService.id)
       .loadBalancer(stickySessionStrategy(activeOrigins(backendService)))
       .build
 
@@ -147,7 +147,7 @@ class StickySessionSpec extends FunSuite with BeforeAndAfter with ShouldMatchers
   }
 
   test("Routes to origins indicated by sticky session cookie when other cookies are provided.") {
-    val client: StyxHttpClient = newHttpClientBuilder(backendService)
+    val client: StyxHttpClient = newHttpClientBuilder(backendService.id)
       .loadBalancer(stickySessionStrategy(activeOrigins(backendService)))
       .build
 
@@ -169,7 +169,7 @@ class StickySessionSpec extends FunSuite with BeforeAndAfter with ShouldMatchers
   }
 
   test("Routes to new origin when the origin indicated by sticky session cookie does not exist.") {
-    val client: StyxHttpClient = newHttpClientBuilder(backendService)
+    val client: StyxHttpClient = newHttpClientBuilder(backendService.id)
       .loadBalancer(stickySessionStrategy(activeOrigins(backendService)))
       .build
 
@@ -194,7 +194,7 @@ class StickySessionSpec extends FunSuite with BeforeAndAfter with ShouldMatchers
   test("Routes to new origin when the origin indicated by sticky session cookie is no longer available.") {
     server1.stop()
 
-    val client: StyxHttpClient = newHttpClientBuilder(backendService)
+    val client: StyxHttpClient = newHttpClientBuilder(backendService.id)
       .loadBalancer(stickySessionStrategy(activeOrigins(backendService)))
       .build
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxHttpClientTest.java
@@ -101,7 +101,7 @@ public class StyxHttpClientTest {
     public void sendsRequestToHostChosenByLoadBalancer() {
         StyxHostHttpClient hostClient = mockHostClient(just(response(OK).build()));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .metricsRegistry(metricRegistry)
                 .loadBalancer(
                         mockLoadBalancer(
@@ -120,7 +120,7 @@ public class StyxHttpClientTest {
         RetryPolicy retryPolicy = mockRetryPolicy(true, true, true);
         StyxHostHttpClient hostClient = mockHostClient(just(response(OK).build()));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .metricsRegistry(metricRegistry)
                 .loadBalancer(
                         mockLoadBalancer(
@@ -158,7 +158,7 @@ public class StyxHttpClientTest {
 
         StyxHostHttpClient secondClient = mockHostClient(just(response(OK).build()));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .metricsRegistry(metricRegistry)
                 .loadBalancer(
                         mockLoadBalancer(
@@ -198,7 +198,7 @@ public class StyxHttpClientTest {
         StyxHostHttpClient secondClient = mockHostClient(Observable.error(new OriginUnreachableException(ORIGIN_2, new RuntimeException("An error occurred"))));
         StyxHostHttpClient thirdClient = mockHostClient(Observable.error(new OriginUnreachableException(ORIGIN_2, new RuntimeException("An error occurred"))));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .metricsRegistry(metricRegistry)
                 .loadBalancer(
                         mockLoadBalancer(
@@ -230,7 +230,7 @@ public class StyxHttpClientTest {
         StyxHostHttpClient thirdClient = mockHostClient(Observable.error(new OriginUnreachableException(ORIGIN_3, new RuntimeException("An error occurred"))));
         StyxHostHttpClient fourthClient = mockHostClient(Observable.error(new OriginUnreachableException(ORIGIN_4, new RuntimeException("An error occurred"))));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .metricsRegistry(metricRegistry)
                 .loadBalancer(
                         mockLoadBalancer(
@@ -262,7 +262,7 @@ public class StyxHttpClientTest {
     public void incrementsResponseStatusMetricsForBadResponse() {
         StyxHostHttpClient hostClient = mockHostClient(just(response(BAD_REQUEST).build()));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .metricsRegistry(metricRegistry)
                 .loadBalancer(
                         mockLoadBalancer(Optional.of(remoteHost(SOME_ORIGIN, toHandler(hostClient), hostClient))))
@@ -279,7 +279,7 @@ public class StyxHttpClientTest {
     public void incrementsResponseStatusMetricsFor401() {
         StyxHostHttpClient hostClient = mockHostClient(just(response(UNAUTHORIZED).build()));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .metricsRegistry(metricRegistry)
                 .loadBalancer(
                         mockLoadBalancer(Optional.of(remoteHost(SOME_ORIGIN, toHandler(hostClient), hostClient)))
@@ -297,7 +297,7 @@ public class StyxHttpClientTest {
     public void incrementsResponseStatusMetricsFor500() {
         StyxHostHttpClient hostClient = mockHostClient(just(response(INTERNAL_SERVER_ERROR).build()));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .metricsRegistry(metricRegistry)
                 .loadBalancer(
                         mockLoadBalancer(Optional.of(remoteHost(SOME_ORIGIN, toHandler(hostClient), hostClient)))
@@ -315,7 +315,7 @@ public class StyxHttpClientTest {
     public void incrementsResponseStatusMetricsFor501() {
         StyxHostHttpClient hostClient = mockHostClient(just(response(NOT_IMPLEMENTED).build()));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .metricsRegistry(metricRegistry)
                 .loadBalancer(
                         mockLoadBalancer(Optional.of(remoteHost(SOME_ORIGIN, toHandler(hostClient), hostClient)))
@@ -336,7 +336,7 @@ public class StyxHttpClientTest {
                         .addHeader(TRANSFER_ENCODING, CHUNKED)
                         .build()));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService)
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .metricsRegistry(metricRegistry)
                 .loadBalancer(
                         mockLoadBalancer(Optional.of(remoteHost(SOME_ORIGIN, toHandler(hostClient), hostClient)))
@@ -358,7 +358,7 @@ public class StyxHttpClientTest {
         PublishSubject<HttpResponse> responseSubject = PublishSubject.create();
         StyxHostHttpClient hostClient = mockHostClient(responseSubject);
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendWithOrigins(origin.host().getPort()))
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .loadBalancer(
                         mockLoadBalancer(Optional.of(remoteHost(origin, toHandler(hostClient), hostClient)))
                 )
@@ -382,7 +382,7 @@ public class StyxHttpClientTest {
 
         LoadBalancer loadBalancer = mockLoadBalancer(Optional.of(remoteHost(origin, toHandler(hostClient), hostClient)));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendWithOrigins(origin.host().getPort()))
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .loadBalancer(loadBalancer)
                 .metricsRegistry(metricRegistry)
                 .build();
@@ -408,7 +408,7 @@ public class StyxHttpClientTest {
 
         LoadBalancer loadBalancer = mockLoadBalancer(Optional.of(remoteHost(origin, toHandler(hostClient), hostClient)));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendWithOrigins(origin.host().getPort()))
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .loadBalancer(loadBalancer)
                 .metricsRegistry(metricRegistry)
                 .originsRestrictionCookieName("restrictedOrigin")
@@ -434,7 +434,7 @@ public class StyxHttpClientTest {
         StyxHostHttpClient hostClient = mockHostClient(just(response(OK).build()));
         LoadBalancer loadBalancer = mockLoadBalancer(Optional.of(remoteHost(origin, toHandler(hostClient), hostClient)));
 
-        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendWithOrigins(origin.host().getPort()))
+        StyxHttpClient styxHttpClient = new StyxHttpClient.Builder(backendService.id())
                 .originsRestrictionCookieName("restrictedOrigin")
                 .loadBalancer(loadBalancer)
                 .metricsRegistry(metricRegistry)

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/StyxBackendServiceClientFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/StyxBackendServiceClientFactory.java
@@ -71,7 +71,7 @@ public class StyxBackendServiceClientFactory implements BackendServiceClientFact
                 originRestrictionCookie
         );
 
-        return new StyxHttpClient.Builder(backendService)
+        return new StyxHttpClient.Builder(backendService.id())
                 .loadBalancer(loadBalancingStrategy)
                 .metricsRegistry(environment.metricRegistry())
                 .retryPolicy(retryPolicy)

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/StyxBackendServiceClientFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/StyxBackendServiceClientFactory.java
@@ -73,6 +73,7 @@ public class StyxBackendServiceClientFactory implements BackendServiceClientFact
 
         return new StyxHttpClient.Builder(backendService.id())
                 .loadBalancer(loadBalancingStrategy)
+                .stickySessionConfig(backendService.stickySessionConfig())
                 .metricsRegistry(environment.metricRegistry())
                 .retryPolicy(retryPolicy)
                 .enableContentValidation()

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/HttpResponseSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/HttpResponseSpec.scala
@@ -18,6 +18,7 @@ package com.hotels.styx
 import java.nio.charset.StandardCharsets.UTF_8
 
 import com.hotels.styx.api.HttpRequest.get
+import com.hotels.styx.api.Id.id
 import com.hotels.styx.api.extension.ActiveOrigins
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancer
 import com.hotels.styx.api.HttpResponseStatus._
@@ -67,7 +68,7 @@ class HttpResponseSpec extends FunSuite
       origins = Origins(originOne),
       responseTimeout = responseTimeout)
 
-    client = newHttpClientBuilder(backendService.asJava)
+    client = newHttpClientBuilder(id(backendService.appId))
       .loadBalancer(busyConnectionStrategy(activeOrigins(backendService.asJava)))
       .build
   }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/ExpiringConnectionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/ExpiringConnectionSpec.scala
@@ -61,7 +61,7 @@ class ExpiringConnectionSpec extends FunSpec
       .origins(newOriginBuilder("localhost", styxServer.httpPort).build())
       .build()
 
-    pooledClient = newHttpClientBuilder(backendService)
+    pooledClient = newHttpClientBuilder(backendService.id)
       .loadBalancer(roundRobinStrategy(activeOrigins(backendService)))
       .build
   }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/OriginClosesConnectionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/OriginClosesConnectionSpec.scala
@@ -112,7 +112,7 @@ class OriginClosesConnectionSpec extends FunSuite
       origins = Origins(originOne),
       responseTimeout = timeout.milliseconds).asJava
     val styxClient = com.hotels.styx.client.StyxHttpClient.newHttpClientBuilder(
-      backendService)
+      backendService.id)
         .loadBalancer(busyConnectionStrategy(activeOrigins(backendService)))
       .build
 


### PR DESCRIPTION
Removed unused `isHttps()` and removed `BackendService` constructor argument from `StyxHttpClient.Builder` 