### PR TITLE
Injectable metricsRegistry

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/MetricRegistry.java
+++ b/components/api/src/main/java/com/hotels/styx/api/MetricRegistry.java
@@ -24,7 +24,6 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistryListener;
 import com.codahale.metrics.Timer;
 
-import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 

--- a/components/api/src/main/java/com/hotels/styx/api/MetricRegistry.java
+++ b/components/api/src/main/java/com/hotels/styx/api/MetricRegistry.java
@@ -200,6 +200,6 @@ public interface MetricRegistry {
      *
      * @return the metrics
      */
-    Map<String, Metric> getMetrics();
+    SortedMap<String, Metric> getMetrics();
 
 }

--- a/components/api/src/main/java/com/hotels/styx/api/MetricRegistry.java
+++ b/components/api/src/main/java/com/hotels/styx/api/MetricRegistry.java
@@ -24,6 +24,7 @@ import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistryListener;
 import com.codahale.metrics.Timer;
 
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 
@@ -192,5 +193,13 @@ public interface MetricRegistry {
      * @return all the timers in the registry
      */
     SortedMap<String, Timer> getTimers(MetricFilter filter);
+
+
+    /**
+     * A map of metric names to metrics.
+     *
+     * @return the metrics
+     */
+    Map<String, Metric> getMetrics();
 
 }

--- a/components/common/src/main/java/com/hotels/styx/api/metrics/ScopedMetricRegistry.java
+++ b/components/common/src/main/java/com/hotels/styx/api/metrics/ScopedMetricRegistry.java
@@ -26,7 +26,6 @@ import com.codahale.metrics.Timer;
 import com.hotels.styx.api.MetricRegistry;
 
 import java.util.List;
-import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 

--- a/components/common/src/main/java/com/hotels/styx/api/metrics/ScopedMetricRegistry.java
+++ b/components/common/src/main/java/com/hotels/styx/api/metrics/ScopedMetricRegistry.java
@@ -186,7 +186,7 @@ public class ScopedMetricRegistry implements MetricRegistry {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
+    public SortedMap<String, Metric> getMetrics() {
         return this.parent.getMetrics();
     }
 }

--- a/components/common/src/main/java/com/hotels/styx/api/metrics/ScopedMetricRegistry.java
+++ b/components/common/src/main/java/com/hotels/styx/api/metrics/ScopedMetricRegistry.java
@@ -26,6 +26,7 @@ import com.codahale.metrics.Timer;
 import com.hotels.styx.api.MetricRegistry;
 
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 
@@ -182,5 +183,10 @@ public class ScopedMetricRegistry implements MetricRegistry {
     @Override
     public SortedMap<String, Timer> getTimers(MetricFilter filter) {
         return this.parent.getTimers(filter);
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        return this.parent.getMetrics();
     }
 }

--- a/components/common/src/main/java/com/hotels/styx/api/metrics/codahale/CodaHaleMetricRegistry.java
+++ b/components/common/src/main/java/com/hotels/styx/api/metrics/codahale/CodaHaleMetricRegistry.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistryListener;
 import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.hotels.styx.api.MetricRegistry;
 import com.hotels.styx.api.metrics.ScopedMetricRegistry;
 
@@ -53,6 +54,7 @@ public class CodaHaleMetricRegistry implements MetricRegistry {
         this(new com.codahale.metrics.MetricRegistry());
     }
 
+    @JsonValue
     public com.codahale.metrics.MetricRegistry getMetricRegistry() {
         return metricRegistry;
     }
@@ -226,5 +228,10 @@ public class CodaHaleMetricRegistry implements MetricRegistry {
         public long getCount() {
             return (long) getSnapshot().size();
         }
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        return metricRegistry.getMetrics();
     }
 }

--- a/components/common/src/main/java/com/hotels/styx/api/metrics/codahale/CodaHaleMetricRegistry.java
+++ b/components/common/src/main/java/com/hotels/styx/api/metrics/codahale/CodaHaleMetricRegistry.java
@@ -23,7 +23,6 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistryListener;
 import com.codahale.metrics.Timer;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.hotels.styx.api.MetricRegistry;
 import com.hotels.styx.api.metrics.ScopedMetricRegistry;
 
