### PR TITLE
Fix intermittently failing ChunkedDownloadSpec

### DIFF
--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedDownloadSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedDownloadSpec.scala
@@ -54,6 +54,7 @@ class ChunkedDownloadSpec extends FunSpec
   }
 
   override protected def afterAll(): Unit = {
+    println("metrics: " + styxServer.metricsSnapshot)
     originOneServer.stopAsync().awaitTerminated()
     super.afterAll()
   }
@@ -85,6 +86,9 @@ class ChunkedDownloadSpec extends FunSpec
     }
 
     it("Cancels the HTTP download request when browser closes the connection.") {
+      assert(noBusyConnectionsToOrigin, "Connection remains busy.")
+      assert(noAvailableConnectionsInPool, "Connection was not closed.")
+
       val messageBody = "Foo bar 0123456789012345678901234567890123456789\\n" * 100
       originRespondingWith(response200OkWithSlowChunkedMessageBody(messageBody))
 


### PR DESCRIPTION
Fixes an intermittently failing end-to-end test.

Root cause: Failing assertion was based on origin metrics. However the origin was shared with two other tests which influenced the asserted metric values.

The fix is to add a new backend service that is only used in the failing test, preventing other tests to influence the origin metrics, thus affecting the assertions.
