### PR TITLE
User guide: Fix a typo in load-balancer documentation.

### DIFF
--- a/docs/user-guide/configure-load-balancing.md
+++ b/docs/user-guide/configure-load-balancing.md
@@ -59,13 +59,13 @@ To enable *Power of Two* load balancing strategy:
       strategy:
         factory: {class: "com.hotels.styx.client.loadbalancing.strategies.PowerOfTwoStrategy$Factory"}
 
-To enable Busy load balancing strategy:
+To enable *Busy* load balancing strategy:
 
     loadBalancing:
       strategy:
         factory: {class: "com.hotels.styx.client.loadbalancing.strategies.BusyConnectionsStrategy$Factory"}
 
-To enable Round Robin load balancing strategy:
+To enable *Round Robin* load balancing strategy:
 
     loadBalancing:
       strategy:

--- a/docs/user-guide/configure-load-balancing.md
+++ b/docs/user-guide/configure-load-balancing.md
@@ -53,7 +53,7 @@ the name of the cookie that should contain the origins restriction information.
 Load balancing strategies and the origin restriction feature are configured
 in the Styx proxy configuration file.
 
-To enable Busy load balancing strategy:
+To enable *Power of Two* load balancing strategy:
 
     loadBalancing:
       strategy:


### PR DESCRIPTION
Instructions for enabling Pow2 load balancer.
