### PR TITLE
Backport #306 to styx-0.7 branch

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/RoundRobinStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/RoundRobinStrategy.java
@@ -69,7 +69,11 @@ public class RoundRobinStrategy implements LoadBalancer {
     @Override
     public Optional<RemoteHost> choose(Preferences preferences) {
         ArrayList<RemoteHost> remoteHosts = origins.get();
-        return Optional.ofNullable(remoteHosts.get(index.getAndIncrement() % remoteHosts.size()));
+        if (remoteHosts == null || remoteHosts.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.ofNullable(remoteHosts.get(index.getAndIncrement() % remoteHosts.size()));
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes an issue #306.

Fix incorrect round-robin strategy behaviour when there are no available hosts. (#307)

(cherry picked from commit 2271ed13a227056fb89b497578bcecdc0d89bf9a)
