### PR TITLE
Improve Javadocs for styx-api module

### DIFF
--- a/codequality/checkstyle_rules.xml
+++ b/codequality/checkstyle_rules.xml
@@ -24,7 +24,7 @@
     </module>
     <module name="JavadocStyle">
       <property name="severity" value="error"/>
-      <property name="checkEmptyJavadoc" value="true"/>
+      <property name="checkEmptyJavadoc" value="false"/>
     </module>
     <module name="ConstantName">
       <property name="severity" value="error"/>

--- a/components/api/src/main/java/com/hotels/styx/api/ContentOverflowException.java
+++ b/components/api/src/main/java/com/hotels/styx/api/ContentOverflowException.java
@@ -16,7 +16,12 @@
 package com.hotels.styx.api;
 
 /**
- * An exception that indicates that a content-aggregation operation exceeded the maximum permitted amount of content.
+ * Thrown when HTTP content aggregation fails because received more data than excepted.
+ * <p>
+ * A streaming HTTP message can  be aggregated and converted (aggregated) to a
+ * full message. Normally the aggregator methods ({@code HttpRequest.toFullRequest}, {@code HttpResponse.toFullResponse})
+ * receive data from the network. The {@code ContentOverflowException}
+ * is thrown when more data is received than the aggregator expected.
  */
 public class ContentOverflowException extends RuntimeException {
     public ContentOverflowException(String message) {

--- a/components/api/src/main/java/com/hotels/styx/api/ContentOverflowException.java
+++ b/components/api/src/main/java/com/hotels/styx/api/ContentOverflowException.java
@@ -16,12 +16,14 @@
 package com.hotels.styx.api;
 
 /**
- * Thrown when HTTP content aggregation fails because received more data than excepted.
+ * Indicates a content aggregation failure because an aggregator function received
+ * more data than expected.
  * <p>
- * A streaming HTTP message can  be aggregated and converted (aggregated) to a
- * full message. Normally the aggregator methods ({@code HttpRequest.toFullRequest}, {@code HttpResponse.toFullResponse})
- * receive data from the network. The {@code ContentOverflowException}
- * is thrown when more data is received than the aggregator expected.
+ * A streaming HTTP message can be aggregated to a full message.
+ * The aggregator methods {@link HttpRequest#toFullRequest}, and
+ * {@link HttpResponse#toFullResponse} consume data from a network socket or
+ * some other unpredictable source and emit this exception when more data is
+ * received than expected.
  */
 public class ContentOverflowException extends RuntimeException {
     public ContentOverflowException(String message) {

--- a/components/api/src/main/java/com/hotels/styx/api/FullHttpMessage.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FullHttpMessage.java
@@ -25,7 +25,7 @@ import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
 /**
  * All behaviour common to both full requests and full responses.
  */
-public interface FullHttpMessage {
+interface FullHttpMessage {
     /**
      * Returns the protocol version of this.
      *

--- a/components/api/src/main/java/com/hotels/styx/api/FullHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FullHttpRequest.java
@@ -55,7 +55,34 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 
 /**
- * HTTP request with a fully aggregated/decoded body.
+ * An immutable HTTP request object containing a finite size content body in full.
+ * <p>
+ * A {@code FullHttpRequest} is useful for HTTP request messages with
+ * finite body content such as PUT or POST for creating or modifying a RESTful
+ * object.
+ * <p>
+ * FullHttpRequest is immutable. Once created, it is impossible to modify any
+ * request attributes, including body content. However the request can
+ * be transformed to another via {@code FullHttpRequest.Builder}.
+ * <p>
+ * A FullHttpRequest is created via {@code FullHttpRequest.Builder}. A new builder
+ * can be obtained by a call to following static methods:
+ *
+ * <ul>
+ *     <li>{@code get}</li>
+ *     <li>{@code head}</li>
+ *     <li>{@code post}</li>
+ *     <li>{@code put}</li>
+ *     <li>{@code delete}</li>
+ *     <li>{@code patch}</li>
+ * </ul>
+ *
+ * A builder can also be created with one of the {@code Builder} constructors.
+ *
+ * A special method {@code newBuilder} creates a prepopulated {@code Builder}
+ * from the current request object. It is useful for transforming a request
+ * to another one my modifying one or more of its attributes.
+ *
  */
 public class FullHttpRequest implements FullHttpMessage {
     private final Object id;

--- a/components/api/src/main/java/com/hotels/styx/api/FullHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FullHttpRequest.java
@@ -57,7 +57,7 @@ import static java.util.stream.Stream.concat;
 /**
  * An immutable HTTP request object including full body content.
  * <p>
- * A {@link FullHttpRequest} is useful for request messages with a
+ * A {@link FullHttpRequest} is useful for requests with a
  * finite body content, such as when PUT or POST are used to create or
  * modify a RESTful object.
  * <p>

--- a/components/api/src/main/java/com/hotels/styx/api/FullHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FullHttpRequest.java
@@ -55,17 +55,13 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 
 /**
- * An immutable HTTP request object containing a finite size content body in full.
+ * An immutable HTTP request object including full body content.
  * <p>
- * A {@code FullHttpRequest} is useful for HTTP request messages with
- * finite body content such as PUT or POST for creating or modifying a RESTful
- * object.
+ * A {@link FullHttpRequest} is useful for request messages with a
+ * finite body content, such as when PUT or POST are used to create or
+ * modify a RESTful object.
  * <p>
- * FullHttpRequest is immutable. Once created, it is impossible to modify any
- * request attributes, including body content. However the request can
- * be transformed to another via {@code FullHttpRequest.Builder}.
- * <p>
- * A FullHttpRequest is created via {@code FullHttpRequest.Builder}. A new builder
+ * A FullHttpRequest is created via {@link FullHttpRequest.Builder}. A new builder
  * can be obtained by a call to following static methods:
  *
  * <ul>
@@ -79,10 +75,10 @@ import static java.util.stream.Stream.concat;
  *
  * A builder can also be created with one of the {@code Builder} constructors.
  *
- * A special method {@code newBuilder} creates a prepopulated {@code Builder}
- * from the current request object. It is useful for transforming a request
- * to another one my modifying one or more of its attributes.
- *
+ * FullHttpRequest is immutable. Once created it cannot be modified.
+ * However a request can be transformed to another using the {@link this#newBuilder}
+ * method. It creates a new {@link Builder} with all message properties and
+ * body content cloned in.
  */
 public class FullHttpRequest implements FullHttpMessage {
     private final Object id;
@@ -328,7 +324,7 @@ public class FullHttpRequest implements FullHttpMessage {
     /**
      * Converts this request into a streaming form (HttpRequest).
      * <p>
-     * Converts this request into a HttpRequest object which represents the HTTP request as a
+     * Converts this request into an HttpRequest object which represents the HTTP request as a
      * stream of bytes.
      *
      * @return A streaming HttpRequest object.

--- a/components/api/src/main/java/com/hotels/styx/api/FullHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FullHttpRequest.java
@@ -106,7 +106,7 @@ public class FullHttpRequest implements FullHttpMessage {
      * Creates a request with the GET method.
      *
      * @param uri URI
-     * @return {@code this}
+     * @return {@link FullHttpRequest.Builder}
      */
     public static Builder get(String uri) {
         return new Builder(GET, uri);
@@ -116,7 +116,7 @@ public class FullHttpRequest implements FullHttpMessage {
      * Creates a request with the HEAD method.
      *
      * @param uri URI
-     * @return {@code this}
+     * @return {@link FullHttpRequest.Builder}
      */
     public static Builder head(String uri) {
         return new Builder(HEAD, uri);
@@ -126,7 +126,7 @@ public class FullHttpRequest implements FullHttpMessage {
      * Creates a request with the POST method.
      *
      * @param uri URI
-     * @return {@code this}
+     * @return {@link FullHttpRequest.Builder}
      */
     public static Builder post(String uri) {
         return new Builder(POST, uri);
@@ -136,7 +136,7 @@ public class FullHttpRequest implements FullHttpMessage {
      * Creates a request with the DELETE method.
      *
      * @param uri URI
-     * @return {@code this}
+     * @return {@link FullHttpRequest.Builder}
      */
     public static Builder delete(String uri) {
         return new Builder(DELETE, uri);
@@ -146,7 +146,7 @@ public class FullHttpRequest implements FullHttpMessage {
      * Creates a request with the PUT method.
      *
      * @param uri URI
-     * @return {@code this}
+     * @return {@link FullHttpRequest.Builder}
      */
     public static Builder put(String uri) {
         return new Builder(PUT, uri);
@@ -156,22 +156,32 @@ public class FullHttpRequest implements FullHttpMessage {
      * Creates a request with the PATCH method.
      *
      * @param uri URI
-     * @return {@code this}
+     * @return {@link FullHttpRequest.Builder}
      */
     public static Builder patch(String uri) {
         return new Builder(PATCH, uri);
     }
 
+    /**
+     * @return HTTP protocol version
+     */
     @Override
     public HttpVersion version() {
         return this.version;
     }
 
+    /**
+     * @return all HTTP headers as an {@link HttpHeaders} instance
+     */
     @Override
     public HttpHeaders headers() {
         return headers;
     }
 
+    /**
+     * @param name header name
+     * @return all values for a given HTTP header name or an empty list if the header is not present
+     */
     @Override
     public List<String> headers(CharSequence name) {
         return headers.getAll(name);
@@ -185,7 +195,7 @@ public class FullHttpRequest implements FullHttpMessage {
      * reference cannot be used to modify the message content.
      * <p>
      *
-     * @return Message body content
+     * @return message body content
      */
     @Override
     public byte[] body() {
@@ -199,8 +209,8 @@ public class FullHttpRequest implements FullHttpMessage {
      * The caller must ensure the provided charset is compatible with message content
      * type and encoding.
      *
-     * @param charset Charset used to decode message body.
-     * @return Message body as a String.
+     * @param charset Charset used to decode message body
+     * @return message body as a String
      */
     @Override
     public String bodyAs(Charset charset) {
@@ -210,17 +220,13 @@ public class FullHttpRequest implements FullHttpMessage {
     }
 
     /**
-     * Gets the unique ID for this request.
-     *
-     * @return request ID
+     * @return an unique request ID
      */
     public Object id() {
         return id;
     }
 
     /**
-     * Returns the HTTP method of this request.
-     *
      * @return the HTTP method
      */
     public HttpMethod method() {
@@ -228,18 +234,14 @@ public class FullHttpRequest implements FullHttpMessage {
     }
 
     /**
-     * Returns the requested URI (or alternatively, path).
-     *
-     * @return The URI being requested
+     * @return the request URL
      */
     public Url url() {
         return url;
     }
 
     /**
-     * Returns the requested path.
-     *
-     * @return the path being requested
+     * @return the request URL path component
      */
     public String path() {
         return url.path();
@@ -258,11 +260,9 @@ public class FullHttpRequest implements FullHttpMessage {
     }
 
     /**
-     * Checks if the request has been transferred over a secure connection. If the protocol is HTTPS and the
-     * content is delivered over SSL then the request is considered to be secure.
-     *
-     * @return true if the request is transferred securely
+     * @deprecated will be removed from the final 1.0 API release
      */
+    @Deprecated
     public boolean isSecure() {
         return secure;
     }
@@ -304,7 +304,7 @@ public class FullHttpRequest implements FullHttpMessage {
     /**
      * Get the names of all query parameters.
      *
-     * @return the names of all query parameters.
+     * @return the names of all query parameters
      */
     public Iterable<String> queryParamNames() {
         return url.queryParamNames();
@@ -327,7 +327,7 @@ public class FullHttpRequest implements FullHttpMessage {
      * Converts this request into an HttpRequest object which represents the HTTP request as a
      * stream of bytes.
      *
-     * @return A streaming HttpRequest object.
+     * @return A streaming HttpRequest object
      */
     public HttpRequest toStreamingRequest() {
         HttpRequest.Builder streamingBuilder = new HttpRequest.Builder(this)
@@ -344,7 +344,7 @@ public class FullHttpRequest implements FullHttpMessage {
     /**
      * Decodes the "Cookie" header in this request and returns the cookies.
      *
-     * @return cookies
+     * @return a set of cookies
      */
     public Set<RequestCookie> cookies() {
         return headers.get(COOKIE)
@@ -356,7 +356,7 @@ public class FullHttpRequest implements FullHttpMessage {
      * Decodes the "Cookie" header in this request and returns the specified cookie.
      *
      * @param name cookie name
-     * @return cookies
+     * @return an optional cookie
      */
     public Optional<RequestCookie> cookie(String name) {
         return cookies().stream()
@@ -392,12 +392,21 @@ public class FullHttpRequest implements FullHttpMessage {
         private HttpVersion version = HTTP_1_1;
         private byte[] body;
 
+        /**
+         * Creates a new {@link Builder} object with default attributes.
+         */
         public Builder() {
             this.url = Url.Builder.url("/").build();
             this.headers = new HttpHeaders.Builder();
             this.body = new byte[0];
         }
 
+        /**
+         * Creates a new  {@link Builder} object with specified and URI.
+         *
+         * @param method a HTTP method
+         * @param uri URI
+         */
         public Builder(HttpMethod method, String uri) {
             this();
             this.method = requireNonNull(method);
@@ -405,6 +414,12 @@ public class FullHttpRequest implements FullHttpMessage {
             this.secure = url.isSecure();
         }
 
+        /**
+         * Creates a new  {@link Builder} from streaming request and a content byte array.
+         *
+         * @param request a streaming HTTP request object
+         * @param body an HTTP body content array
+         */
         public Builder(HttpRequest request, byte[] body) {
             this.id = request.id();
             this.method = request.method();
@@ -444,7 +459,7 @@ public class FullHttpRequest implements FullHttpMessage {
          * charset, and sets the Content-Length header accordingly.
          *
          * @param content request body
-         * @param charset Charset for string encoding.
+         * @param charset Charset for string encoding
          * @return {@code this}
          */
         public Builder body(String content, Charset charset) {
@@ -459,7 +474,7 @@ public class FullHttpRequest implements FullHttpMessage {
          * argument is true.
          *
          * @param content          request body
-         * @param charset          Charset used for encoding request body.
+         * @param charset          charset used for encoding request body
          * @param setContentLength If true, Content-Length header is set, otherwise it is not set.
          * @return {@code this}
          */
@@ -531,8 +546,8 @@ public class FullHttpRequest implements FullHttpMessage {
          * <p/>
          * Will not replace any existing values for the header.
          *
-         * @param name  The name of the header
-         * @param value The value of the header
+         * @param name  the name of the header
+         * @param value the value of the header
          * @return {@code this}
          */
         public Builder addHeader(CharSequence name, Object value) {
@@ -589,7 +604,7 @@ public class FullHttpRequest implements FullHttpMessage {
          * Sets the cookies on this request by overwriting the value of the "Cookie" header.
          *
          * @param cookies cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder cookies(RequestCookie... cookies) {
             return cookies(asList(cookies));
@@ -599,7 +614,7 @@ public class FullHttpRequest implements FullHttpMessage {
          * Sets the cookies on this request by overwriting the value of the "Cookie" header.
          *
          * @param cookies cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder cookies(Collection<RequestCookie> cookies) {
             requireNonNull(cookies);
@@ -618,7 +633,7 @@ public class FullHttpRequest implements FullHttpMessage {
          * add all new cookies in one call to the method rather than spreading them out.
          *
          * @param cookies new cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder addCookies(RequestCookie... cookies) {
             return addCookies(asList(cookies));
@@ -631,7 +646,7 @@ public class FullHttpRequest implements FullHttpMessage {
          * add all new cookies in one call to the method rather than spreading them out.
          *
          * @param cookies new cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder addCookies(Collection<RequestCookie> cookies) {
             requireNonNull(cookies);
@@ -645,7 +660,7 @@ public class FullHttpRequest implements FullHttpMessage {
          * Removes all cookies matching one of the supplied names by overwriting the value of the "Cookie" header.
          *
          * @param names cookie names
-         * @return this builder
+         * @return {@code this}
          */
         public Builder removeCookies(String... names) {
             return removeCookies(asList(names));
@@ -655,7 +670,7 @@ public class FullHttpRequest implements FullHttpMessage {
          * Removes all cookies matching one of the supplied names by overwriting the value of the "Cookie" header.
          *
          * @param names cookie names
-         * @return this builder
+         * @return {@code this}
          */
         public Builder removeCookies(Collection<String> names) {
             requireNonNull(names);

--- a/components/api/src/main/java/com/hotels/styx/api/FullHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FullHttpResponse.java
@@ -128,8 +128,8 @@ public class FullHttpResponse implements FullHttpMessage {
      * The caller must ensure the provided charset is compatible with message content
      * type and encoding.
      *
-     * @param charset Charset used to decode message body.
-     * @return Message body as a String.
+     * @param charset Charset used to decode message body
+     * @return message body as a String
      */
     @Override
     public String bodyAs(Charset charset) {
@@ -138,19 +138,36 @@ public class FullHttpResponse implements FullHttpMessage {
         // CHECKSTYLE:ON
     }
 
+    /**
+     * @return a HTTP protocol version
+     */
     @Override
     public HttpVersion version() {
         return version;
     }
 
+    /**
+     * Return a new {@link FullHttpResponse.Builder} that will inherit properties from this response.
+     * <p>
+     * This allows a new response to be made that is identical to this one
+     * except for the properties overridden by the builder methods.
+     *
+     * @return new builder based on this response
+     */
     public Builder newBuilder() {
         return new Builder(this);
     }
 
+    /**
+     * @return an HTTP response status
+     */
     public HttpResponseStatus status() {
         return status;
     }
 
+    /**
+     * @return true if this response is a redirect
+     */
     public boolean isRedirect() {
         return status.code() >= 300 && status.code() < 400;
     }
@@ -161,7 +178,7 @@ public class FullHttpResponse implements FullHttpMessage {
      * Converts this response to an HttpResponse object which represents the HTTP response as a
      * stream of bytes.
      *
-     * @return A streaming HttpResponse object.
+     * @return A streaming HttpResponse object
      */
     public HttpResponse toStreamingResponse() {
         if (this.body.length == 0) {
@@ -174,7 +191,7 @@ public class FullHttpResponse implements FullHttpMessage {
     /**
      * Decodes the "Set-Cookie" headers in this response and returns the cookies.
      *
-     * @return cookies
+     * @return a set of cookies
      */
     public Set<ResponseCookie> cookies() {
         return decode(headers.getAll(SET_COOKIE));
@@ -184,7 +201,7 @@ public class FullHttpResponse implements FullHttpMessage {
      * Decodes the "Set-Cookie" headers in this response and returns the specified cookie.
      *
      * @param name cookie name
-     * @return cookie
+     * @return an optional cookie
      */
     public Optional<ResponseCookie> cookie(String name) {
         return cookies().stream()
@@ -230,16 +247,30 @@ public class FullHttpResponse implements FullHttpMessage {
         private boolean validate = true;
         private byte[] body;
 
+        /**
+         * Creates a new {@link Builder} object with default attributes.
+         */
         public Builder() {
             this.headers = new HttpHeaders.Builder();
             this.body = new byte[0];
         }
 
+        /**
+         * Creates a new {@link Builder} object with specified response status.
+         *
+         * @param status an HTTP response status
+         */
         public Builder(HttpResponseStatus status) {
             this();
             this.status = status;
         }
 
+        /**
+         * Creates a new {@link Builder} object from an existing {@link HttpResponse} object.
+         * Similar to {@link this.newBuilder} method.
+         *
+         * @param response a full HTTP response instance
+         */
         public Builder(FullHttpResponse response) {
             this.status = response.status();
             this.version = response.version();
@@ -247,11 +278,17 @@ public class FullHttpResponse implements FullHttpMessage {
             this.body = response.body();
         }
 
-        public Builder(HttpResponse response, byte[] decoded) {
+        /**
+         * Creates a new {@link Builder} object from a response code and a content byte array.
+         *
+         * @param response a streaming HTTP response instance
+         * @param body a HTTP message body
+         */
+        public Builder(HttpResponse response, byte[] body) {
             this.status = response.status();
             this.version = response.version();
             this.headers = response.headers().newBuilder();
-            this.body = decoded;
+            this.body = body;
         }
 
         /**
@@ -272,7 +309,7 @@ public class FullHttpResponse implements FullHttpMessage {
          * charset, and sets the Content-Length header accordingly.
          *
          * @param content request body
-         * @param charset Charset for string encoding.
+         * @param charset charset for string encoding
          * @return {@code this}
          */
         public Builder body(String content, Charset charset) {
@@ -287,7 +324,7 @@ public class FullHttpResponse implements FullHttpMessage {
          * argument is true.
          *
          * @param content          response body
-         * @param charset          Charset used for encoding response body.
+         * @param charset          charset used for encoding response body
          * @param setContentLength If true, Content-Length header is set, otherwise it is not set.
          * @return {@code this}
          */
@@ -356,7 +393,7 @@ public class FullHttpResponse implements FullHttpMessage {
          * Sets the cookies on this response by removing existing "Set-Cookie" headers and adding new ones.
          *
          * @param cookies cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder cookies(ResponseCookie... cookies) {
             return cookies(asList(cookies));
@@ -366,7 +403,7 @@ public class FullHttpResponse implements FullHttpMessage {
          * Sets the cookies on this response by removing existing "Set-Cookie" headers and adding new ones.
          *
          * @param cookies cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder cookies(Collection<ResponseCookie> cookies) {
             requireNonNull(cookies);
@@ -378,7 +415,7 @@ public class FullHttpResponse implements FullHttpMessage {
          * Adds cookies into this response by adding "Set-Cookie" headers.
          *
          * @param cookies cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder addCookies(ResponseCookie... cookies) {
             return addCookies(asList(cookies));
@@ -388,7 +425,7 @@ public class FullHttpResponse implements FullHttpMessage {
          * Adds cookies into this response by adding "Set-Cookie" headers.
          *
          * @param cookies cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder addCookies(Collection<ResponseCookie> cookies) {
             requireNonNull(cookies);
@@ -408,7 +445,7 @@ public class FullHttpResponse implements FullHttpMessage {
          * Removes all cookies matching one of the supplied names by removing their "Set-Cookie" headers.
          *
          * @param names cookie names
-         * @return this builder
+         * @return {@code this}
          */
         public Builder removeCookies(String... names) {
             return removeCookies(asList(names));
@@ -418,7 +455,7 @@ public class FullHttpResponse implements FullHttpMessage {
          * Removes all cookies matching one of the supplied names by removing their "Set-Cookie" headers.
          *
          * @param names cookie names
-         * @return this builder
+         * @return {@code this}
          */
         public Builder removeCookies(Collection<String> names) {
             requireNonNull(names);

--- a/components/api/src/main/java/com/hotels/styx/api/FullHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FullHttpResponse.java
@@ -45,7 +45,7 @@ import static java.util.stream.Collectors.toList;
 /**
  * An immutable HTTP response object including full body content.
  * <p>
- * A {@link FullHttpResponse} is useful for response messages with a
+ * A {@link FullHttpResponse} is useful for responses with a
  * finite body content, such as when a REST API object is returned as a
  * response to a GET request.
  * <p>

--- a/components/api/src/main/java/com/hotels/styx/api/FullHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FullHttpResponse.java
@@ -43,16 +43,13 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
- * An immutable HTTP response object containing a finite size content body in full.
+ * An immutable HTTP response object including full body content.
  * <p>
- * A {@code FullHttpResponse} is useful for HTTP response messages with
- * finite body content such as returning a REST object.
+ * A {@link FullHttpResponse} is useful for response messages with a
+ * finite body content, such as when a REST API object is returned as a
+ * response to a GET request.
  * <p>
- * FullHttpResponse is immutable. Once created, it is impossible to modify any
- * response attributes, including body content. However a response can
- * be transformed to another via {@code FullHttpResponse.Builder}.
- * <p>
- * A FullHttpResponse is created via {@code FullHttpResponse.Builder}. A new builder
+ * A FullHttpResponse is created via {@link FullHttpResponse.Builder}. A new builder
  * can be obtained by a call to following static methods:
  *
  * <ul>
@@ -62,10 +59,10 @@ import static java.util.stream.Collectors.toList;
  *
  * A builder can also be created with one of the {@code Builder} constructors.
  *
- * A special method {@code newBuilder} creates a prepopulated {@code Builder}
- * from the current response object. It is useful for transforming a response
- * to another one my modifying one or more of its attributes.
- *
+ * FullHttpResponse is immutable. Once created it cannot be modified.
+ * However a response can be transformed to another using the {@link this#newBuilder}
+ * method. It creates a new {@link Builder} with all message properties and
+ * body content cloned in.
  */
 public class FullHttpResponse implements FullHttpMessage {
     private final HttpVersion version;
@@ -161,7 +158,7 @@ public class FullHttpResponse implements FullHttpMessage {
     /**
      * Converts this response to a streaming form (HttpResponse).
      * <p>
-     * Converts this response to a HttpResponse object which represents the HTTP response as a
+     * Converts this response to an HttpResponse object which represents the HTTP response as a
      * stream of bytes.
      *
      * @return A streaming HttpResponse object.

--- a/components/api/src/main/java/com/hotels/styx/api/FullHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FullHttpResponse.java
@@ -43,7 +43,29 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
- * HTTP response with a fully aggregated/decoded body.
+ * An immutable HTTP response object containing a finite size content body in full.
+ * <p>
+ * A {@code FullHttpResponse} is useful for HTTP response messages with
+ * finite body content such as returning a REST object.
+ * <p>
+ * FullHttpResponse is immutable. Once created, it is impossible to modify any
+ * response attributes, including body content. However a response can
+ * be transformed to another via {@code FullHttpResponse.Builder}.
+ * <p>
+ * A FullHttpResponse is created via {@code FullHttpResponse.Builder}. A new builder
+ * can be obtained by a call to following static methods:
+ *
+ * <ul>
+ *     <li>{@code response()}</li>
+ *     <li>{@code response(HttpResponseStatus)}</li>
+ * </ul>
+ *
+ * A builder can also be created with one of the {@code Builder} constructors.
+ *
+ * A special method {@code newBuilder} creates a prepopulated {@code Builder}
+ * from the current response object. It is useful for transforming a response
+ * to another one my modifying one or more of its attributes.
+ *
  */
 public class FullHttpResponse implements FullHttpMessage {
     private final HttpVersion version;

--- a/components/api/src/main/java/com/hotels/styx/api/HttpMessageSupport.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpMessageSupport.java
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.hotels.styx.api.HttpVersion;
-
 import java.util.Optional;
 
 import static com.hotels.styx.api.HttpHeaderNames.CHUNKED;

--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -63,7 +63,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 
 /**
- * A HTTP request object with a byte stream body.
+ * An HTTP request object with a byte stream body.
  * <p>
  * A {@code HttpRequest} is used in {@link HttpInterceptor} where each content
  * chunk must be processed as they arrive. It is also useful for dealing with
@@ -383,7 +383,7 @@ public class HttpRequest implements StreamingHttpMessage {
     /**
      * Aggregates content stream and converts this request to a {@link FullHttpRequest}.
      * <p>
-     * Returns a {@link StyxObservable<FullHttpRequest>} that eventually produces a
+     * Returns a {@link StyxObservable} that eventually produces a
      * {@link FullHttpRequest}. The resulting full request object has the same
      * request line, headers, and content as this request.
      *
@@ -469,7 +469,7 @@ public class HttpRequest implements StreamingHttpMessage {
     }
 
     /**
-     * A HTTP request builder.
+     * An HTTP request builder.
      */
     public static final class Builder {
         private static final InetSocketAddress LOCAL_HOST = createUnresolved("127.0.0.1", 0);

--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -63,7 +63,41 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 
 /**
- * HTTP request with a fully aggregated/decoded body.
+ * A HTTP request object with a byte stream body.
+ * <p>
+ * A {@code HttpRequest} is used in {@link HttpInterceptor} where each content
+ * chunk must be processed as they arrive. It is also useful for dealing with
+ * very large content sizes, and in situations where content size is not known
+ * upfront.
+ * <p>
+ * A {@code HttpRequest} object is immutable with respect to the request line
+ * attributes and HTTP headers. Once an instance is created, they cannot change.
+ *
+ * A {@code HttpRequest} body is a byte buffer stream that can be consumed
+ * as sequence of asynchronous events. Once consumed, stream is exhausted and
+ * can not be reused. Conceptually each {@code HttpRequest} object
+ * has an associated producer object that publishes data to the stream.
+ * For example, a Styx Server implements a content producer for {@link HttpInterceptor}
+ * extensions. The producer receives data chunks from a network socket and publishes
+ * them to an appropriate content stream.
+ *
+ * HTTP requests are created via {@code Builder} object, which can be created
+ * with static helper methods:
+ *
+ * <ul>
+ *     <li>{@code get}</li>
+ *     <li>{@code head}</li>
+ *     <li>{@code post}</li>
+ *     <li>{@code put}</li>
+ *     <li>{@code delete}</li>
+ *     <li>{@code patch}</li>
+ * </ul>
+ *
+ * A builder can also be created with one of the {@code Builder} constructors.
+ *
+ * A special method {@code newBuilder} creates a prepopulated {@code Builder}
+ * from the current request object. It is useful for transforming a request
+ * to another one my modifying one or more of its attributes.
  */
 public class HttpRequest implements StreamingHttpMessage {
     private final Object id;

--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -65,16 +65,16 @@ import static java.util.stream.Stream.concat;
 /**
  * An HTTP request object with a byte stream body.
  * <p>
- * A {@code HttpRequest} is used in {@link HttpInterceptor} where each content
+ * An {@code HttpRequest} is used in {@link HttpInterceptor} where each content
  * chunk must be processed as they arrive. It is also useful for dealing with
  * very large content sizes, and in situations where content size is not known
  * upfront.
  * <p>
- * A {@code HttpRequest} object is immutable with respect to the request line
+ * An {@code HttpRequest} object is immutable with respect to the request line
  * attributes and HTTP headers. Once an instance is created, they cannot change.
  *
- * A {@code HttpRequest} body is a byte buffer stream that can be consumed
- * as sequence of asynchronous events. Once consumed, stream is exhausted and
+ * An {@code HttpRequest} body is a byte buffer stream that can be consumed
+ * as sequence of asynchronous events. Once consumed, the stream is exhausted and
  * can not be reused. Conceptually each {@code HttpRequest} object
  * has an associated producer object that publishes data to the stream.
  * For example, a Styx Server implements a content producer for {@link HttpInterceptor}

--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -218,8 +218,7 @@ public class HttpRequest implements StreamingHttpMessage {
     }
 
     /**
-     * Returns the HTTP protocol version.
-     * @return
+     * @return HTTP protocol version
      */
     @Override
     public HttpVersion version() {
@@ -227,9 +226,7 @@ public class HttpRequest implements StreamingHttpMessage {
     }
 
     /**
-     * Returns all HTTP headers as {@link HttpHeaders} instance.
-     *
-     * @return {@link HttpHeaders} object.
+     * @return all HTTP headers as an {@link HttpHeaders} instance
      */
     @Override
     public HttpHeaders headers() {
@@ -237,12 +234,8 @@ public class HttpRequest implements StreamingHttpMessage {
     }
 
     /**
-     * Returns all values for a given HTTP header name.
-     *
-     * Returns an empty list if header is not present.
-     *
      * @param name header name
-     * @return A list of all header names.
+     * @return all values for a given HTTP header name or an empty list if the header is not present
      */
     @Override
     public List<String> headers(CharSequence name) {
@@ -250,11 +243,7 @@ public class HttpRequest implements StreamingHttpMessage {
     }
 
     /**
-     * Returns the body as a byte stream.
-     * <p>
-     * The byte stream returned as a {@link StyxObservable}.
-     *
-     * @return
+     * @return request body as a byte stream
      */
     @Override
     public StyxObservable<ByteBuf> body() {
@@ -262,17 +251,13 @@ public class HttpRequest implements StreamingHttpMessage {
     }
 
     /**
-     * Gets the unique ID for this request.
-     *
-     * @return request ID
+     * @return an unique request ID
      */
     public Object id() {
         return id;
     }
 
     /**
-     * Returns the HTTP method of this request.
-     *
      * @return the HTTP method
      */
     public HttpMethod method() {
@@ -280,18 +265,14 @@ public class HttpRequest implements StreamingHttpMessage {
     }
 
     /**
-     * Returns the requested URI (or alternatively, path).
-     *
-     * @return The URI being requested
+     * @return the request URL
      */
     public Url url() {
         return url;
     }
 
     /**
-     * Returns the requested path.
-     *
-     * @return the path being requested
+     * @return the request URL path component
      */
     public String path() {
         return url.path();
@@ -310,11 +291,9 @@ public class HttpRequest implements StreamingHttpMessage {
     }
 
     /**
-     * Checks if the request has been transferred over a secure connection.
-     * If the protocol is HTTPS then the request is considered to be secure.
-     *
-     * @return true if protocol is set to "https".
+     * @deprecated will be removed from the final 1.0 API release
      */
+    @Deprecated
     public boolean isSecure() {
         return secure;
     }
@@ -322,7 +301,7 @@ public class HttpRequest implements StreamingHttpMessage {
     /**
      * Will be removed in due course.
      *
-     * @deprecated will not appear in 1.0 interface.
+     * @deprecated will not appear in 1.0 interface
      *
      * @return
      */
@@ -364,7 +343,7 @@ public class HttpRequest implements StreamingHttpMessage {
     /**
      * Get the names of all query parameters.
      *
-     * @return the names of all query parameters.
+     * @return the names of all query parameters
      */
     public Iterable<String> queryParamNames() {
         return url.queryParamNames();
@@ -399,8 +378,8 @@ public class HttpRequest implements StreamingHttpMessage {
      * size stream exceeds the {@code maxContentBytes}, a @{link ContentOverflowException}
      * is emitted on the returned observable.
      *
-     * @param maxContentBytes Maximum allowed content size.
-     * @return a {@link StyxObservable}.
+     * @param maxContentBytes maximum expected content size
+     * @return a {@link StyxObservable}
      */
     public StyxObservable<FullHttpRequest> toFullRequest(int maxContentBytes) {
         CompositeByteBuf byteBufs = compositeBuffer();
@@ -437,7 +416,7 @@ public class HttpRequest implements StreamingHttpMessage {
     /**
      * Decodes the "Cookie" header in this request and returns the cookies.
      *
-     * @return cookies
+     * @return a set of cookies
      */
     public Set<RequestCookie> cookies() {
         return headers.get(COOKIE)
@@ -449,7 +428,7 @@ public class HttpRequest implements StreamingHttpMessage {
      * Decodes the "Cookie" header in this request and returns the specified cookie.
      *
      * @param name cookie name
-     * @return cookies
+     * @return an optional cookie
      */
     public Optional<RequestCookie> cookie(String name) {
         return cookies().stream()
@@ -497,6 +476,9 @@ public class HttpRequest implements StreamingHttpMessage {
 
         /**
          * Creates a new {@link Builder} with specified HTTP method and URI.
+         *
+         * @param method a HTTP method
+         * @param uri a HTTP URI
          */
         public Builder(HttpMethod method, String uri) {
             this();
@@ -506,9 +488,12 @@ public class HttpRequest implements StreamingHttpMessage {
         }
 
         /**
-         * Creates a new {@link Builder} from an existing request with a new body content stream..
+         * Creates a new {@link Builder} from an existing request with a new body content stream.
+         *
+         * @param request a HTTP request object
+         * @param contentStream a body content stream
          */
-        public Builder(HttpRequest request, StyxObservable<ByteBuf> body) {
+        public Builder(HttpRequest request, StyxObservable<ByteBuf> contentStream) {
             this.id = request.id();
             this.method = httpMethod(request.method().name());
             this.clientAddress = request.clientAddress();
@@ -663,7 +648,7 @@ public class HttpRequest implements StreamingHttpMessage {
          * @deprecated Will not appear in 1.0 API.
          *
          * @param clientAddress
-         * @return
+         * @return {@code this}
          */
         @Deprecated
         public Builder clientAddress(InetSocketAddress clientAddress) {

--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -321,9 +321,11 @@ public class HttpRequest implements StreamingHttpMessage {
 
     /**
      * Will be removed in due course.
+     *
+     * @deprecated will not appear in 1.0 interface.
+     *
      * @return
      */
-
     // Relic of old API, kept only for conversions
     @Deprecated
     public InetSocketAddress clientAddress() {
@@ -656,7 +658,9 @@ public class HttpRequest implements StreamingHttpMessage {
         }
 
         /**
-         * Deprecated. Do not use in any new code.
+         * Do not use in any new code.
+         *
+         * @deprecated Will not appear in 1.0 API.
          *
          * @param clientAddress
          * @return
@@ -669,6 +673,8 @@ public class HttpRequest implements StreamingHttpMessage {
 
         /**
          * Don't use. Will be removed soon.
+         *
+         * @deprecated Will not appear in 1.0 API.
          *
          * @param secure true if secure
          * @return {@code this}

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -130,23 +130,7 @@ public class HttpResponse implements StreamingHttpMessage {
     }
 
     /**
-     * Returns an HTTP header value.
-     * <p>
-     * When the header has been set multiple times, this still returns
-     * just one value.
-     *
-     * @param name header name
-     * @return An optional of value, or empty if not present.
-     */
-    @Override
-    public Optional<String> header(CharSequence name) {
-        return headers.get(name);
-    }
-
-    /**
-     * Returns all HTTP headers as an {@link HttpHeaders} instance.
-     *
-     * @return {@link HttpHeaders} object.
+     * @return all HTTP headers as an {@link HttpHeaders} object
      */
     @Override
     public HttpHeaders headers() {
@@ -154,24 +138,7 @@ public class HttpResponse implements StreamingHttpMessage {
     }
 
     /**
-     * Returns all values for a given HTTP header name.
-     *
-     * Returns an empty list if header is not present.
-     *
-     * @param name header name
-     * @return A list of all header names.
-     */
-    @Override
-    public List<String> headers(CharSequence name) {
-        return headers.getAll(name);
-    }
-
-    /**
-     * Returns the body as a byte stream.
-     * <p>
-     * The byte stream returned as a {@link StyxObservable}.
-     *
-     * @return
+     * @return the response body as a byte stream
      */
     @Override
     public StyxObservable<ByteBuf> body() {
@@ -179,9 +146,7 @@ public class HttpResponse implements StreamingHttpMessage {
     }
 
     /**
-     * Returns the HTTP protocol version.
-     *
-     * @return A {@link HttpVersion}.
+     * @return a HTTP protocol version
      */
     @Override
     public HttpVersion version() {
@@ -201,18 +166,14 @@ public class HttpResponse implements StreamingHttpMessage {
     }
 
     /**
-     * Returns the HTTP status.
-     *
-     * @return
+     * @return an HTTP response status
      */
     public HttpResponseStatus status() {
         return status;
     }
 
     /**
-     * Returns true if the response is an HTTP redirect.
-     *
-     * @return
+     * @return true if this response is a redirect
      */
     public boolean isRedirect() {
         return status.code() >= 300 && status.code() < 400;
@@ -235,8 +196,8 @@ public class HttpResponse implements StreamingHttpMessage {
      * size stream exceeds the {@code maxContentBytes}, a @{link ContentOverflowException}
      * is emitted on the returned observable.
      *
-     * @param maxContentBytes Maximum allowed content size.
-     * @return a {@link StyxObservable}.
+     * @param maxContentBytes maximum expected content size
+     * @return a {@link StyxObservable}
      */
     public StyxObservable<FullHttpResponse> toFullResponse(int maxContentBytes) {
         CompositeByteBuf byteBufs = compositeBuffer();
@@ -274,19 +235,20 @@ public class HttpResponse implements StreamingHttpMessage {
     }
 
     /**
-     * Returns "Set-Cookie" headers decoded as {@link ResponseCookie} set.
+     * Decodes "Set-Cookie" header values and returns them as set of {@link ResponseCookie} objects.
      *
-     * @return cookies
+     * @return a set of {@link ResponseCookie} objects
      */
     public Set<ResponseCookie> cookies() {
         return decode(headers.getAll(SET_COOKIE));
     }
 
     /**
-     * Returns a specified cookie decoded as {@link ResponseCookie}.
+     * Decodes a specified Set-Cookie header and returns it as a {@link ResponseCookie} object.
      *
      * @param name cookie name
-     * @return cookie
+     * @return an optional {@link ResponseCookie} value if corresponding cookie name is present,
+     *         or {@link Optional#empty} if not.
      */
     public Optional<ResponseCookie> cookie(String name) {
         return cookies().stream()
@@ -342,6 +304,8 @@ public class HttpResponse implements StreamingHttpMessage {
 
         /**
          * Creates a new {@link Builder} object with specified response status.
+         *
+         * @param status a HTTP response status
          */
         public Builder(HttpResponseStatus status) {
             this();
@@ -351,6 +315,8 @@ public class HttpResponse implements StreamingHttpMessage {
         /**
          * Creates a new {@link Builder} object from an existing {@link HttpResponse} object.
          * Similar to {@link this.newBuilder} method.
+         *
+         * @param response a response object for which the builder is based on
          */
         public Builder(HttpResponse response) {
             this.status = response.status();
@@ -361,12 +327,18 @@ public class HttpResponse implements StreamingHttpMessage {
 
         /**
          * Creates a new {@link Builder} object from a response code and a content stream.
+         * <p>
+         * Builder's response status line parameters and the HTTP headers are populated from
+         * the given {@code response} object, but the content stream is set to {@code contentStream}.
+         *
+         * @param response a full response for which the builder is based on
+         * @param contentStream a content byte stream
          */
-        public Builder(FullHttpResponse response, StyxObservable<ByteBuf> decoded) {
+        public Builder(FullHttpResponse response, StyxObservable<ByteBuf> contentStream) {
             this.status = statusWithCode(response.status().code());
             this.version = httpVersion(response.version().toString());
             this.headers = response.headers().newBuilder();
-            this.body = decoded;
+            this.body = contentStream;
         }
 
         /**
@@ -440,7 +412,7 @@ public class HttpResponse implements StreamingHttpMessage {
          * Sets the cookies on this response by removing existing "Set-Cookie" headers and adding new ones.
          *
          * @param cookies cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder cookies(ResponseCookie... cookies) {
             return cookies(asList(cookies));
@@ -450,7 +422,7 @@ public class HttpResponse implements StreamingHttpMessage {
          * Sets the cookies on this response by removing existing "Set-Cookie" headers and adding new ones.
          *
          * @param cookies cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder cookies(Collection<ResponseCookie> cookies) {
             requireNonNull(cookies);
@@ -462,7 +434,7 @@ public class HttpResponse implements StreamingHttpMessage {
          * Adds cookies into this response by adding "Set-Cookie" headers.
          *
          * @param cookies cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder addCookies(ResponseCookie... cookies) {
             return addCookies(asList(cookies));
@@ -472,7 +444,7 @@ public class HttpResponse implements StreamingHttpMessage {
          * Adds cookies into this response by adding "Set-Cookie" headers.
          *
          * @param cookies cookies
-         * @return this builder
+         * @return {@code this}
          */
         public Builder addCookies(Collection<ResponseCookie> cookies) {
             requireNonNull(cookies);
@@ -492,7 +464,7 @@ public class HttpResponse implements StreamingHttpMessage {
          * Removes all cookies matching one of the supplied names by removing their "Set-Cookie" headers.
          *
          * @param names cookie names
-         * @return this builder
+         * @return {@code this}
          */
         public Builder removeCookies(String... names) {
             return removeCookies(asList(names));
@@ -502,7 +474,7 @@ public class HttpResponse implements StreamingHttpMessage {
          * Removes all cookies matching one of the supplied names by removing their "Set-Cookie" headers.
          *
          * @param names cookie names
-         * @return this builder
+         * @return {@code this}
          */
         public <T> Builder removeCookies(Collection<String> names) {
             requireNonNull(names);
@@ -633,8 +605,8 @@ public class HttpResponse implements StreamingHttpMessage {
          *     <ul> The {@code Content-Length} header is zero or positive integer
          * </li>
          *
-         * @throws IllegalArgumentException when validation fails.
-         * @return A new full response.
+         * @throws IllegalArgumentException when validation fails
+         * @return a new full response.
          */
         public HttpResponse build() {
             if (validate) {

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -609,8 +609,8 @@ public class HttpResponse implements StreamingHttpMessage {
          * method is invoked. Specifically that:
          *
          * <li>
-         *     <ul> There is maximum of only one {@code Content-Length} header
-         *     <ul> The {@code Content-Length} header is zero or positive integer
+         *     <ul>There is maximum of only one {@code Content-Length} header</ul>
+         *     <ul>The {@code Content-Length} header is zero or positive integer</ul>
          * </li>
          *
          * @return {@code this}

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -53,7 +53,38 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
- * HTTP response with a fully aggregated/decoded body.
+ * A HTTP response object with a byte stream body.
+ * <p>
+ * A {@code HttpResponse} is used in {@link HttpInterceptor} where each content
+ * chunk must be processed as they arrive. It is also useful for dealing with
+ * very large content sizes, and in situations where content size is not known
+ * upfront.
+ * <p>
+ * A {@code HttpResponse} object is immutable with respect to the response
+ * attributes and HTTP headers. Once an instance is created, they cannot change.
+ *
+ * A {@code HttpResponse} body is a byte buffer stream that can be consumed
+ * as sequence of asynchronous events. Once consumed, stream is exhausted and
+ * can not be reused. Conceptually each {@code HttpResponse} object has an
+ * associated producer object that publishes data to the stream. For example,
+ * a Styx Server implements a content producer for {@link HttpInterceptor}
+ * extensions. The producer receives data chunks from a network socket and
+ * publishes them to an appropriate content stream.
+ *
+ * HTTP responses are created via {@code Builder} object, which can be created
+ * with static helper methods:
+ *
+ * <ul>
+ *     <li>{@code response()}</li>
+ *     <li>{@code response(HttpResponseStatus)}</li>
+ *     <li>{@code response(HttpResponseStatus, StyxObservable<ByteBuf>)}</li>
+ * </ul>
+ *
+ * A builder can also be created with one of the {@code Builder} constructors.
+ *
+ * A special method {@code newBuilder} creates a prepopulated {@code Builder}
+ * from the current response object. It is useful for transforming a response
+ * to another one my modifying one or more of its attributes.
  */
 public class HttpResponse implements StreamingHttpMessage {
     private final HttpVersion version;

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -53,7 +53,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
- * A HTTP response object with a byte stream body.
+ * An response object with a byte stream body.
  * <p>
  * A {@code HttpResponse} is used in {@link HttpInterceptor} where each content
  * chunk must be processed as they arrive. It is also useful for dealing with
@@ -130,7 +130,7 @@ public class HttpResponse implements StreamingHttpMessage {
     }
 
     /**
-     * Returns a HTTP header value.
+     * Returns an HTTP header value.
      * <p>
      * When the header has been set multiple times, this still returns
      * just one value.
@@ -144,7 +144,7 @@ public class HttpResponse implements StreamingHttpMessage {
     }
 
     /**
-     * Returns all HTTP headers as {@link HttpHeaders} instance.
+     * Returns all HTTP headers as an {@link HttpHeaders} instance.
      *
      * @return {@link HttpHeaders} object.
      */
@@ -210,7 +210,7 @@ public class HttpResponse implements StreamingHttpMessage {
     }
 
     /**
-     * Returns true if the response is a HTTP redirect.
+     * Returns true if the response is an HTTP redirect.
      *
      * @return
      */
@@ -323,7 +323,7 @@ public class HttpResponse implements StreamingHttpMessage {
     }
 
     /**
-     * A HTTP response builder.
+     * An HTTP response builder.
      */
     public static final class Builder {
         private HttpResponseStatus status = OK;

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -53,18 +53,18 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
- * An response object with a byte stream body.
+ * An HTTP response object with a byte stream body.
  * <p>
- * A {@code HttpResponse} is used in {@link HttpInterceptor} where each content
+ * An {@code HttpResponse} is used in {@link HttpInterceptor} where each content
  * chunk must be processed as they arrive. It is also useful for dealing with
  * very large content sizes, and in situations where content size is not known
  * upfront.
  * <p>
- * A {@code HttpResponse} object is immutable with respect to the response
+ * An {@code HttpResponse} object is immutable with respect to the response
  * attributes and HTTP headers. Once an instance is created, they cannot change.
  *
- * A {@code HttpResponse} body is a byte buffer stream that can be consumed
- * as sequence of asynchronous events. Once consumed, stream is exhausted and
+ * An {@code HttpResponse} body is a byte buffer stream that can be consumed
+ * as sequence of asynchronous events. Once consumed, the stream is exhausted and
  * can not be reused. Conceptually each {@code HttpResponse} object has an
  * associated producer object that publishes data to the stream. For example,
  * a Styx Server implements a content producer for {@link HttpInterceptor}

--- a/components/api/src/main/java/com/hotels/styx/api/HttpVersion.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpVersion.java
@@ -38,6 +38,15 @@ public class HttpVersion {
         this.version = version;
     }
 
+    /**
+     * Creates a HttpVersion from String.
+     *
+     * Accepted strings are "HTTP/1.0" and "HTTP/1.1".
+     * Otherwise throws an {@link IllegalArgumentException}.
+     *
+     * @param version
+     * @return
+     */
     public static HttpVersion httpVersion(String version) {
         checkArgument(VERSIONS.containsKey(version), "No such HTTP version %s", version);
 

--- a/components/api/src/main/java/com/hotels/styx/api/MetricRegistry.java
+++ b/components/api/src/main/java/com/hotels/styx/api/MetricRegistry.java
@@ -28,7 +28,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 
 /**
- * A registry for collecting all metrics.
+ * A Styx metrics registry that is based on CodaHale {@link Metric} objects.
  */
 public interface MetricRegistry {
 

--- a/components/api/src/main/java/com/hotels/styx/api/RequestCookie.java
+++ b/components/api/src/main/java/com/hotels/styx/api/RequestCookie.java
@@ -32,7 +32,12 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
 /**
- * Represents an HTTP cookie as sent in the {@code Cookie} header of an HTTP request.
+ * Represents an HTTP cookie as sent in the HTTP request {@code Cookie} header.
+ *
+ * A client includes a {@code RequestCookie} in a request to the remote server.
+ * It has just two attributes, {@code name} and {@code value}. Unlike {@link ResponseCookie}
+ * it doesn't have any cookie attributes.
+ *
  */
 public final class RequestCookie {
     private final String name;

--- a/components/api/src/main/java/com/hotels/styx/api/ResponseCookie.java
+++ b/components/api/src/main/java/com/hotels/styx/api/ResponseCookie.java
@@ -32,7 +32,11 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
 /**
- * Represents an HTTP cookie as sent in the {@code Set-Cookie} header.
+ * Represents an HTTP cookie as sent in the HTTP response {@code Set-Cookie} header.
+ *
+ * A server can include a {@code ResponseCookie} in its response to a client request.
+ * It contains cookie {@code name}, {@code value}, and attributes such as {@code path}
+ * and {@code maxAge}.
  */
 public final class ResponseCookie {
     private final String name;

--- a/components/api/src/main/java/com/hotels/styx/api/package-info.java
+++ b/components/api/src/main/java/com/hotels/styx/api/package-info.java
@@ -16,19 +16,28 @@
 
 
 /**
- * A programming interface for Styx extensions. This includes a Styx
+ * A programming interface for implementing Styx extensions. This includes
  * {@code HttpInterceptor} interface for intercepting HTTP traffic, and classes
  * to represent HTTP Request and Response messages.
  * <p></p>
  *
- * Styx exposes intercepted traffic to custom extensions via {@code HttpInterceptor}
- * class.
+ * Styx exposes intercepted traffic to custom extensions by {@code HttpInterceptor}
+ * interface. A Styx plugin extends this interface to provide additional features
+ * for shaping or modifying proxied HTTP messages, including requests and responses.
  * <p></p>
- * The intercepted live traffic is represented as {@code HttpRequest} and
- * {@code HttpResponse} classes.
+ * Styx represents proxied life traffic as instances of {@code HttpRequest} and
+ * {@code HttpResponse} classes. They offer an interface for processing
+ * a HTTP message content as a stream of network events. These classes are used
+ * (1) from HttpInterceptors to process live traffic or (2) to deal with arbitrarily
+ * large HTTP content.
  * <p></p>
- * The API also has aggregated {@code FullHttpRequest} and {@code FullHttpResponse}
- * classes. They are useful for most situations apart from intercepting live traffic.
+ * {@code FullHttpRequest} and {@code FullHttpResponse} classes provide an immutable
+ * aggregate view of a HTTP messages with full headers and content.
+ * They are useful for dealing with HTTP messages with limited content sizes,
+ * such as most RESTful API endpoints, or when "real-time" content processing
+ * is not relevant.
+ *
+ * The API provides methods to convert between the streaming and full representations.
  *
  */
 package com.hotels.styx.api;

--- a/components/api/src/main/java/com/hotels/styx/api/package-info.java
+++ b/components/api/src/main/java/com/hotels/styx/api/package-info.java
@@ -1,0 +1,34 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+
+/**
+ * A programming interface for Styx extensions. This includes a Styx
+ * {@code HttpInterceptor} interface for intercepting HTTP traffic, and classes
+ * to represent HTTP Request and Response messages.
+ * <p></p>
+ *
+ * Styx exposes intercepted traffic to custom extensions via {@code HttpInterceptor}
+ * class.
+ * <p></p>
+ * The intercepted live traffic is represented as {@code HttpRequest} and
+ * {@code HttpResponse} classes.
+ * <p></p>
+ * The API also has aggregated {@code FullHttpRequest} and {@code FullHttpResponse}
+ * classes. They are useful for most situations apart from intercepting live traffic.
+ *
+ */
+package com.hotels.styx.api;

--- a/components/api/src/main/java/com/hotels/styx/api/package-info.java
+++ b/components/api/src/main/java/com/hotels/styx/api/package-info.java
@@ -16,22 +16,22 @@
 
 
 /**
- * A programming interface for implementing Styx extensions. This includes
- * {@code HttpInterceptor} interface for intercepting HTTP traffic, and classes
+ * A programming interface for implementing Styx extensions. This includes the
+ * {@link com.hotels.styx.api.HttpInterceptor} interface for intercepting HTTP traffic, and classes
  * to represent HTTP Request and Response messages.
  * <p></p>
  *
- * Styx exposes intercepted traffic to custom extensions by {@code HttpInterceptor}
+ * Styx exposes intercepted traffic to custom extensions by {@link com.hotels.styx.api.HttpInterceptor}
  * interface. A Styx plugin extends this interface to provide additional features
  * for shaping or modifying proxied HTTP messages, including requests and responses.
  * <p></p>
- * Styx represents proxied life traffic as instances of {@code HttpRequest} and
- * {@code HttpResponse} classes. They offer an interface for processing
+ * Styx represents proxied live traffic as instances of {@link com.hotels.styx.api.HttpRequest} and
+ * {@link com.hotels.styx.api.HttpResponse} classes. They offer an interface for processing
  * a HTTP message content as a stream of network events. These classes are used
  * (1) from HttpInterceptors to process live traffic or (2) to deal with arbitrarily
  * large HTTP content.
  * <p></p>
- * {@code FullHttpRequest} and {@code FullHttpResponse} classes provide an immutable
+ * {@link com.hotels.styx.api.FullHttpRequest} and {@link com.hotels.styx.api.FullHttpResponse} classes provide an immutable
  * aggregate view of a HTTP messages with full headers and content.
  * They are useful for dealing with HTTP messages with limited content sizes,
  * such as most RESTful API endpoints, or when "real-time" content processing

--- a/components/api/src/test/java/com/hotels/styx/api/HttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpResponseTest.java
@@ -286,16 +286,6 @@ public class HttpResponseTest {
                 .build();
     }
 
-    @Test
-    public void headerValues() {
-        HttpResponse r = response()
-                .addHeader("X-Styx", "14, 16")
-                .addHeader("X-Styx", "15")
-                .build();
-
-        System.out.println("headers: " + r.header("X-Styx"));
-    }
-
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void rejectsInvalidContentLength() {
         response()

--- a/components/api/src/test/java/com/hotels/styx/api/HttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpResponseTest.java
@@ -286,6 +286,16 @@ public class HttpResponseTest {
                 .build();
     }
 
+    @Test
+    public void headerValues() {
+        HttpResponse r = response()
+                .addHeader("X-Styx", "14, 16")
+                .addHeader("X-Styx", "15")
+                .build();
+
+        System.out.println("headers: " + r.header("X-Styx"));
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void rejectsInvalidContentLength() {
         response()

--- a/pom.xml
+++ b/pom.xml
@@ -506,6 +506,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.0.1</version>
+        </plugin>
+        <plugin>
           <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-maven-plugin</artifactId>
           <version>${kotlin.version}</version>
@@ -1180,5 +1185,13 @@
     </profile>
   </profiles>
 
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1145,19 +1145,6 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>${maven-javadoc-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
             <executions>
@@ -1184,14 +1171,5 @@
       </properties>
     </profile>
   </profiles>
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </reporting>
 
 </project>


### PR DESCRIPTION
This PR also adds package level API docs for `com.hotels.styx.api` and improves existing Javadocs for HTTP message objects.

BTW, the Javadocs can be generated locally with:

```
mvn javadoc:javadoc
```

Or specifically for the *styx-api* module:

```
mvn -f components/api/pom.xml javadoc:javadoc
```
