### PR TITLE
Remove unused cancel method from HttpTransaction interface

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/HttpTransaction.java
+++ b/components/client/src/main/java/com/hotels/styx/client/HttpTransaction.java
@@ -31,13 +31,6 @@ interface HttpTransaction {
     Observable<HttpResponse> response();
 
     /**
-     * Cancels the ongoing transaction. Default implementation does nothing.
-     */
-    default void cancel() {
-        // do nothing
-    }
-
-    /**
      * Checks whether the current transaction is cancelled (non-consumable). Default implementation always returns false.
      *
      * @return true if the transaction was cancelled

--- a/components/client/src/main/java/com/hotels/styx/client/Transport.java
+++ b/components/client/src/main/java/com/hotels/styx/client/Transport.java
@@ -18,8 +18,8 @@ package com.hotels.styx.client;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.Id;
-import com.hotels.styx.client.connectionpool.ConnectionPool;
 import com.hotels.styx.api.exceptions.NoAvailableHostsException;
+import com.hotels.styx.client.connectionpool.ConnectionPool;
 import rx.Observable;
 
 import java.util.Optional;
@@ -52,13 +52,6 @@ class Transport {
 
         return new HttpTransaction() {
             private final AtomicBoolean cancelled = new AtomicBoolean(false);
-
-            @Override
-            public void cancel() {
-                if (!cancelled.getAndSet(true)) {
-                    closeIfConnected(origin, connectionRef);
-                }
-            }
 
             @Override
             public Observable<HttpResponse> response() {


### PR DESCRIPTION
The `HttpTransaction.cancel` method is never used. So remove it. Also remove it from the implementing `Transport` class.
