### PR TITLE
Log SSL handshake failures

### DIFF
--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -380,10 +380,10 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
                 ctx.channel().close();
             }
 
-            LOGGER.info("SSL handshake failure from incoming connection " +
-                    "cause=\"{}\", " +
-                    "serverAddress={}, " +
-                    "clientAddress={}",
+            LOGGER.info("SSL handshake failure from incoming connection "
+                    + "cause=\"{}\", "
+                    + "serverAddress={}, "
+                    + "clientAddress={}",
                     new Object [] {sslException.getMessage(),
                     ctx.channel().localAddress(),
                     ctx.channel().remoteAddress()});

--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -22,17 +22,14 @@ import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
-import com.hotels.styx.server.NoServiceConfiguredException;
-import com.hotels.styx.api.StyxObservable;
 import com.hotels.styx.api.HttpResponseStatus;
-import com.hotels.styx.server.HttpErrorStatusListener;
 import com.hotels.styx.api.MetricRegistry;
-import com.hotels.styx.server.RequestProgressListener;
-import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
+import com.hotels.styx.api.StyxObservable;
 import com.hotels.styx.api.exceptions.NoAvailableHostsException;
 import com.hotels.styx.api.exceptions.OriginUnreachableException;
 import com.hotels.styx.api.exceptions.ResponseTimeoutException;
 import com.hotels.styx.api.exceptions.TransportLostException;
+import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.api.plugins.spi.PluginException;
 import com.hotels.styx.client.BadHttpResponseException;
 import com.hotels.styx.client.StyxClientException;
@@ -42,6 +39,9 @@ import com.hotels.styx.common.FsmEventProcessor;
 import com.hotels.styx.common.QueueDrainingEventProcessor;
 import com.hotels.styx.common.StateMachine;
 import com.hotels.styx.server.BadRequestException;
+import com.hotels.styx.server.HttpErrorStatusListener;
+import com.hotels.styx.server.NoServiceConfiguredException;
+import com.hotels.styx.server.RequestProgressListener;
 import com.hotels.styx.server.RequestTimeoutException;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -52,6 +52,7 @@ import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
 
+import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -59,7 +60,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH;
-import static com.hotels.styx.api.StyxInternalObservables.toRxObservable;
 import static com.hotels.styx.api.HttpResponseStatus.BAD_GATEWAY;
 import static com.hotels.styx.api.HttpResponseStatus.BAD_REQUEST;
 import static com.hotels.styx.api.HttpResponseStatus.GATEWAY_TIMEOUT;
@@ -68,6 +68,7 @@ import static com.hotels.styx.api.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
 import static com.hotels.styx.api.HttpResponseStatus.REQUEST_TIMEOUT;
 import static com.hotels.styx.api.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static com.hotels.styx.api.HttpVersion.HTTP_1_1;
+import static com.hotels.styx.api.StyxInternalObservables.toRxObservable;
 import static com.hotels.styx.server.HttpErrorStatusListener.IGNORE_ERROR_STATUS;
 import static com.hotels.styx.server.RequestProgressListener.IGNORE_REQUEST_PROGRESS;
 import static com.hotels.styx.server.netty.connectors.HttpPipelineHandler.State.ACCEPTING_REQUESTS;
@@ -373,6 +374,23 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
     }
 
     private State handleChannelException(ChannelHandlerContext ctx, Throwable cause) {
+        Throwable sslException = sslException(cause);
+        if (sslException != null) {
+            if (ctx.channel().isActive()) {
+                ctx.channel().close();
+            }
+
+            LOGGER.info("SSL handshake failure from incoming connection " +
+                    "cause=\"{}\", " +
+                    "serverAddress={}, " +
+                    "clientAddress={}",
+                    new Object [] {sslException.getMessage(),
+                    ctx.channel().localAddress(),
+                    ctx.channel().remoteAddress()});
+
+            return TERMINATED;
+        }
+
         if (!isIoException(cause)) {
             HttpResponse response = exceptionToResponse(cause, ongoingRequest);
             httpErrorStatusListener.proxyErrorOccurred(response.status(), cause);
@@ -381,6 +399,14 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<HttpRequest
             }
         }
         return TERMINATED;
