### PR TITLE
Use Optional.orElseGet in RouteHandlerAdapter

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/proxy/RouteHandlerAdapter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/RouteHandlerAdapter.java
@@ -37,6 +37,6 @@ public class RouteHandlerAdapter implements HttpHandler {
     public StyxObservable<HttpResponse> handle(HttpRequest request, HttpInterceptor.Context context) {
         return router.route(request, context)
                 .map(pipeline -> pipeline.handle(request, context))
-                .orElse(StyxObservable.error(new NoServiceConfiguredException(request.path())));
+                .orElseGet(() -> StyxObservable.error(new NoServiceConfiguredException(request.path())));
     }
 }


### PR DESCRIPTION
Use Optional.orElseGet to prevent constructing the Exception on each request