@@ -55,7 +54,6 @@ public class CodaHaleMetricRegistry implements MetricRegistry {
         this(new com.codahale.metrics.MetricRegistry());
     }
 
-    @JsonValue
     public com.codahale.metrics.MetricRegistry getMetricRegistry() {
         return metricRegistry;
     }

--- a/components/common/src/main/java/com/hotels/styx/api/metrics/codahale/CodaHaleMetricRegistry.java
+++ b/components/common/src/main/java/com/hotels/styx/api/metrics/codahale/CodaHaleMetricRegistry.java
@@ -30,6 +30,7 @@ import com.hotels.styx.api.metrics.ScopedMetricRegistry;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeMap;
 
 /**
  * A {@link MetricRegistry} that acts as an adapter for Codahale's {@link com.codahale.metrics.MetricRegistry}.
@@ -231,7 +232,7 @@ public class CodaHaleMetricRegistry implements MetricRegistry {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        return metricRegistry.getMetrics();
+    public SortedMap<String, Metric> getMetrics() {
+        return new TreeMap<>(metricRegistry.getMetrics());
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/Environment.java
+++ b/components/proxy/src/main/java/com/hotels/styx/Environment.java
@@ -16,10 +16,11 @@
 package com.hotels.styx;
 
 import com.google.common.eventbus.EventBus;
-import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
-import com.hotels.styx.configstore.ConfigStore;
+import com.hotels.styx.api.MetricRegistry;
 import com.hotels.styx.proxy.HttpErrorStatusCauseLogger;
 import com.hotels.styx.proxy.HttpErrorStatusMetrics;
+import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
+import com.hotels.styx.configstore.ConfigStore;
 import com.hotels.styx.server.HttpErrorStatusListener;
 import com.hotels.styx.server.ServerEnvironment;
 
@@ -76,7 +77,7 @@ public final class Environment implements com.hotels.styx.api.Environment {
     }
 
     @Override
-    public CodaHaleMetricRegistry metricRegistry() {
+    public MetricRegistry metricRegistry() {
         return serverEnvironment.metricRegistry();
     }
 
@@ -94,7 +95,7 @@ public final class Environment implements com.hotels.styx.api.Environment {
      */
     public static class Builder {
         private AggregatedConfiguration aggregatedConfiguration;
-        private CodaHaleMetricRegistry metricRegistry;
+        private MetricRegistry metricRegistry;
         private Version version;
         private EventBus eventBus;
 
@@ -114,7 +115,7 @@ public final class Environment implements com.hotels.styx.api.Environment {
             return this;
         }
 
-        public Builder metricsRegistry(CodaHaleMetricRegistry metricRegistry) {
+        public Builder metricsRegistry(MetricRegistry metricRegistry) {
             this.metricRegistry = metricRegistry;
             return this;
         }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/JVMMetricsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/JVMMetricsHandler.java
@@ -28,6 +28,7 @@ import com.google.common.base.Predicate;
 import com.hotels.styx.api.MetricRegistry;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -157,6 +158,11 @@ public class JVMMetricsHandler extends JsonHandler<MetricRegistry> {
         @Override
         public SortedMap<String, Timer> getTimers(MetricFilter filter) {
             return null;
+        }
+
+        @Override
+        public Map<String, Metric> getMetrics() {
+            return filterKeys(original.getMetrics(), STARTS_WITH_JVM);
         }
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/JVMMetricsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/JVMMetricsHandler.java
@@ -161,7 +161,7 @@ public class JVMMetricsHandler extends JsonHandler<MetricRegistry> {
         }
 
         @Override
-        public Map<String, Metric> getMetrics() {
+        public SortedMap<String, Metric> getMetrics() {
             return filterKeys(original.getMetrics(), STARTS_WITH_JVM);
         }
     }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/JVMMetricsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/JVMMetricsHandler.java
@@ -28,7 +28,6 @@ import com.google.common.base.Predicate;
 import com.hotels.styx.api.MetricRegistry;
 
 import java.time.Duration;
-import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.SortedSet;

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/MetricsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/MetricsHandler.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.admin.handlers;
 
 import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.json.MetricsModule;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,8 +24,8 @@ import com.hotels.styx.api.FullHttpResponse;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
+import com.hotels.styx.api.MetricRegistry;
 import com.hotels.styx.api.StyxObservable;
-import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 
 import java.time.Duration;
 import java.util.Map;
@@ -56,7 +55,7 @@ public class MetricsHandler extends JsonHandler<MetricRegistry> {
     private final ObjectMapper metricSerialiser = new ObjectMapper()
             .registerModule(new MetricsModule(SECONDS, MILLISECONDS, DO_NOT_SHOW_SAMPLES));
 
-    private final CodaHaleMetricRegistry metricRegistry;
+    private final MetricRegistry metricRegistry;
 
     /**
      * Constructs a new handler.
@@ -64,8 +63,8 @@ public class MetricsHandler extends JsonHandler<MetricRegistry> {
      * @param metricRegistry  metrics registry
      * @param cacheExpiration duration for which generated page content should be cached
      */
-    public MetricsHandler(CodaHaleMetricRegistry metricRegistry, Optional<Duration> cacheExpiration) {
-        super(requireNonNull(metricRegistry.getMetricRegistry()), cacheExpiration, new MetricsModule(SECONDS, MILLISECONDS, DO_NOT_SHOW_SAMPLES));
+    public MetricsHandler(MetricRegistry metricRegistry, Optional<Duration> cacheExpiration) {
+        super(requireNonNull(metricRegistry), cacheExpiration, new MetricsModule(SECONDS, MILLISECONDS, DO_NOT_SHOW_SAMPLES));
 
         this.metricRegistry = metricRegistry;
     }
@@ -80,7 +79,7 @@ public class MetricsHandler extends JsonHandler<MetricRegistry> {
     }
 
     private FullHttpResponse.Builder restrictedMetricsResponse(MetricRequest request) {
-        Map<String, Metric> fullMetrics = metricRegistry.getMetricRegistry().getMetrics();
+        Map<String, Metric> fullMetrics = metricRegistry.getMetrics();
 
         Map<String, Metric> restricted = filter(fullMetrics, (name, metric) -> request.matchesRoot(name));
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/MetricsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/MetricsHandler.java
@@ -74,11 +74,13 @@ public class MetricsHandler extends JsonHandler<MetricRegistry> {
 
         this.metricRegistry = metricRegistry;
     }
-    private static class FullMetricsModule extends SimpleModule{
-        FullMetricsModule(){
+
+    private static class FullMetricsModule extends SimpleModule {
+        FullMetricsModule() {
             setMixInAnnotation(CodaHaleMetricRegistry.class, CodaHaleMetricRegistryMixin.class);
         }
     }
+
     @Override
     public StyxObservable<HttpResponse> handle(HttpRequest request, HttpInterceptor.Context context) {
         MetricRequest metricRequest = new MetricRequest(request);

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/json/mixins/CodaHaleMetricRegistryMixin.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/json/mixins/CodaHaleMetricRegistryMixin.java
@@ -1,0 +1,28 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.infrastructure.configuration.json.mixins;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Jackson annotations for {@link com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry}.
+ */
+public abstract class CodaHaleMetricRegistryMixin {
+
+    @JsonValue
+    public abstract com.codahale.metrics.MetricRegistry getMetricRegistry();
+
+}

--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
@@ -22,6 +22,7 @@ import com.google.common.eventbus.AsyncEventBus;
 import com.hotels.styx.Environment;
 import com.hotels.styx.StyxConfig;
 import com.hotels.styx.Version;
+import com.hotels.styx.api.MetricRegistry;
 import com.hotels.styx.api.configuration.Configuration;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
@@ -73,7 +74,7 @@ public class StyxServerComponents {
         return plugins;
     }
 
-    private static Environment newEnvironment(StyxConfig styxConfig, CodaHaleMetricRegistry metricRegistry) {
+    private static Environment newEnvironment(StyxConfig styxConfig, MetricRegistry metricRegistry) {
         return new Environment.Builder()
                 .configuration(styxConfig)
                 .metricsRegistry(metricRegistry)
@@ -109,7 +110,7 @@ public class StyxServerComponents {
         private LoggingSetUp loggingSetUp = DO_NOT_MODIFY;
         private PluginsLoader pluginsLoader = PLUGINS_FROM_CONFIG;
         private ServicesLoader servicesLoader = SERVICES_FROM_CONFIG;
-        private CodaHaleMetricRegistry metricRegistry = new CodaHaleMetricRegistry();
+        private MetricRegistry metricRegistry = new CodaHaleMetricRegistry();
 
         private final Map<String, StyxService> additionalServices = new HashMap<>();
 
@@ -118,7 +119,7 @@ public class StyxServerComponents {
             return this;
         }
 
-        public Builder metricsRegistry(CodaHaleMetricRegistry metricRegistry) {
+        public Builder metricsRegistry(MetricRegistry metricRegistry) {
             this.metricRegistry = requireNonNull(metricRegistry);
             return this;
         }

--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
@@ -50,7 +50,7 @@ public class StyxServerComponents {
     private StyxServerComponents(Builder builder) {
         StyxConfig styxConfig = requireNonNull(builder.styxConfig);
 
-        this.environment = newEnvironment(styxConfig);
+        this.environment = newEnvironment(styxConfig, builder.metricRegistry);
         builder.loggingSetUp.setUp(environment);
 
         this.plugins = builder.pluginsLoader.load(environment);
@@ -73,10 +73,10 @@ public class StyxServerComponents {
         return plugins;
     }
 
-    private static Environment newEnvironment(StyxConfig styxConfig) {
+    private static Environment newEnvironment(StyxConfig styxConfig, CodaHaleMetricRegistry metricRegistry) {
         return new Environment.Builder()
                 .configuration(styxConfig)
-                .metricsRegistry(new CodaHaleMetricRegistry())
+                .metricsRegistry(metricRegistry)
                 .buildInfo(readBuildInfo())
                 .eventBus(new AsyncEventBus("styx", newSingleThreadExecutor()))
                 .build();
@@ -109,11 +109,17 @@ public class StyxServerComponents {
         private LoggingSetUp loggingSetUp = DO_NOT_MODIFY;
         private PluginsLoader pluginsLoader = PLUGINS_FROM_CONFIG;
         private ServicesLoader servicesLoader = SERVICES_FROM_CONFIG;
+        private CodaHaleMetricRegistry metricRegistry = new CodaHaleMetricRegistry();
 
         private final Map<String, StyxService> additionalServices = new HashMap<>();
 
         public Builder styxConfig(StyxConfig styxConfig) {
             this.styxConfig = requireNonNull(styxConfig);
+            return this;
+        }
+
+        public Builder metricsRegistry(CodaHaleMetricRegistry metricRegistry) {
+            this.metricRegistry = requireNonNull(metricRegistry);
             return this;
         }
 

--- a/components/server/src/main/java/com/hotels/styx/server/ServerEnvironment.java
+++ b/components/server/src/main/java/com/hotels/styx/server/ServerEnvironment.java
@@ -16,19 +16,20 @@
 package com.hotels.styx.server;
 
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
+import com.hotels.styx.api.MetricRegistry;
 
 public final class ServerEnvironment {
-    private final CodaHaleMetricRegistry metricRegistry;
+    private final MetricRegistry metricRegistry;
 
     public ServerEnvironment() {
         this(new CodaHaleMetricRegistry());
     }
 
-    public ServerEnvironment(CodaHaleMetricRegistry metricRegistry) {
+    public ServerEnvironment(MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
     }
 
-    public CodaHaleMetricRegistry metricRegistry() {
+    public MetricRegistry metricRegistry() {
         return metricRegistry;
     }
 }


### PR DESCRIPTION
This allows the user to set the metrics registry instead of it being auto created.
Useful for Dependency Injection.