### PR TITLE
Add HttpInterceptor.Context to HttpRouter.route() API.

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
@@ -85,7 +85,7 @@ public class BackendServicesRouter implements HttpRouter, Registry.ChangeListene
     }
 
     @Override
-    public Optional<HttpHandler> route(HttpRequest request) {
+    public Optional<HttpHandler> route(HttpRequest request, HttpInterceptor.Context ignore) {
         String path = request.path();
 
         return routes.entrySet().stream()

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/RouteHandlerAdapter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/RouteHandlerAdapter.java
@@ -35,7 +35,7 @@ public class RouteHandlerAdapter implements HttpHandler {
 
     @Override
     public StyxObservable<HttpResponse> handle(HttpRequest request, HttpInterceptor.Context context) {
-        return router.route(request)
+        return router.route(request, context)
                 .map(pipeline -> pipeline.handle(request, context))
                 .orElse(StyxObservable.error(new NoServiceConfiguredException(request.path())));
     }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ConditionRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ConditionRouter.java
@@ -18,6 +18,7 @@ package com.hotels.styx.routing.handlers;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.hotels.styx.api.HttpHandler;
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.StyxObservable;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
@@ -57,9 +58,9 @@ public class ConditionRouter implements HttpRouter {
     }
 
     @Override
-    public Optional<HttpHandler> route(HttpRequest request) {
+    public Optional<HttpHandler> route(HttpRequest request, HttpInterceptor.Context context) {
         for (Route route : routes) {
-            HttpHandler handler = route.match(request);
+            HttpHandler handler = route.match(request, context);
             if (handler != null) {
                 return Optional.of(handler);
             }
@@ -77,8 +78,8 @@ public class ConditionRouter implements HttpRouter {
             this.handler = handler;
         }
 
-        public HttpHandler match(HttpRequest request) {
-            return matcher.apply(request) ? handler : null;
+        public HttpHandler match(HttpRequest request, HttpInterceptor.Context context) {
+            return matcher.apply(request, context) ? handler : null;
         }
     }
 

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/BackendServicesRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/BackendServicesRouterTest.java
@@ -25,6 +25,7 @@ import com.hotels.styx.api.extension.service.BackendService;
 import com.hotels.styx.api.extension.service.spi.Registry;
 import com.hotels.styx.client.OriginStatsFactory;
 import com.hotels.styx.client.OriginsInventory;
+import com.hotels.styx.server.HttpInterceptorContext;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -59,7 +60,7 @@ public class BackendServicesRouterTest {
 
     private final BackendServiceClientFactory serviceClientFactory =
             (backendService, originsInventory, originStatsFactory) -> request -> responseWithOriginIdHeader(backendService);
-    private HttpInterceptor.Context context;
+    private HttpInterceptor.Context context = HttpInterceptorContext.create();
 
     private Environment environment;
 
@@ -91,7 +92,7 @@ public class BackendServicesRouterTest {
         router.onChange(changes);
 
         HttpRequest request = get("/appB/hotel/details.html").build();
-        Optional<HttpHandler> route = router.route(request);
+        Optional<HttpHandler> route = router.route(request, context);
 
         assertThat(proxyTo(route, request).header(ORIGIN_ID_DEFAULT), isValue(APP_B));
     }
@@ -106,7 +107,7 @@ public class BackendServicesRouterTest {
         router.onChange(changes);
 
         HttpRequest request = get("/appB/hotel/details.html").build();
-        Optional<HttpHandler> route = router.route(request);
+        Optional<HttpHandler> route = router.route(request, context);
 
         assertThat(proxyTo(route, request).header(ORIGIN_ID_DEFAULT), isValue(APP_B));
     }
@@ -122,7 +123,7 @@ public class BackendServicesRouterTest {
         router.onChange(changes);
 
         HttpRequest request = get("/").build();
-        Optional<HttpHandler> route = router.route(request);
+        Optional<HttpHandler> route = router.route(request, context);
 
         assertThat(proxyTo(route, request).header(ORIGIN_ID_DEFAULT), isValue(APP_A));
     }
@@ -137,7 +138,7 @@ public class BackendServicesRouterTest {
         router.onChange(changes);
 
         HttpRequest request = get("/").build();
-        Optional<HttpHandler> route = router.route(request);
+        Optional<HttpHandler> route = router.route(request, context);
 
         assertThat(proxyTo(route, request).header(ORIGIN_ID_DEFAULT), isValue(APP_A));
     }
@@ -152,7 +153,7 @@ public class BackendServicesRouterTest {
         router.onChange(changes);
 
         HttpRequest request = get("/appB/").build();
-        Optional<HttpHandler> route = router.route(request);
+        Optional<HttpHandler> route = router.route(request, context);
 
         assertThat(proxyTo(route, request).header(ORIGIN_ID_DEFAULT), isValue(APP_B));
     }
@@ -163,7 +164,7 @@ public class BackendServicesRouterTest {
         router.onChange(added(appB().newCopy().path("/appB/hotel/details.html").build()));
 
         HttpRequest request = get("/ba/").build();
-        Optional<HttpHandler> route = router.route(request);
+        Optional<HttpHandler> route = router.route(request, context);
         System.out.println("route: " + route);
 
         assertThat(route, is(Optional.empty()));
@@ -175,7 +176,7 @@ public class BackendServicesRouterTest {
         router.onChange(added(appB().newCopy().path("/appB/hotel/details.html").build()));
 
         HttpRequest request = get("/qwertyuiop").build();
-        assertThat(router.route(request), is(Optional.empty()));
+        assertThat(router.route(request, context), is(Optional.empty()));
     }
 
     @Test
@@ -189,7 +190,7 @@ public class BackendServicesRouterTest {
                 .build());
 
         HttpRequest request = get("/appB/").build();
-        Optional<HttpHandler> route = router.route(request);
+        Optional<HttpHandler> route = router.route(request, context);
         assertThat(proxyTo(route, request).header(ORIGIN_ID_DEFAULT), isValue("X"));
     }
 
@@ -201,12 +202,12 @@ public class BackendServicesRouterTest {
 
         router.onChange(added(appB()));
 
-        Optional<HttpHandler> route = router.route(request);
+        Optional<HttpHandler> route = router.route(request, context);
         assertThat(proxyTo(route, request).header(ORIGIN_ID_DEFAULT), isValue(APP_B));
 
         router.onChange(new Registry.Changes.Builder<BackendService>().build());
 
-        Optional<HttpHandler> route2 = router.route(request);
+        Optional<HttpHandler> route2 = router.route(request, context);
         assertThat(proxyTo(route2, request).header(ORIGIN_ID_DEFAULT), isValue(APP_B));
     }
 

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/RouteHandlerAdapterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/RouteHandlerAdapterTest.java
@@ -46,7 +46,7 @@ public class RouteHandlerAdapterTest {
         when(pipeline.handle(any(HttpRequest.class), any(HttpInterceptor.Context.class))).thenReturn(StyxObservable.of(respOk));
 
         HttpRouter router = mock(HttpRouter.class);
-        when(router.route(any(HttpRequest.class))).thenReturn(Optional.of(pipeline));
+        when(router.route(any(HttpRequest.class), any(HttpInterceptor.Context.class))).thenReturn(Optional.of(pipeline));
 
         HttpResponse response = new RouteHandlerAdapter(router).handle(request, HttpInterceptorContext.create()).asCompletableFuture().get();
 

--- a/components/server/src/main/java/com/hotels/styx/server/HttpRouter.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpRouter.java
@@ -16,6 +16,7 @@
 package com.hotels.styx.server;
 
 import com.hotels.styx.api.HttpHandler;
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 
 import java.util.Optional;
@@ -24,5 +25,5 @@ import java.util.Optional;
  * Http Router.
  */
 public interface HttpRouter {
-    Optional<HttpHandler> route(HttpRequest request);
+    Optional<HttpHandler> route(HttpRequest request, HttpInterceptor.Context context);
 }

--- a/components/server/src/main/java/com/hotels/styx/server/PathPrefixRouter.java
+++ b/components/server/src/main/java/com/hotels/styx/server/PathPrefixRouter.java
@@ -16,6 +16,7 @@
 package com.hotels.styx.server;
 
 import com.hotels.styx.api.HttpHandler;
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 
 import java.util.Optional;
@@ -27,7 +28,7 @@ public class PathPrefixRouter implements HttpRouter {
     private final PathTrie<HttpHandler> routes = new PathTrie<>();
 
     @Override
-    public Optional<HttpHandler> route(HttpRequest request) {
+    public Optional<HttpHandler> route(HttpRequest request, HttpInterceptor.Context ignore) {
         return routes.get(request.path());
     }
 

--- a/components/server/src/main/java/com/hotels/styx/server/routing/Condition.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/Condition.java
@@ -15,13 +15,14 @@
  */
 package com.hotels.styx.server.routing;
 
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 
 /**
  * Base interface for routing rules.
  */
 public interface Condition {
-    boolean evaluate(HttpRequest request);
+    boolean evaluate(HttpRequest request, HttpInterceptor.Context context);
 
     /**
      * Parser for a condition.

--- a/components/server/src/main/java/com/hotels/styx/server/routing/Matcher.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/Matcher.java
@@ -15,12 +15,13 @@
  */
 package com.hotels.styx.server.routing;
 
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 
 /**
  * A matcher condition to match against HTTP requests.
  */
 public interface Matcher {
-    boolean apply(HttpRequest request);
+    boolean apply(HttpRequest request, HttpInterceptor.Context context);
 }
 

--- a/components/server/src/main/java/com/hotels/styx/server/routing/antlr/AntlrCondition.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/antlr/AntlrCondition.java
@@ -15,6 +15,7 @@
  */
 package com.hotels.styx.server.routing.antlr;
 
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.server.routing.Condition;
 
@@ -32,8 +33,8 @@ class AntlrCondition implements Condition {
     }
 
     @Override
-    public boolean evaluate(HttpRequest request) {
-        return expression.evaluate(request);
+    public boolean evaluate(HttpRequest request, HttpInterceptor.Context context) {
+        return expression.evaluate(request, context);
     }
 
 }

--- a/components/server/src/main/java/com/hotels/styx/server/routing/antlr/Expression.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/antlr/Expression.java
@@ -15,8 +15,9 @@
  */
 package com.hotels.styx.server.routing.antlr;
 
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 
 interface Expression<T> {
-    T evaluate(HttpRequest request);
+    T evaluate(HttpRequest request, HttpInterceptor.Context context);
 }

--- a/components/server/src/main/java/com/hotels/styx/server/routing/antlr/ExpressionVisitor.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/antlr/ExpressionVisitor.java
@@ -37,20 +37,20 @@ class ExpressionVisitor extends ConditionBaseVisitor<Expression<Boolean>> {
     public Expression<Boolean> visitAndExpression(ConditionParser.AndExpressionContext ctx) {
         Expression<Boolean> left = visit(ctx.expression(0));
         Expression<Boolean> right = visit(ctx.expression(1));
-        return request -> left.evaluate(request) && right.evaluate(request);
+        return (request, context) -> left.evaluate(request, context) && right.evaluate(request, context);
     }
 
     @Override
     public Expression<Boolean> visitOrExpression(ConditionParser.OrExpressionContext ctx) {
         Expression<Boolean> left = visit(ctx.expression(0));
         Expression<Boolean> right = visit(ctx.expression(1));
-        return request -> left.evaluate(request) || right.evaluate(request);
+        return (request, context) -> left.evaluate(request, context) || right.evaluate(request, context);
     }
 
     @Override
     public Expression<Boolean> visitNotExpression(ConditionParser.NotExpressionContext ctx) {
         Expression<Boolean> expression = visit(ctx.expression());
-        return request -> !expression.evaluate(request);
+        return (request, context) -> !expression.evaluate(request, context);
     }
 
     @Override
@@ -62,22 +62,22 @@ class ExpressionVisitor extends ConditionBaseVisitor<Expression<Boolean>> {
     @Override
     public Expression<Boolean> visitStringIsPresent(StringIsPresentContext ctx) {
         Expression<String> stringExpression = stringVisitor.visitStringExpression(ctx.stringExpression());
-        return request -> nullToEmpty(stringExpression.evaluate(request)).length() > 0;
+        return (request, context) -> nullToEmpty(stringExpression.evaluate(request, context)).length() > 0;
     }
 
     @Override
     public Expression<Boolean> visitStringEqualsString(ConditionParser.StringEqualsStringContext ctx) {
         Expression<String> left = stringVisitor.visitStringExpression(ctx.stringExpression(0));
         Expression<String> right = stringVisitor.visitStringExpression(ctx.stringExpression(1));
-        return request -> nullToEmpty(left.evaluate(request)).equals(right.evaluate(request));
+        return (request, context) -> nullToEmpty(left.evaluate(request, context)).equals(right.evaluate(request, context));
     }
 
     @Override
     public Expression<Boolean> visitStringMatchesRegexp(ConditionParser.StringMatchesRegexpContext ctx) {
         Expression<String> stringExpression = stringVisitor.visitStringExpression(ctx.stringExpression());
         Pattern pattern = Pattern.compile(stripFirstAndLastCharacter(ctx.string().getText()));
-        return request -> {
-            String evaluate = stringExpression.evaluate(request);
+        return (request, context) -> {
+            String evaluate = stringExpression.evaluate(request, context);
             return pattern.matcher(evaluate).matches();
         };
     }

--- a/components/server/src/main/java/com/hotels/styx/server/routing/antlr/Function0.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/antlr/Function0.java
@@ -15,11 +15,12 @@
  */
 package com.hotels.styx.server.routing.antlr;
 
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 
 /**
  * A Zero argument function.
  */
 public interface Function0 {
-    String call(HttpRequest request);
+    String call(HttpRequest request, HttpInterceptor.Context context);
 }

--- a/components/server/src/main/java/com/hotels/styx/server/routing/antlr/Function1.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/antlr/Function1.java
@@ -15,11 +15,12 @@
  */
 package com.hotels.styx.server.routing.antlr;
 
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 
 /**
  * A One argument function.
  */
 public interface Function1 {
-    String call(HttpRequest request, String input);
+    String call(HttpRequest request, HttpInterceptor.Context context, String input);
 }

--- a/components/server/src/main/java/com/hotels/styx/server/routing/antlr/FunctionResolver.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/antlr/FunctionResolver.java
@@ -15,6 +15,7 @@
  */
 package com.hotels.styx.server.routing.antlr;
 
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 
 import java.util.List;
@@ -47,14 +48,14 @@ class FunctionResolver {
                 Function1 function1 = ensureNotNull(
                         oneArgumentFunctions.get(name),
                         "No such function=[%s], with n=[%d] arguments=[%s]", name, argumentSize, argumentsRepresentation);
-                return request -> function1.call(request, arguments.get(0));
+                return (request, context) -> function1.call(request, context, arguments.get(0));
 
             default:
                 throw new IllegalArgumentException(format("No such function=[%s], with n=[%d] arguments=[%s]", name, argumentSize, argumentsRepresentation));
         }
     }
 
-    private <T> T ensureNotNull(T functionRef, String message, String name, int argumentSize, String argumentsRepresentation) {
+    private static <T> T ensureNotNull(T functionRef, String message, String name, int argumentSize, String argumentsRepresentation) {
         if (functionRef == null) {
             throw new DslFunctionResolutionError(String.format(message, name, argumentSize, argumentsRepresentation));
         }
@@ -62,6 +63,6 @@ class FunctionResolver {
     }
 
     interface PartialFunction {
-        String call(HttpRequest request);
+        String call(HttpRequest request, HttpInterceptor.Context context);
     }
 }

--- a/components/server/src/main/java/com/hotels/styx/server/routing/antlr/StringCompareVisitor.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/antlr/StringCompareVisitor.java
@@ -33,7 +33,7 @@ class StringCompareVisitor extends ConditionBaseVisitor<Expression<String>> {
 
     @Override
     public Expression<String> visitString(ConditionParser.StringContext ctx) {
-        return request -> stripFirstAndLastCharacter(ctx.getText());
+        return (request, context) -> stripFirstAndLastCharacter(ctx.getText());
     }
 
     @Override

--- a/components/server/src/test/java/com/hotels/styx/server/routing/AntlrMatcherTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/routing/AntlrMatcherTest.java
@@ -15,6 +15,7 @@
  */
 package com.hotels.styx.server.routing;
 
+import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.Test;
 
 import static com.hotels.styx.api.HttpRequest.get;
@@ -23,11 +24,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AntlrMatcherTest {
 
+    private final HttpInterceptorContext context = HttpInterceptorContext.create();
+
     @Test
     public void matchesHttpProtocol() throws Exception {
         AntlrMatcher matcher = AntlrMatcher.antlrMatcher("protocol() == 'https'");
-        assertThat(matcher.apply(get("/path").secure(true).build()), is(true));
-        assertThat(matcher.apply(get("/path").secure(false).build()), is(false));
+        assertThat(matcher.apply(get("/path").secure(true).build(), context), is(true));
+        assertThat(matcher.apply(get("/path").secure(false).build(), context), is(false));
     }
 
 }


### PR DESCRIPTION
This is preparatory work for issue #274. The second part of implementing #274 will move the `isSecure` method from `HttpRequest` into `HttpInterceptor.Context`.

Before `isSecure` can be removed from `HttpRequest` class, we must make sure our ANTLR based routing DSL, specifically the `protocol()` function, keeps working. After #274 the actual transport protocol has to be determined from HTTP context. To make the context available to routers, this PR is adding it as an extra argument to `HttpRouter.route` method:

```
    Optional<HttpHandler> route(HttpRequest request, HttpInterceptor.Context context);
```