+    }
+
+    private static Throwable sslException(Throwable cause) {
+        if (cause.getCause() != null && cause.getCause() instanceof SSLHandshakeException) {
+            return cause.getCause();
+        } else {
+            return null;
+        }
     }
 
     private void respondAndClose(ChannelHandlerContext ctx, HttpResponse response) {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/TlsErrorSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/TlsErrorSpec.scala
@@ -1,0 +1,110 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.proxy.https
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.hotels.styx.api.HttpHeaderNames._
+import com.hotels.styx.api.HttpMethod.GET
+import com.hotels.styx.api.HttpResponseStatus.OK
+import com.hotels.styx.api.{FullHttpClient, FullHttpRequest}
+import com.hotels.styx.client.SimpleHttpClient
+import com.hotels.styx.infrastructure.HttpResponseImplicits
+import com.hotels.styx.support.ResourcePaths.fixturesHome
+import com.hotels.styx.support.backends.FakeHttpServer
+import com.hotels.styx.support.configuration._
+import com.hotels.styx.{SSLSetup, StyxProxySpec}
+import org.scalatest.{FunSpec, ShouldMatchers}
+
+import scala.compat.java8.FutureConverters.CompletionStageOps
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class Tls12Spec extends FunSpec
+  with StyxProxySpec
+  with HttpResponseImplicits
+  with ShouldMatchers
+  with SSLSetup {
+
+  val crtFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.crt").toString
+  val keyFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.key").toString
+  val clientV12 = newClient(Seq("TLSv1.2"))
+  val clientV11 = newClient(Seq("TLSv1.1"))
+
+  override val styxConfig = StyxYamlConfig(
+    yamlConfig =
+      s"""
+        |proxy:
+        |  connectors:
+        |    https:
+        |      port: 0
+        |      sslProvider: JDK
+        |      certificateFile: $crtFile
+        |      certificateKeyFile: $keyFile
+        |      protocols:
+        |       - TLSv1.2
+        |admin:
+        |  connectors:
+        |    http:
+        |      port: 0
+        |
+      """.stripMargin
+  )
+
+  val recordingBackend = FakeHttpServer.HttpsStartupConfig()
+    .start()
+
+  override protected def beforeAll() = {
+    super.beforeAll()
+    styxServer.setBackends("/secure" -> HttpsBackend(
+      "https-app", Origins(recordingBackend), TlsSettings()
+    ))
+  }
+
+  override protected def afterAll() = {
+    recordingBackend.stop()
+    super.afterAll()
+  }
+
+  describe("TLS protocol restriction") {
+    recordingBackend.stub(urlPathEqualTo("/secure"), aResponse.withStatus(200))
+
+    it("Accepts TLS 1.2 only") {
+      val req = new FullHttpRequest.Builder(GET, styxServer.secureRouterURL("/secure"))
+        .header(HOST, styxServer.httpsProxyHost)
+        .build()
+
+      val resp = Await.result(clientV12.sendRequest(req).toScala, 3.seconds)
+
+      resp.status() should be(OK)
+    }
+
+    it("Refuses TLS 1.1 when TLS 1.2 is required") {
+      val req = new FullHttpRequest.Builder(GET, styxServer.secureRouterURL("/secure"))
+        .header(HOST, styxServer.httpsProxyHost)
+        .build()
+
+      an[RuntimeException] should be thrownBy {
+        Await.result(clientV11.sendRequest(req).toScala, 3.seconds)
+      }
+    }
+  }
+
+  def newClient(supportedProtocols: Seq[String]): FullHttpClient =
+    new SimpleHttpClient.Builder()
+      .tlsSettings(TlsSettings(protocols = supportedProtocols).asJava)
+      .build()
+
+}

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/TlsErrorSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/TlsErrorSpec.scala
@@ -83,11 +83,12 @@ class TlsErrorSpec extends FunSpec
     log.stop()
   }
 
-  describe("TLS protocol restriction") {
+  describe("TLS errors handling") {
     app.stub(urlPathEqualTo("/secure"), aResponse.withStatus(200))
-    val serverPort = styxServer.proxyHttpsAddress().getPort
 
     it("Logs an SSL handshake exception") {
+      val serverPort = styxServer.proxyHttpsAddress().getPort
+
       val req = FullHttpRequest.get(styxServer.secureRouterURL("/secure"))
         .header(HOST, styxServer.httpsProxyHost)
         .build()

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/TlsErrorSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/TlsErrorSpec.scala
@@ -30,6 +30,7 @@ import com.hotels.styx.support.matchers.LoggingTestSupport
 import com.hotels.styx.{SSLSetup, StyxProxySpec}
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasItem
+import org.scalatest.concurrent.Eventually
 import org.scalatest.{FunSpec, ShouldMatchers}
 
 import scala.compat.java8.FutureConverters.CompletionStageOps
@@ -40,7 +41,8 @@ class TlsErrorSpec extends FunSpec
   with StyxProxySpec
   with HttpResponseImplicits
   with ShouldMatchers
-  with SSLSetup {
+  with SSLSetup
+  with Eventually {
 
   val crtFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.crt").toString
   val keyFile = fixturesHome(classOf[ProtocolsSpec], "/ssl/testCredentials.key").toString
@@ -101,7 +103,9 @@ class TlsErrorSpec extends FunSpec
         """SSL handshake failure from incoming connection cause="Client requested protocol """ +
           s"""TLSv1.1 not enabled or not supported", serverAddress=.*:$serverPort, clientAddress=.*"""
 
-      assertThat(log.log(), hasItem(loggingEvent(INFO, message)))
+      eventually(timeout(3 seconds)) {
+        assertThat(log.log(), hasItem(loggingEvent(INFO, message)))
+      }
     }
   }
 


### PR DESCRIPTION
Log SSL handshake failures without excessive stack traces. Specifically:
* Clearly indicates a failure is from incoming connection
* Logs the underlying cause eg. wrong TLS protocol version
* Logs the server port where the failure occurred
* Logs the client address.
