### PR TITLE
Move isSecure flag to HttpInterceptor.Context

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/FullHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FullHttpRequest.java
@@ -88,7 +88,6 @@ public class FullHttpRequest implements FullHttpMessage {
     private final HttpMethod method;
     private final Url url;
     private final HttpHeaders headers;
-    private final boolean secure;
     private final byte[] body;
 
     FullHttpRequest(Builder builder) {
@@ -97,7 +96,6 @@ public class FullHttpRequest implements FullHttpMessage {
         this.version = builder.version;
         this.method = builder.method;
         this.url = builder.url;
-        this.secure = builder.secure;
         this.headers = builder.headers.build();
         this.body = requireNonNull(builder.body);
     }
@@ -259,13 +257,6 @@ public class FullHttpRequest implements FullHttpMessage {
         return HttpMessageSupport.keepAlive(headers, version);
     }
 
-    /**
-     * @deprecated will be removed from the final 1.0 API release
-     */
-    @Deprecated
-    public boolean isSecure() {
-        return secure;
-    }
 
     // Relic of old API, kept only for conversions
     InetSocketAddress clientAddress() {
@@ -372,7 +363,6 @@ public class FullHttpRequest implements FullHttpMessage {
                 .add("uri", url)
                 .add("headers", headers)
                 .add("id", id)
-                .add("secure", secure)
                 .toString();
     }
 
@@ -387,7 +377,6 @@ public class FullHttpRequest implements FullHttpMessage {
         private InetSocketAddress clientAddress = LOCAL_HOST;
         private boolean validate = true;
         private Url url;
-        private boolean secure;
         private HttpHeaders.Builder headers;
         private HttpVersion version = HTTP_1_1;
         private byte[] body;
@@ -411,7 +400,6 @@ public class FullHttpRequest implements FullHttpMessage {
             this();
             this.method = requireNonNull(method);
             this.url = Url.Builder.url(uri).build();
-            this.secure = url.isSecure();
         }
 
         /**
@@ -425,7 +413,6 @@ public class FullHttpRequest implements FullHttpMessage {
             this.method = request.method();
             this.clientAddress = request.clientAddress();
             this.url = request.url();
-            this.secure = request.isSecure();
             this.version = request.version();
             this.headers = request.headers().newBuilder();
             this.body = body;
@@ -436,7 +423,6 @@ public class FullHttpRequest implements FullHttpMessage {
             this.method = request.method();
             this.clientAddress = request.clientAddress;
             this.url = request.url();
-            this.secure = request.isSecure();
             this.version = request.version();
             this.headers = request.headers().newBuilder();
             this.body = request.body();
@@ -574,7 +560,6 @@ public class FullHttpRequest implements FullHttpMessage {
          */
         public Builder url(Url url) {
             this.url = url;
-            this.secure = url.isSecure();
             return this;
         }
 
@@ -689,17 +674,6 @@ public class FullHttpRequest implements FullHttpMessage {
 
         private static <T> Set<T> toSet(Collection<T> collection) {
             return collection instanceof Set ? (Set<T>) collection : ImmutableSet.copyOf(collection);
-        }
-
-        /**
-         * Sets whether the request is be secure.
-         *
-         * @param secure true if secure
-         * @return {@code this}
-         */
-        public Builder secure(boolean secure) {
-            this.secure = secure;
-            return this;
         }
 
         /**

--- a/components/api/src/main/java/com/hotels/styx/api/HttpInterceptor.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpInterceptor.java
@@ -51,6 +51,13 @@ public interface HttpInterceptor {
         default <T> Optional<T> getIfAvailable(String key, Class<T> clazz) {
             return Optional.ofNullable(get(key, clazz));
         }
+
+        /**
+         * Returns true if this request was received over a secure connection.
+         *
+         * @return returns true if this request was received over a secure connection
+         */
+        boolean isSecure();
     }
 
     /**

--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -107,7 +107,6 @@ public class HttpRequest implements StreamingHttpMessage {
     private final HttpMethod method;
     private final Url url;
     private final HttpHeaders headers;
-    private final boolean secure;
     private final StyxObservable<ByteBuf> body;
 
     HttpRequest(Builder builder) {
@@ -116,7 +115,6 @@ public class HttpRequest implements StreamingHttpMessage {
         this.version = builder.version;
         this.method = builder.method;
         this.url = builder.url;
-        this.secure = builder.secure;
         this.headers = builder.headers.build();
         this.body = requireNonNull(builder.body);
     }
@@ -291,21 +289,8 @@ public class HttpRequest implements StreamingHttpMessage {
     }
 
     /**
-     * @deprecated will be removed from the final 1.0 API release
+     * @deprecated will be removed from Styx 1.0 api release
      */
-    @Deprecated
-    public boolean isSecure() {
-        return secure;
-    }
-
-    /**
-     * Will be removed in due course.
-     *
-     * @deprecated will not appear in 1.0 interface
-     *
-     * @return
-     */
-    // Relic of old API, kept only for conversions
     @Deprecated
     public InetSocketAddress clientAddress() {
         return this.clientAddress;
@@ -444,7 +429,6 @@ public class HttpRequest implements StreamingHttpMessage {
                 .add("uri", url)
                 .add("headers", headers)
                 .add("id", id)
-                .add("secure", secure)
                 .add("clientAddress", clientAddress)
                 .toString();
     }
@@ -460,7 +444,6 @@ public class HttpRequest implements StreamingHttpMessage {
         private InetSocketAddress clientAddress = LOCAL_HOST;
         private boolean validate = true;
         private Url url;
-        private boolean secure;
         private HttpHeaders.Builder headers;
         private HttpVersion version = HTTP_1_1;
         private StyxObservable<ByteBuf> body;
@@ -484,7 +467,6 @@ public class HttpRequest implements StreamingHttpMessage {
             this();
             this.method = requireNonNull(method);
             this.url = Url.Builder.url(uri).build();
-            this.secure = url.isSecure();
         }
 
         /**
@@ -498,7 +480,6 @@ public class HttpRequest implements StreamingHttpMessage {
             this.method = httpMethod(request.method().name());
             this.clientAddress = request.clientAddress();
             this.url = request.url();
-            this.secure = request.isSecure();
             this.version = httpVersion(request.version().toString());
             this.headers = request.headers().newBuilder();
             this.body = body;
@@ -509,7 +490,6 @@ public class HttpRequest implements StreamingHttpMessage {
             this.method = request.method();
             this.clientAddress = request.clientAddress();
             this.url = request.url();
-            this.secure = request.isSecure();
             this.version = request.version();
             this.headers = request.headers().newBuilder();
             this.body = request.body();
@@ -520,7 +500,6 @@ public class HttpRequest implements StreamingHttpMessage {
             this.method = request.method();
             this.clientAddress = request.clientAddress();
             this.url = request.url();
-            this.secure = request.isSecure();
             this.version = request.version();
             this.headers = request.headers().newBuilder();
             this.body = StyxCoreObservable.of(copiedBuffer(request.body()));
@@ -616,7 +595,6 @@ public class HttpRequest implements StreamingHttpMessage {
          */
         public Builder url(Url url) {
             this.url = url;
-            this.secure = url.isSecure();
             return this;
         }
 
@@ -653,20 +631,6 @@ public class HttpRequest implements StreamingHttpMessage {
         @Deprecated
         public Builder clientAddress(InetSocketAddress clientAddress) {
             this.clientAddress = clientAddress;
-            return this;
-        }
-
-        /**
-         * Don't use. Will be removed soon.
-         *
-         * @deprecated Will not appear in 1.0 API.
-         *
-         * @param secure true if secure
-         * @return {@code this}
-         */
-        @Deprecated
-        public Builder secure(boolean secure) {
-            this.secure = secure;
             return this;
         }
 

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -601,8 +601,8 @@ public class HttpResponse implements StreamingHttpMessage {
          * When validation is enabled (by default), ensures that:
          *
          * <li>
-         *     <ul> There is maximum of only one {@code Content-Length} header
-         *     <ul> The {@code Content-Length} header is zero or positive integer
+         *     <ul>There is maximum of only one {@code Content-Length} header</ul>
+         *     <ul>The {@code Content-Length} header is zero or positive integer</ul>
          * </li>
          *
          * @throws IllegalArgumentException when validation fails

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
@@ -151,7 +151,7 @@ public class TlsSettings {
          * When true, styx will not attempt to authenticate backend servers.
          * It will accept any certificate presented by the origins.
          *
-         * @deprecated
+         * @deprecated will be removed in future
          * @param trustAllCerts
          * @return
          */

--- a/components/api/src/test/java/com/hotels/styx/api/FullHttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/FullHttpRequestTest.java
@@ -58,7 +58,6 @@ public class FullHttpRequestTest {
     @Test
     public void convertsToStreamingHttpRequest() throws Exception {
         FullHttpRequest fullRequest = new FullHttpRequest.Builder(POST, "/foo/bar").body("foobar", UTF_8)
-                .secure(true)
                 .version(HTTP_1_1)
                 .header("HeaderName", "HeaderValue")
                 .cookies(requestCookie("CookieName", "CookieValue"))
@@ -68,7 +67,6 @@ public class FullHttpRequestTest {
 
         assertThat(streaming.method(), is(HttpMethod.POST));
         assertThat(streaming.url(), is(url("/foo/bar").build()));
-        assertThat(streaming.isSecure(), is(true));
         assertThat(streaming.version(), is(HTTP_1_1));
         assertThat(streaming.headers(), containsInAnyOrder(
                 header("Content-Length", "6"),
@@ -118,7 +116,6 @@ public class FullHttpRequestTest {
         assertThat(request.url().toString(), is("/index"));
         assertThat(request.path(), is("/index"));
         assertThat(request.id(), is(notNullValue()));
-        assertThat(request.isSecure(), is(false));
         assertThat(request.cookies(), is(emptyIterable()));
         assertThat(request.headers(), is(emptyIterable()));
         assertThat(request.headers("any"), is(emptyIterable()));
@@ -142,7 +139,7 @@ public class FullHttpRequestTest {
                 .build();
 
         assertThat(request.toString(), is("FullHttpRequest{version=HTTP/1.1, method=PATCH, uri=https://hotels.com, " +
-                "headers=[headerName=a, Cookie=cfoo=bar, Host=hotels.com], id=id, secure=true}"));
+                "headers=[headerName=a, Cookie=cfoo=bar, Host=hotels.com], id=id}"));
 
         assertThat(request.headers("headerName"), is(singletonList("a")));
     }
@@ -259,12 +256,6 @@ public class FullHttpRequestTest {
 
         assertThat(request.bodyAs(UTF_8), is("Original body"));
         assertThat(newRequest.bodyAs(UTF_8), is("New body"));
-    }
-
-    @Test
-    public void shouldDetermineIfRequestIsSecure() {
-        assertThat(get("https://hotels.com").build().isSecure(), is(true));
-        assertThat(get("http://hotels.com").build().isSecure(), is(false));
     }
 
     @Test

--- a/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
@@ -59,7 +59,6 @@ public class HttpRequestTest {
     @Test
     public void decodesToFullHttpRequest() throws Exception {
         HttpRequest streamingRequest = post("/foo/bar", body("foo", "bar"))
-                .secure(true)
                 .version(HTTP_1_0)
                 .header("HeaderName", "HeaderValue")
                 .cookies(requestCookie("CookieName", "CookieValue"))
@@ -71,7 +70,6 @@ public class HttpRequestTest {
 
         assertThat(full.method(), is(POST));
         assertThat(full.url(), is(url("/foo/bar").build()));
-        assertThat(full.isSecure(), is(true));
         assertThat(full.version(), is(HTTP_1_0));
         assertThat(full.headers(), containsInAnyOrder(
                 header("HeaderName", "HeaderValue"),
@@ -123,7 +121,6 @@ public class HttpRequestTest {
         assertThat(request.path(), is("/index"));
         assertThat(request.clientAddress().getHostName(), is("127.0.0.1"));
         assertThat(request.id(), is(notNullValue()));
-        assertThat(request.isSecure(), is(false));
         assertThat(request.cookies(), is(emptyIterable()));
         assertThat(request.headers(), is(emptyIterable()));
         assertThat(request.headers("any"), is(emptyIterable()));
@@ -147,7 +144,7 @@ public class HttpRequestTest {
                 .build();
 
         assertThat(request.toString(), is("HttpRequest{version=HTTP/1.0, method=PATCH, uri=https://hotels.com, headers=[headerName=a, Cookie=cfoo=bar, Host=hotels.com]," +
-                " id=id, secure=true, clientAddress=127.0.0.1:0}"));
+                " id=id, clientAddress=127.0.0.1:0}"));
 
         assertThat(request.headers("headerName"), is(singletonList("a")));
     }
@@ -167,12 +164,6 @@ public class HttpRequestTest {
         assertThat(newRequest.method(), is(DELETE));
         assertThat(newRequest.url().path(), is("/home"));
         assertThat(newRequest.headers(), hasItem(header("remove", "notanymore")));
-    }
-
-    @Test
-    public void shouldDetermineIfRequestIsSecure() {
-        assertThat(get("https://hotels.com").build().isSecure(), is(true));
-        assertThat(get("http://hotels.com").build().isSecure(), is(false));
     }
 
     @Test

--- a/components/api/src/test/java/com/hotels/styx/api/MockContext.java
+++ b/components/api/src/test/java/com/hotels/styx/api/MockContext.java
@@ -28,4 +28,9 @@ public class MockContext implements HttpInterceptor.Context {
     public <T> T get(String key, Class<T> clazz) {
         return null;
     }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
 }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/SimpleHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/SimpleHttpClientTest.java
@@ -188,13 +188,14 @@ public class SimpleHttpClientTest {
     @Test
     public void sendsToDefaultHttpsPort() {
         Connection.Factory connectionFactory = mockConnectionFactory(mockConnection(response(OK).build()));
+        TlsSettings tlsSettings = mock(TlsSettings.class);
 
         SimpleHttpClient client = new SimpleHttpClient.Builder()
                 .setConnectionFactory(connectionFactory)
+                .tlsSettings(tlsSettings)
                 .build();
 
         client.sendRequest(get("/")
-                .secure(true)
                 .header(HOST, "localhost")
                 .build());
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/HttpRequestMessageLoggerTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/HttpRequestMessageLoggerTest.java
@@ -66,19 +66,19 @@ public class HttpRequestMessageLoggerTest {
     @Test
     public void logsClientSideRequestShortFormat() {
         HttpRequest styxRequest = get("http://www.hotels.com/foo/bar/request").build();
-        new HttpRequestMessageLogger("com.hotels.styx.http-messages.outbound", false).logRequest(styxRequest, origin);
+        new HttpRequestMessageLogger("com.hotels.styx.http-messages.outbound", false).logRequest(styxRequest, origin, true);
 
-        assertThat(log.lastMessage(), is(loggingEvent(INFO, format("requestId=%s, request=\\{method=GET, secure=false, uri=%s, origin=\"%s\"\\}",
+        assertThat(log.lastMessage(), is(loggingEvent(INFO, format("requestId=%s, secure=true, request=\\{method=GET, uri=%s, origin=\"%s\"\\}",
                 styxRequest.id(), styxRequest.url(), origin.hostAndPortString()))));
     }
 
     @Test
     public void logsClientSideRequestLongFormat() {
         HttpRequest styxRequest = get("http://www.hotels.com/foo/bar/request").build();
-        new HttpRequestMessageLogger("com.hotels.styx.http-messages.outbound", true).logRequest(styxRequest, origin);
+        new HttpRequestMessageLogger("com.hotels.styx.http-messages.outbound", true).logRequest(styxRequest, origin, true);
 
         assertThat(log.lastMessage(), is(loggingEvent(INFO,
-                format("requestId=%s, request=\\{method=GET, secure=false, uri=%s, origin=\"%s\", headers=\\[Host=www.hotels.com\\]\\}",
+                format("requestId=%s, secure=true, request=\\{method=GET, uri=%s, origin=\"%s\", headers=\\[Host=www.hotels.com\\]\\}",
                         styxRequest.id(), styxRequest.url(), origin.hostAndPortString()))));
     }
 
@@ -102,7 +102,7 @@ public class HttpRequestMessageLoggerTest {
 
     @Test
     public void requestLoggingDoesNotThrowExceptionWhenReceivingNullArguments() {
-        new HttpRequestMessageLogger("com.hotels.styx.http-messages.outbound", false).logRequest(null, origin);
+        new HttpRequestMessageLogger("com.hotels.styx.http-messages.outbound", false).logRequest(null, origin, true);
 
         assertThat(log.lastMessage(), is(loggingEvent(WARN, "requestId=N/A, request=null, origin=MyApp:h1:hostA:80")));
     }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagatorTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagatorTest.java
@@ -17,9 +17,9 @@ package com.hotels.styx.client.netty.connectionpool;
 
 import com.google.common.base.Throwables;
 import com.hotels.styx.api.HttpResponse;
-import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.exceptions.ResponseTimeoutException;
 import com.hotels.styx.api.exceptions.TransportLostException;
+import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.client.BadHttpResponseException;
 import com.hotels.styx.client.StyxClientException;
 import io.netty.buffer.ByteBuf;
@@ -43,11 +43,10 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static com.google.common.net.HostAndPort.fromParts;
 import static com.hotels.styx.api.Id.GENERIC_APP;
+import static com.hotels.styx.api.ResponseCookie.responseCookie;
 import static com.hotels.styx.api.StyxInternalObservables.toRxObservable;
 import static com.hotels.styx.api.extension.Origin.newOriginBuilder;
-import static com.hotels.styx.api.ResponseCookie.responseCookie;
 import static com.hotels.styx.client.netty.connectionpool.NettyToStyxResponsePropagator.toStyxResponse;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
 import static io.netty.buffer.Unpooled.copiedBuffer;

--- a/components/common/src/main/java/com/hotels/styx/common/logging/HttpRequestMessageLogger.java
+++ b/components/common/src/main/java/com/hotels/styx/common/logging/HttpRequestMessageLogger.java
@@ -38,7 +38,15 @@ public class HttpRequestMessageLogger {
         if (request == null) {
             logger.warn("requestId=N/A, request=null, origin={}", origin);
         } else {
-            logger.info("requestId={}, request={}", request.id(), information(request, origin, longFormatEnabled));
+            logger.info("requestId={}, request={}", new Object[] {request.id(), information(request, origin, longFormatEnabled)});
+        }
+    }
+
+    public void logRequest(HttpRequest request, Origin origin, boolean secure) {
+        if (request == null) {
+            logger.warn("requestId=N/A, request=null, origin={}", origin);
+        } else {
+            logger.info("requestId={}, secure={}, request={}", new Object[] {request.id(), secure, information(request, origin, longFormatEnabled)});
         }
     }
 
@@ -47,6 +55,14 @@ public class HttpRequestMessageLogger {
             logger.warn("requestId={}, response=null", id(request));
         } else {
             logger.info("requestId={}, response={}", id(request), information(response, longFormatEnabled));
+        }
+    }
+
+    public void logResponse(HttpRequest request, HttpResponse response, boolean secure) {
+        if (response == null) {
+            logger.warn("requestId={}, response=null", id(request));
+        } else {
+            logger.info("requestId={}, secure={}, response={}", new Object[] {id(request), secure, information(response, longFormatEnabled)});
         }
     }
 
@@ -66,7 +82,6 @@ public class HttpRequestMessageLogger {
     private static Info information(HttpRequest request, Origin origin, boolean longFormatEnabled) {
         Info info = new Info()
                 .add("method", request.method())
-                .add("secure", request.isSecure())
                 .add("uri", request.url())
                 .add("origin", origin != null ? origin.hostAndPortString() : "N/A");
 

--- a/components/common/src/main/java/com/hotels/styx/server/HttpInterceptorContext.java
+++ b/components/common/src/main/java/com/hotels/styx/server/HttpInterceptorContext.java
@@ -25,6 +25,11 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class HttpInterceptorContext implements HttpInterceptor.Context {
     private final Map<String, Object> context = new ConcurrentHashMap<>();
+    private boolean secure;
+
+    private HttpInterceptorContext(boolean secure) {
+        this.secure = secure;
+    }
 
     @Override
     public void add(String key, Object value) {
@@ -36,7 +41,16 @@ public final class HttpInterceptorContext implements HttpInterceptor.Context {
         return (T) context.get(key);
     }
 
+    @Override
+    public boolean isSecure() {
+        return secure;
+    }
+
     public static HttpInterceptorContext create() {
-        return new HttpInterceptorContext();
+        return new HttpInterceptorContext(false);
+    }
+
+    public static HttpInterceptorContext create(boolean secure) {
+        return new HttpInterceptorContext(secure);
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyConnectorFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyConnectorFactory.java
@@ -160,13 +160,13 @@ class ProxyConnectorFactory implements ServerConnectorFactory {
                             .errorStatusListener(httpErrorStatusListener)
                             .progressListener(requestStatsCollector)
                             .metricRegistry(metrics)
+                            .secure(sslContext.isPresent())
                             .build());
         }
 
 
         private NettyToStyxRequestDecoder requestTranslator() {
             return new NettyToStyxRequestDecoder.Builder()
-                    .secure(isHttps())
                     .flowControlEnabled(true)
                     .unwiseCharEncoder(unwiseCharEncoder)
                     .build();

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/interceptors/HttpMessageLoggingInterceptor.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/interceptors/HttpMessageLoggingInterceptor.java
@@ -34,17 +34,14 @@ public class HttpMessageLoggingInterceptor implements HttpInterceptor {
 
     @Override
     public StyxObservable<HttpResponse> intercept(HttpRequest request, Chain chain) {
-        log(request);
-        return chain.proceed(request).map(response -> log(request, response));
-    }
-
-    private HttpResponse log(HttpRequest request, HttpResponse response) {
-        logger.logResponse(request, response);
-        return response;
-    }
-
-    private void log(HttpRequest request) {
         // Note that the request ID is repeated for request logging so that a single search term can be used to find both request and response logs.
-        logger.logRequest(request, null);
+        boolean secure = chain.context().isSecure();
+        logger.logRequest(request, null, secure);
+
+        return chain.proceed(request).map(response -> {
+            logger.logResponse(request, response, secure);
+            return response;
+        });
     }
+
 }

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/interceptors/RequestEnrichingInterceptor.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/interceptors/RequestEnrichingInterceptor.java
@@ -37,21 +37,21 @@ public class RequestEnrichingInterceptor implements HttpInterceptor {
 
     @Override
     public StyxObservable<HttpResponse> intercept(HttpRequest request, Chain chain) {
-        return chain.proceed(enrich(request));
+        return chain.proceed(enrich(request, chain.context().isSecure()));
     }
 
-    private HttpRequest enrich(HttpRequest request) {
+    private HttpRequest enrich(HttpRequest request, boolean secure) {
         return request.newBuilder()
                 .header(requestIdHeaderName, request.id())
                 .header(X_FORWARDED_FOR, xForwardedFor(request))
-                .header(X_FORWARDED_PROTO, xForwardedProto(request))
+                .header(X_FORWARDED_PROTO, xForwardedProto(request, secure))
                 .build();
     }
 
-    private static CharSequence xForwardedProto(HttpRequest request) {
+    private static CharSequence xForwardedProto(HttpRequest request, boolean secure) {
         return request
                 .header(X_FORWARDED_PROTO)
-                .orElse(request.isSecure() ? "https" : "http");
+                .orElse(secure ? "https" : "http");
     }
 
     private static String xForwardedFor(HttpRequest request) {

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ConfigurationContextResolverInterceptorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ConfigurationContextResolverInterceptorTest.java
@@ -96,6 +96,11 @@ public class ConfigurationContextResolverInterceptorTest {
             public <T> T get(String key, Class<T> type) {
                 return type.cast(map.get(key));
             }
+
+            @Override
+            public boolean isSecure() {
+                return false;
+            }
         }
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/RequestRecordingChain.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/RequestRecordingChain.java
@@ -15,6 +15,7 @@
  */
 package com.hotels.styx.proxy.interceptors;
 
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpInterceptor.Chain;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.StyxObservable;
@@ -40,6 +41,11 @@ public final class RequestRecordingChain implements Chain {
     public StyxObservable<HttpResponse> proceed(HttpRequest request) {
         this.request = request;
         return delegate.proceed(request);
+    }
+
+    @Override
+    public HttpInterceptor.Context context() {
+        return delegate.context();
     }
 
     public HttpRequest recordedRequest() {

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ReturnResponseChain.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ReturnResponseChain.java
@@ -16,12 +16,14 @@
 package com.hotels.styx.proxy.interceptors;
 
 import com.hotels.styx.api.FullHttpResponse;
+import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpInterceptor.Chain;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.StyxObservable;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import com.hotels.styx.api.HttpRequest;
+import com.hotels.styx.server.HttpInterceptorContext;
 
 /**
  * A handler that return whatever response returned from the passed in handler.
@@ -29,13 +31,23 @@ import com.hotels.styx.api.HttpRequest;
  */
 public final class ReturnResponseChain implements Chain {
     private final HttpResponse response;
+    private HttpInterceptor.Context context;
 
-    private ReturnResponseChain(HttpResponse response) {
+    private ReturnResponseChain(HttpResponse response, HttpInterceptor.Context context) {
         this.response = response;
+        this.context = context;
+    }
+
+    public HttpInterceptor.Context context() {
+        return context;
     }
 
     public static ReturnResponseChain returnsResponse(HttpResponse response) {
-        return new ReturnResponseChain(response);
+        return new ReturnResponseChain(response, HttpInterceptorContext.create());
+    }
+
+    public static ReturnResponseChain returnsResponse(HttpResponse response, HttpInterceptor.Context context) {
+        return new ReturnResponseChain(response, context);
     }
 
     public static ReturnResponseChain returnsResponse(String response) {

--- a/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/ConditionRouterConfigSpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/ConditionRouterConfigSpec.scala
@@ -32,8 +32,7 @@ import scala.collection.JavaConversions._
 
 class ConditionRouterConfigSpec extends FunSpec with ShouldMatchers with MockitoSugar {
 
-  private val httpsRequest = HttpRequest.get("/foo").secure(true).build
-  private val httpRequest = HttpRequest.get("/foo").secure(false).build
+  private val request = HttpRequest.get("/foo").build
   private val routeHandlerFactory = new RouteHandlerFactory(Map("StaticResponseHandler" -> new StaticResponseHandler.ConfigFactory), Map[String, HttpHandler]())
 
   private val config = configBlock(
@@ -73,7 +72,7 @@ class ConditionRouterConfigSpec extends FunSpec with ShouldMatchers with Mockito
 
   it("Builds an instance with fallback handler") {
     val router = new ConditionRouter.ConfigFactory().build(List(), routeHandlerFactory, config)
-    val response = StyxFutures.await(router.handle(httpsRequest, HttpInterceptorContext.create)
+    val response = StyxFutures.await(router.handle(request, HttpInterceptorContext.create(true))
     .asCompletableFuture())
 
     response.status() should be(OK)
@@ -81,7 +80,7 @@ class ConditionRouterConfigSpec extends FunSpec with ShouldMatchers with Mockito
 
   it("Builds condition router instance routes") {
     val router = new ConditionRouter.ConfigFactory().build(List(), routeHandlerFactory, config)
-    val response = StyxFutures.await(router.handle(httpRequest, HttpInterceptorContext.create).asCompletableFuture())
+    val response = StyxFutures.await(router.handle(request, HttpInterceptorContext.create(false)).asCompletableFuture())
 
     response.status().code() should be(301)
   }
@@ -96,7 +95,7 @@ class ConditionRouterConfigSpec extends FunSpec with ShouldMatchers with Mockito
 
     val router = new ConditionRouter.ConfigFactory().build(List(), routeHandlerFactory, configWithReferences)
 
-    val resp = StyxFutures.await(router.handle(httpRequest, HttpInterceptorContext.create).asCompletableFuture())
+    val resp = StyxFutures.await(router.handle(request, HttpInterceptorContext.create(false)).asCompletableFuture())
 
     resp.header("source").get() should be("fallback")
   }
@@ -115,7 +114,7 @@ class ConditionRouterConfigSpec extends FunSpec with ShouldMatchers with Mockito
       configWithReferences
       )
 
-    val resp = StyxFutures.await(router.handle(httpsRequest, HttpInterceptorContext.create).asCompletableFuture())
+    val resp = StyxFutures.await(router.handle(request, HttpInterceptorContext.create(true)).asCompletableFuture())
 
     resp.header("source").get() should be("secure")
   }
@@ -160,7 +159,7 @@ class ConditionRouterConfigSpec extends FunSpec with ShouldMatchers with Mockito
         |""".stripMargin)
 
     val router = new ConditionRouter.ConfigFactory().build(List(), routeHandlerFactory, config)
-    val resp = StyxFutures.await(router.handle(httpRequest, HttpInterceptorContext.create).asCompletableFuture())
+    val resp = StyxFutures.await(router.handle(request, HttpInterceptorContext.create(false)).asCompletableFuture())
 
     resp.status() should be(BAD_GATEWAY)
   }

--- a/components/server/src/main/java/com/hotels/styx/server/routing/AntlrMatcher.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/AntlrMatcher.java
@@ -30,7 +30,7 @@ public final class AntlrMatcher implements Matcher {
             .registerFunction("method", (request, context) -> request.method().name())
             .registerFunction("path", (request, context) -> request.path())
             .registerFunction("userAgent", (request, context) -> request.header(USER_AGENT).orElse(""))
-            .registerFunction("protocol", (request, context) -> request.isSecure() ? "https" : "http")
+            .registerFunction("protocol", (request, context) -> context.isSecure() ? "https" : "http")
             .registerFunction("header", (request, context, input) -> request.header(input).orElse(""))
             .registerFunction("cookie", (request, context, input) -> request.cookie(input).map(RequestCookie::value).orElse(""))
             .build();

--- a/components/server/src/test/java/com/hotels/styx/server/routing/AntlrMatcherTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/routing/AntlrMatcherTest.java
@@ -24,13 +24,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AntlrMatcherTest {
 
-    private final HttpInterceptorContext context = HttpInterceptorContext.create();
+    private final HttpInterceptorContext contextHttps = HttpInterceptorContext.create(true);
+    private final HttpInterceptorContext contextHttp = HttpInterceptorContext.create();
 
     @Test
     public void matchesHttpProtocol() throws Exception {
         AntlrMatcher matcher = AntlrMatcher.antlrMatcher("protocol() == 'https'");
-        assertThat(matcher.apply(get("/path").secure(true).build(), context), is(true));
-        assertThat(matcher.apply(get("/path").secure(false).build(), context), is(false));
+        assertThat(matcher.apply(get("/path").build(), contextHttps), is(true));
+        assertThat(matcher.apply(get("/path").build(), contextHttp), is(false));
     }
 
 }

--- a/support/api-testsupport/src/main/java/com/hotels/styx/server/HttpInterceptorContext.java
+++ b/support/api-testsupport/src/main/java/com/hotels/styx/server/HttpInterceptorContext.java
@@ -29,6 +29,11 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class HttpInterceptorContext implements HttpInterceptor.Context {
     private final Map<String, Object> context = new ConcurrentHashMap<>();
+    private boolean secure;
+
+    private HttpInterceptorContext(boolean secure) {
+        this.secure = secure;
+    }
 
     @Override
     public void add(String key, Object value) {
@@ -40,7 +45,16 @@ public final class HttpInterceptorContext implements HttpInterceptor.Context {
         return (T) context.get(key);
     }
 
+    @Override
+    public boolean isSecure() {
+        return secure;
+    }
+
     public static HttpInterceptorContext create() {
-        return new HttpInterceptorContext();
+        return new HttpInterceptorContext(false);
+    }
+
+    public static HttpInterceptorContext create(boolean secure) {
+        return new HttpInterceptorContext(secure);
     }
 }

--- a/support/test-api/src/main/java/com/hotels/styx/testapi/HttpInterceptorContext.java
+++ b/support/test-api/src/main/java/com/hotels/styx/testapi/HttpInterceptorContext.java
@@ -27,6 +27,11 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class HttpInterceptorContext implements HttpInterceptor.Context {
     private final Map<String, Object> context = new ConcurrentHashMap<>();
+    private final boolean secure;
+
+    private HttpInterceptorContext(boolean secure) {
+        this.secure = secure;
+    }
 
     @Override
     public void add(String key, Object value) {
@@ -38,7 +43,16 @@ public final class HttpInterceptorContext implements HttpInterceptor.Context {
         return (T) context.get(key);
     }
 
+    @Override
+    public boolean isSecure() {
+        return secure;
+    }
+
     public static HttpInterceptorContext create() {
-        return new HttpInterceptorContext();
+        return new HttpInterceptorContext(false);
+    }
+
+    public static HttpInterceptorContext create(boolean secure) {
+        return new HttpInterceptorContext(secure);
     }
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxClientSupplier.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxClientSupplier.scala
@@ -46,15 +46,17 @@ trait StyxClientSupplier {
 
   private def doSecureRequest(request: FullHttpRequest): Future[FullHttpResponse] = httpsClient.sendRequest(request).toScala
 
-  private def doRequest(request: FullHttpRequest, debug: Boolean = false): Future[FullHttpResponse] = if (request.isSecure)
+  private def doRequest(request: FullHttpRequest, debug: Boolean = false, secure: Boolean = false): Future[FullHttpResponse] = if (secure)
     doSecureRequest(request)
   else
     doHttpRequest(request, debug = debug)
 
   def decodedRequest(request: FullHttpRequest,
                      debug: Boolean = false,
-                     maxSize: Int = 1024 * 1024, timeout: Duration = 30.seconds): FullHttpResponse = {
-    val future = doRequest(request, debug = debug)
+                     maxSize: Int = 1024 * 1024, timeout: Duration = 30.seconds,
+                     secure: Boolean = false
+                    ): FullHttpResponse = {
+    val future = doRequest(request, debug = debug, secure = secure)
       .map(response => {
         if (debug) {
           println("StyxClientSupplier: received response for: " + request.url().path())

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpMessageLoggingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpMessageLoggingSpec.scala
@@ -113,17 +113,17 @@ class HttpMessageLoggingSpec extends FunSpec
         assertThat(logger.log.size(), is(2))
 
         assertThat(logger.log(), hasItem(loggingEvent(INFO,
-          "requestId=[-a-z0-9]+, request=\\{method=GET, secure=false, uri=http://localhost:[0-9]+/foobar, origin=\"N/A\", headers=\\[Host=localhost:[0-9]+\\]}")))
+          "requestId=[-a-z0-9]+, secure=false, request=\\{method=GET, uri=http://localhost:[0-9]+/foobar, origin=\"N/A\", headers=\\[Host=localhost:[0-9]+\\]}")))
 
         assertThat(logger.log(), hasItem(loggingEvent(INFO,
-          "requestId=[-a-z0-9]+, response=\\{status=200 OK, headers=\\[Server=Jetty\\(6.1.26\\), " + ORIGIN_ID_DEFAULT + "=generic-app-01, Via=1.1 styx\\]\\}")))
+          "requestId=[-a-z0-9]+, secure=false, response=\\{status=200 OK, headers=\\[Server=Jetty\\(6.1.26\\), " + ORIGIN_ID_DEFAULT + "=generic-app-01, Via=1.1 styx\\]\\}")))
       }
     }
 
     it("Should log HTTPS request") {
       val request = get(styxServer.secureRouterURL("/foobar")).build()
 
-      val resp = decodedRequest(request)
+      val resp = decodedRequest(request, secure = true)
 
       assertThat(resp.status(), is(OK))
 
@@ -131,10 +131,10 @@ class HttpMessageLoggingSpec extends FunSpec
         assertThat(logger.log.size(), is(2))
 
         assertThat(logger.log(), hasItem(loggingEvent(INFO,
-          "requestId=[-a-z0-9]+, request=\\{method=GET, secure=true, uri=https://localhost:[0-9]+/foobar, origin=\"N/A\", headers=.*}")))
+          "requestId=[-a-z0-9]+, secure=true, request=\\{method=GET, uri=https://localhost:[0-9]+/foobar, origin=\"N/A\", headers=.*}")))
 
         assertThat(logger.log(), hasItem(loggingEvent(INFO,
-          "requestId=[-a-z0-9]+, response=\\{status=200 OK, headers=\\[Server=Jetty\\(6.1.26\\), " + ORIGIN_ID_DEFAULT + "=generic-app-01, Via=1.1 styx\\]\\}")))
+          "requestId=[-a-z0-9]+, secure=true, response=\\{status=200 OK, headers=\\[Server=Jetty\\(6.1.26\\), " + ORIGIN_ID_DEFAULT + "=generic-app-01, Via=1.1 styx\\]\\}")))
       }
     }
   }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpOutboundMessageLoggingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/HttpOutboundMessageLoggingSpec.scala
@@ -112,7 +112,7 @@ class HttpOutboundMessageLoggingSpec extends FunSpec
         assertThat(logger.log.size(), is(2))
 
         assertThat(logger.log(), hasItem(loggingEvent(INFO,
-          "requestId=[-a-z0-9]+, request=\\{method=GET, secure=false, uri=http://localhost:[0-9]+/foobar, origin=\"localhost:[0-9]+\", headers=\\[.*\\]}")))
+          "requestId=[-a-z0-9]+, request=\\{method=GET, uri=http://localhost:[0-9]+/foobar, origin=\"localhost:[0-9]+\", headers=\\[.*\\]}")))
 
         assertThat(logger.log(), hasItem(loggingEvent(INFO,
           "requestId=[-a-z0-9]+, response=\\{status=200 OK, headers=\\[Transfer-Encoding=chunked, Server=Jetty\\(6.1.26\\)\\]\\}")))

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/EmptyTlsProtocolsListSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/EmptyTlsProtocolsListSpec.scala
@@ -76,7 +76,6 @@ class EmptyTlsProtocolsListSpec extends FunSpec
     it("Empty TLS protocols list activates all supported protocols") {
       val req = FullHttpRequest.get(styxServer.secureRouterURL("/secure"))
         .header(HOST, styxServer.httpsProxyHost)
-        .secure(true)
         .build()
 
       val resp1 = Await.result(clientV11.sendRequest(req).toScala, 3.seconds)

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/HttpsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/HttpsSpec.scala
@@ -67,9 +67,7 @@ class HttpsSpec extends FunSpec
         .header(HOST, styxServer.httpsProxyHost)
         .build()
 
-      req.isSecure should be(true)
-
-      val resp = decodedRequest(req)
+      val resp = decodedRequest(req, secure = true)
       resp.status() should be(OK)
 
       recordingBackend.verify(getRequestedFor(urlPathEqualTo("/secure"))

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/ProtocolsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/ProtocolsSpec.scala
@@ -175,7 +175,7 @@ class ProtocolsSpec extends FunSpec
   describe("Styx routing of HTTPS requests") {
 
     it("Proxies HTTPS requests to HTTP backend") {
-      val response = decodedRequest(httpsRequest("/http/app.x.4"))
+      val response = decodedRequest(httpsRequest("/http/app.x.4"), secure = true)
 
       assert(response.status() == OK)
       assert(response.bodyAs(UTF_8) == "Hello, World!")
@@ -186,7 +186,7 @@ class ProtocolsSpec extends FunSpec
     }
 
     it("Proxies HTTPS requests to HTTPS backend") {
-      val response = decodedRequest(httpsRequest("/https/trustAllCerts/foo.5"))
+      val response = decodedRequest(httpsRequest("/https/trustAllCerts/foo.5"), secure = true)
 
       assert(response.status() == OK)
       assert(response.bodyAs(UTF_8) == "Hello, World!")
@@ -200,7 +200,8 @@ class ProtocolsSpec extends FunSpec
       val response = decodedRequest(
         httpsRequest("/https/trustAllCerts/foo.6")
           .newBuilder().header(X_FORWARDED_PROTO, "http")
-          .build
+          .build,
+        secure = true
       )
 
       assert(response.status() == OK)
@@ -218,7 +219,7 @@ class ProtocolsSpec extends FunSpec
       val request = get(styxServer.secureRouterURL("/https/authenticate/secure/foo.7"))
         .build()
 
-      val response = decodedRequest(request)
+      val response = decodedRequest(request, secure = true)
 
       assert(response.status() == OK)
       assert(response.bodyAs(UTF_8) == "Hello, World!")
@@ -229,7 +230,7 @@ class ProtocolsSpec extends FunSpec
       val request = get(styxServer.secureRouterURL("/https/authenticate/insecure/foo.8"))
         .build()
 
-      val response = decodedRequest(request)
+      val response = decodedRequest(request, secure = true)
       assert(response.status() == BAD_GATEWAY)
 
       httpsOriginWithCert.verify(0, getRequestedFor(urlEqualTo("/https/authenticate/insecure/foo.8")))
@@ -239,7 +240,7 @@ class ProtocolsSpec extends FunSpec
       val request = get(styxServer.secureRouterURL("/https/trustAllCerts/foo.9"))
         .build()
 
-      val response = decodedRequest(request)
+      val response = decodedRequest(request, secure = true)
 
       assert(response.status() == OK)
       assert(response.bodyAs(UTF_8) == "Hello, World!")

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/Tls12Spec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/Tls12Spec.scala
@@ -84,7 +84,6 @@ class Tls12Spec extends FunSpec
     it("Accepts TLS 1.2 only") {
       val req = new FullHttpRequest.Builder(GET, styxServer.secureRouterURL("/secure"))
         .header(HOST, styxServer.httpsProxyHost)
-        .secure(true)
         .build()
 
       val resp = Await.result(clientV12.sendRequest(req).toScala, 3.seconds)
@@ -95,7 +94,6 @@ class Tls12Spec extends FunSpec
     it("Refuses TLS 1.1 when TLS 1.2 is required") {
       val req = new FullHttpRequest.Builder(GET, styxServer.secureRouterURL("/secure"))
         .header(HOST, styxServer.httpsProxyHost)
-        .secure(true)
         .build()
 
       an[RuntimeException] should be thrownBy {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/routing/ConditionRoutingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/routing/ConditionRoutingSpec.scala
@@ -143,7 +143,7 @@ class ConditionRoutingSpec extends FunSpec
     }
 
     it("Routes HTTPS protocol to HTTPS origins") {
-      val response = decodedRequest(httpsRequest("/app.2"))
+      val response = decodedRequest(httpsRequest("/app.2"), secure = true)
 
       assert(response.status() == OK)
       assert(response.bodyAs(UTF_8) == "Hello, World!")

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/WiremockStyxRequestAdapter.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/WiremockStyxRequestAdapter.java
@@ -51,7 +51,7 @@ public class WiremockStyxRequestAdapter implements Request {
     @Override
     public String getAbsoluteUrl() {
         String host = styxRequest.header(HOST).orElse("");
-        String protocol = styxRequest.isSecure() ? "https" : "http";
+        String protocol = "http";
 
         return protocol + "://" + host + styxRequest.url().toURI().toString();
     }


### PR DESCRIPTION
Concludes the work for #274.
* Move `isSecure` attribute from HTTP request objects into `HttpInterceptor.Context`.

This has an implication to a request logging feature. The isSecure is no longer a request attribute, and therefore it no longer appears in request's textual representation. It is logged separately from the request, but only when Interceptor.Context is available. Therefore `isSecure` is logged for the inbound requests because the interceptor context is visible for the inbound request logger. But it is not logged for outbound requests because the context is not visible to the StyxHttpClient that logs the outbound requests.

