### PR TITLE
End-to-end tests: fix leak threads.

### DIFF
--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxProxySpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxProxySpec.scala
@@ -52,12 +52,14 @@ trait StyxProxySpec extends StyxClientSupplier
     styxServer = styxConfig.startServer(new RegistryServiceAdapter(backendsRegistry))
     println("Styx http port is: [%d]".format(styxServer.httpPort))
     println("Styx https port is: [%d]".format(styxServer.secureHttpPort))
+    super.beforeAll()
   }
 
   override protected def afterAll() = {
     println("Styx http port was: [%d]".format(styxServer.httpPort))
     println("Styx https port was: [%d]".format(styxServer.secureHttpPort))
     styxServer.stopAsync().awaitTerminated()
+    super.afterAll()
   }
 }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxServerSupport.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/StyxServerSupport.scala
@@ -65,6 +65,8 @@ object StyxServerSupport {
 
   def newAdminServerConfigBuilder(adminHttpConnConfig: HttpConnectorConfig) = {
     new AdminServerConfig.Builder()
+      .setBossThreadsCount(1)
+      .setWorkerThreadsCount(1)
       .setHttpConnector(adminHttpConnConfig)
   }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/UnwiseCharactersSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/UnwiseCharactersSpec.scala
@@ -30,8 +30,10 @@ import com.hotels.styx.support.server.UrlMatchingStrategies._
 import org.hamcrest.MatcherAssert._
 import org.hamcrest.Matchers.hasItem
 import org.scalatest._
+import org.scalatest.concurrent.Eventually
+import scala.concurrent.duration._
 
-class UnwiseCharactersSpec extends FunSpec with StyxProxySpec {
+class UnwiseCharactersSpec extends FunSpec with StyxProxySpec with Eventually {
 
   val recordingBackend = FakeHttpServer.HttpStartupConfig().start()
 
@@ -66,7 +68,9 @@ class UnwiseCharactersSpec extends FunSpec with StyxProxySpec {
       decodedRequest(req)
 
       recordingBackend.verify(receivedRewrittenUrl("/url/unwise%51%51blah"))
-      assertThat(logger.log(), hasItem(loggingEvent(WARN, "Value contains unwise chars. you should fix this. raw=/url/unwiseQQblah, escaped=/url/unwise%51%51blah.*")))
+      eventually(timeout(3.seconds)) {
+        assertThat(logger.log(), hasItem(loggingEvent(WARN, "Value contains unwise chars. you should fix this. raw=/url/unwiseQQblah, escaped=/url/unwise%51%51blah.*")))
+      }
     }
   }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/ProtocolsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/ProtocolsSpec.scala
@@ -119,6 +119,7 @@ class ProtocolsSpec extends FunSpec
 
   override protected def afterAll(): Unit = {
     httpsOriginWithoutCert.stop()
+    httpsOriginWithCert.stop()
     httpServer.stop()
     super.afterAll()
   }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/ProxyConfig.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/ProxyConfig.scala
@@ -20,8 +20,8 @@ import com.hotels.styx.support.configuration.ProxyConfig.proxyServerDefaults
 
 
 case class ProxyConfig(connectors: Connectors = Connectors(HttpConnectorConfig(), null),
-                       bossThreadCount: Int = proxyServerDefaults.bossThreadsCount(),
-                       workerThreadsCount: Int = proxyServerDefaults.workerThreadsCount(),
+                       bossThreadCount: Int = 1,
+                       workerThreadsCount: Int = 1,
                        nioAcceptorBacklog: Int = proxyServerDefaults.nioAcceptorBacklog(),
                        tcpNoDelay: Boolean = proxyServerDefaults.tcpNoDelay(),
                        nioReuseAddress: Boolean = proxyServerDefaults.nioReuseAddress(),
@@ -33,7 +33,7 @@ case class ProxyConfig(connectors: Connectors = Connectors(HttpConnectorConfig()
                        requestTimeoutMillis: Int = proxyServerDefaults.requestTimeoutMillis(),
                        keepAliveTimeoutMillis: Int = proxyServerDefaults.keepAliveTimeoutMillis(),
                        maxConnectionsCount: Int = proxyServerDefaults.maxConnectionsCount(),
-                       clientWorkerThreadsCount: Int = proxyServerDefaults.clientWorkerThreadsCount()) {
+                       clientWorkerThreadsCount: Int = 1) {
 }
 
 

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/HttpTestClient.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/HttpTestClient.java
@@ -44,17 +44,17 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class HttpTestClient {
+    private static final NioEventLoopGroup eventLoopGroup =
+            new NioEventLoopGroup(1, new ThreadFactoryBuilder().setNameFormat("Test-Client-%d").build());
+
     private final HostAndPort destination;
     private final LinkedBlockingDeque<Object> receivedResponses = new LinkedBlockingDeque<>();
     private final Supplier<Bootstrap> bootstrap;
 
     private ChannelFuture channelFuture;
-    private final NioEventLoopGroup eventLoopGroup;
 
     public HttpTestClient(HostAndPort destination, ChannelInitializer<Channel> initializer) {
         this.destination = requireNonNull(destination);
-
-        eventLoopGroup = new NioEventLoopGroup(1, new ThreadFactoryBuilder().setNameFormat("Test-Client-%d").build());
 
         this.bootstrap = lazy(() -> new Bootstrap()
                 .group(eventLoopGroup)
@@ -77,9 +77,7 @@ public class HttpTestClient {
     }
 
     public CompletableFuture<Void> disconnect() {
-        return CompletableFuture.allOf(
-                toCompletableFuture(channelFuture.channel().close()),
-                toCompletableFuture(eventLoopGroup.shutdownGracefully()));
+        return toCompletableFuture(channelFuture.channel().close());
     }
 
     private CompletableFuture<Void> toCompletableFuture(Future<?> nettyFuture) {

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/HttpTestClient.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/HttpTestClient.java
@@ -28,7 +28,9 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.Future;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -47,11 +49,12 @@ public class HttpTestClient {
     private final Supplier<Bootstrap> bootstrap;
 
     private ChannelFuture channelFuture;
+    private final NioEventLoopGroup eventLoopGroup;
 
     public HttpTestClient(HostAndPort destination, ChannelInitializer<Channel> initializer) {
         this.destination = requireNonNull(destination);
 
-        NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(1, new ThreadFactoryBuilder().setNameFormat("Test-Client-%d").build());
+        eventLoopGroup = new NioEventLoopGroup(1, new ThreadFactoryBuilder().setNameFormat("Test-Client-%d").build());
 
         this.bootstrap = lazy(() -> new Bootstrap()
                 .group(eventLoopGroup)
@@ -73,8 +76,22 @@ public class HttpTestClient {
         return this;
     }
 
-    public void disconnect() throws InterruptedException {
-        channelFuture.channel().close().await();
+    public CompletableFuture<Void> disconnect() {
+        return CompletableFuture.allOf(
+                toCompletableFuture(channelFuture.channel().close()),
+                toCompletableFuture(eventLoopGroup.shutdownGracefully()));
+    }
+
+    private CompletableFuture<Void> toCompletableFuture(Future<?> nettyFuture) {
+        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+        nettyFuture.addListener(it -> {
+            if (it.isSuccess()) {
+                completableFuture.complete(null);
+            } else {
+                completableFuture.completeExceptionally(it.cause());
+            }
+        });
+        return completableFuture;
     }
 
     public ChannelFuture channelFuture() {


### PR DESCRIPTION
A few thread leaks were found in Styx end to end test suite. This PR fixes most of them:

* Majority of the leaks was caused by `HttpTestClient` being repeatedly instantiated but never shut. Fixed this leak by creating one static thread pool that serves all `HttpTestClient` instances. 

* Styx Server created for each e2e suite was unnecessarily configured with one thread per CPU core. Only one thread per server is enough. 

* Fixed couple of other little mistakes.
