### PR TITLE
Track current http requests in styx

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -22,6 +22,7 @@ import com.hotels.styx.Environment;
 import com.hotels.styx.StyxConfig;
 import com.hotels.styx.admin.dashboard.DashboardData;
 import com.hotels.styx.admin.dashboard.DashboardDataSupplier;
+import com.hotels.styx.admin.handlers.CurrentRequestsHandler;
 import com.hotels.styx.admin.handlers.IndexHandler;
 import com.hotels.styx.admin.handlers.JVMMetricsHandler;
 import com.hotels.styx.admin.handlers.JsonHandler;
@@ -50,6 +51,8 @@ import com.hotels.styx.server.StandardHttpRouter;
 import com.hotels.styx.server.handlers.ClassPathResourceHandler;
 import com.hotels.styx.server.netty.NettyServerBuilderSpec;
 import com.hotels.styx.server.netty.WebServerConnectorFactory;
+import com.hotels.styx.server.track.CurrentRequestTracker;
+
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -110,6 +113,7 @@ public class AdminServerBuilder {
         httpRouter.add("/admin", new IndexHandler(indexLinkPaths()));
         httpRouter.add("/admin/ping", new PingHandler());
         httpRouter.add("/admin/threads", new ThreadsHandler());
+        httpRouter.add("/admin/current_requests", new CurrentRequestsHandler(CurrentRequestTracker.INSTANCE));
         MetricsHandler metricsHandler = new MetricsHandler(environment.metricRegistry(), metricsCacheExpiration);
         httpRouter.add("/admin/metrics", metricsHandler);
         httpRouter.add("/admin/metrics/", metricsHandler);
@@ -157,6 +161,7 @@ public class AdminServerBuilder {
                 link("version.txt", "/version.txt"),
                 link("Ping", "/admin/ping"),
                 link("Threads", "/admin/threads"),
+                link("Current Requests", "/admin/current_requests?withStackTrace=true"),
                 link("Metrics", "/admin/metrics?pretty"),
                 link("Configuration", "/admin/configuration?pretty"),
                 link("Log Configuration", "/admin/configuration/logging"),

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/CurrentRequestsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/CurrentRequestsHandler.java
@@ -1,0 +1,174 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.admin.handlers;
+
+import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
+import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static java.lang.management.ManagementFactory.getThreadMXBean;
+import static java.lang.Thread.State.BLOCKED;
+import static java.lang.System.currentTimeMillis;
+import static java.lang.String.format;
+
+import java.lang.management.LockInfo;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.nio.charset.Charset;
+
+import com.hotels.styx.api.HttpResponse;
+import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.common.http.handler.BaseHttpHandler;
+import com.hotels.styx.server.track.CurrentRequestTracker;
+
+/**
+ * Admin handler that will help in tracking only the current HTTP requests to Styx.
+ */
+public class CurrentRequestsHandler extends BaseHttpHandler {
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+    private final ThreadMXBean threadMXBean;
+    private CurrentRequestTracker tracker;
+
+    public CurrentRequestsHandler(CurrentRequestTracker tracker) {
+        this.threadMXBean = getThreadMXBean();
+        this.tracker = tracker;
+    }
+
+    @Override
+    public LiveHttpResponse doHandle(LiveHttpRequest request) {
+        boolean withStackTrace = request.queryParam("withStackTrace")
+                .map(it -> "true".equals(it))
+                .orElse(false);
+
+        return HttpResponse
+                .response(OK)
+                .disableCaching()
+                .header(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                .body(getCurrentRequestContent(withStackTrace), UTF_8, true)
+                .build()
+                .stream();
+    }
+
+    private String getCurrentRequestContent(boolean withStackTrace) {
+        StringBuilder sb = new StringBuilder();
+        tracker.getCurrentRequests().forEach(req -> {
+            sb.append("[\n");
+            sb.append(req.getRequest().replaceAll(",", "\n"));
+            sb.append("\n\n");
+            sb.append("running for: ");
+            sb.append(currentTimeMillis() - req.getStartingTimeMillies());
+            sb.append("ms\n");
+            if (req.isRequestSent()) {
+                sb.append("\nRequest state: Waiting response from origin.\n");
+            } else {
+                sb.append("\nRequest state: Plugins pipeline.\n");
+                sb.append("\n\n   ...   Thread Info: ...\n");
+                if (withStackTrace) {
+                    sb.append(getThreadInfo(req.getCurrentThread().getId()));
+                } else {
+                    sb.append("Name: ");
+                    sb.append(req.getCurrentThread().getName());
+                    sb.append("\n");
+                }
+            }
+            sb.append("]\n\n");
+        });
+
+        return sb.toString();
+    }
+
+    private String getThreadInfo(long threadId) {
+
+        StringBuilder sb = new StringBuilder();
+
+        final ThreadInfo t = threadMXBean.getThreadInfo(threadId, Integer.MAX_VALUE);
+        sb.append(format("\"%s\" id=%d state=%s", t.getThreadName(), t.getThreadId(), t.getThreadState()));
+        sb.append(getThreadState(t));
+
+        if (t.isSuspended()) {
+            sb.append(" (suspended)");
+        }
+
+        if (t.isInNative()) {
+            sb.append(" (running in native)");
+        }
+
+        sb.append("\n");
+        if (t.getLockOwnerName() != null) {
+            sb.append(format("     owned by %s id=%d%n", t.getLockOwnerName(), t.getLockOwnerId()));
+        }
+
+        sb.append(getThreadElements(t));
+        sb.append("\n");
+
+        sb.append(getThreadLockedSynchronizer(t));
+
+        return sb.toString();
+    }
+
+    private String getThreadState(ThreadInfo t) {
+
+        StringBuilder sb = new StringBuilder();
+
+        final LockInfo lock = t.getLockInfo();
+        if (lock != null && t.getThreadState() != BLOCKED) {
+            sb.append(format("%n    - waiting on <0x%08x> (a %s)", lock.getIdentityHashCode(), lock.getClassName()));
+            sb.append(format("%n    - locked <0x%08x> (a %s)", lock.getIdentityHashCode(), lock.getClassName()));
+        } else if (lock != null && t.getThreadState() == BLOCKED) {
+            sb.append(format("%n    - waiting to lock <0x%08x> (a %s)", lock.getIdentityHashCode(), lock.getClassName()));
+        }
+
+        return sb.toString();
+    }
+
+    private String getThreadLockedSynchronizer(ThreadInfo t) {
+
+        StringBuilder sb = new StringBuilder();
+
+        final LockInfo[] locks = t.getLockedSynchronizers();
+        if (locks.length > 0) {
+            sb.append(format("    Locked synchronizers: count = %d%n", locks.length));
+            for (LockInfo l : locks) {
+                sb.append(format("      - %s%n", l));
+            }
+            sb.append("\n");
+        }
+
+        return sb.toString();
+    }
+
+    private String getThreadElements(ThreadInfo t) {
+        final StackTraceElement[] elements = t.getStackTrace();
+        final MonitorInfo[] monitors = t.getLockedMonitors();
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < elements.length; i++) {
+            final StackTraceElement element = elements[i];
+            sb.append(format("    at %s%n", element));
+            for (int j = 1; j < monitors.length; j++) {
+                final MonitorInfo monitor = monitors[j];
+                if (monitor.getLockedStackDepth() == i) {
+                    sb.append(format("      - locked %s%n", monitor));
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+}

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyConnectorFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyConnectorFactory.java
@@ -32,6 +32,7 @@ import com.hotels.styx.server.netty.connectors.ResponseEnhancer;
 import com.hotels.styx.server.netty.handlers.ChannelStatisticsHandler;
 import com.hotels.styx.server.netty.handlers.ExcessConnectionRejector;
 import com.hotels.styx.server.netty.handlers.RequestTimeoutHandler;
+import com.hotels.styx.server.track.CurrentRequestTracker;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -161,6 +162,7 @@ class ProxyConnectorFactory implements ServerConnectorFactory {
                             .progressListener(requestStatsCollector)
                             .metricRegistry(metrics)
                             .secure(sslContext.isPresent())
+                            .requestTracker(CurrentRequestTracker.INSTANCE)
                             .build());
         }
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StandardHttpPipeline.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StandardHttpPipeline.java
@@ -15,21 +15,23 @@
  */
 package com.hotels.styx.routing.handlers;
 
-import com.hotels.styx.api.Eventual;
-import com.hotels.styx.api.HttpHandler;
-import com.hotels.styx.api.HttpInterceptor;
-import com.hotels.styx.api.LiveHttpRequest;
-import com.hotels.styx.api.LiveHttpResponse;
-import rx.Observable;
-
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static rx.Observable.create;
 import static rx.RxReactiveStreams.toObservable;
 import static rx.RxReactiveStreams.toPublisher;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.hotels.styx.api.Eventual;
+import com.hotels.styx.api.HttpHandler;
+import com.hotels.styx.api.HttpInterceptor;
+import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.server.track.CurrentRequestTracker;
+
+import rx.Observable;
 
 /**
  * The pipeline consists of a chain of interceptors followed by a handler.
@@ -78,6 +80,10 @@ class StandardHttpPipeline implements HttpHandler {
 
         @Override
         public Eventual<LiveHttpResponse> proceed(LiveHttpRequest request) {
+
+
+            CurrentRequestTracker.INSTANCE.trackRequest(request);
+
             if (index < interceptors.size()) {
                 HttpInterceptor.Chain chain = new HttpInterceptorChain(this, index + 1);
                 HttpInterceptor interceptor = interceptors.get(index);
@@ -88,6 +94,9 @@ class StandardHttpPipeline implements HttpHandler {
                     return Eventual.error(e);
                 }
             }
+
+            CurrentRequestTracker.INSTANCE.markRequestAsSent(request);
+
             return new Eventual<>(toPublisher(toObservable(client.handle(request, this.context))
                     .compose(StandardHttpPipeline::sendErrorOnDoubleSubscription)));
         }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StandardHttpPipeline.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StandardHttpPipeline.java
@@ -80,8 +80,6 @@ class StandardHttpPipeline implements HttpHandler {
 
         @Override
         public Eventual<LiveHttpResponse> proceed(LiveHttpRequest request) {
-
-
             CurrentRequestTracker.INSTANCE.trackRequest(request);
 
             if (index < interceptors.size()) {

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
@@ -1,0 +1,78 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.admin.handlers;
+
+import static com.hotels.styx.api.LiveHttpRequest.get;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import org.testng.annotations.Test;
+
+import com.hotels.styx.api.Buffer;
+import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.server.track.CurrentRequestTracker;
+
+import reactor.core.publisher.Flux;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class CurrentRequestsHandlerTest {
+
+    LiveHttpRequest req1 = get("/requestId1").build();
+    LiveHttpRequest req2 = get("/requestId2").build();
+
+    @Test
+    public void testStackTrace() {
+        CurrentRequestTracker.INSTANCE.clear();
+        Thread.currentThread().setName("Test-Thread");
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        LiveHttpResponse response = (new CurrentRequestsHandler(CurrentRequestTracker.INSTANCE)).doHandle(req1);
+        assertThat(Flux.from(response.body()).map(this::decodeUtf8String).blockFirst().contains("Test-Thread"), is(true));
+    }
+
+    @Test
+    public void testStackTraceForSentRequest() {
+        CurrentRequestTracker.INSTANCE.clear();
+        Thread.currentThread().setName("Test-Thread-1");
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        CurrentRequestTracker.INSTANCE.markRequestAsSent(req1);
+        LiveHttpResponse response = (new CurrentRequestsHandler(CurrentRequestTracker.INSTANCE)).doHandle(req1);
+        assertThat(Flux.from(response.body()).map(this::decodeUtf8String).blockFirst().contains("Request state: Waiting response from origin."), is(true));
+    }
+
+    @Test
+    public void testWithStackTrace() {
+        CurrentRequestTracker.INSTANCE.clear();
+        Thread.currentThread().setName("Test-Thread");
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        LiveHttpResponse response = (new CurrentRequestsHandler(CurrentRequestTracker.INSTANCE)).doHandle(get("/req?withStackTrace=true").build());
+        assertThat(Flux.from(response.body()).map(this::decodeUtf8String).blockFirst().contains("id=" + Thread.currentThread().getId()), is(true));
+    }
+
+    @Test
+    public void testWithoutStackTrace() {
+        CurrentRequestTracker.INSTANCE.clear();
+        Thread.currentThread().setName("Test-Thread");
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        LiveHttpResponse response = (new CurrentRequestsHandler(CurrentRequestTracker.INSTANCE)).doHandle(req1);
+        assertThat(Flux.from(response.body()).map(this::decodeUtf8String).blockFirst().contains("id=" + Thread.currentThread().getId()), is(false));
+    }
+
+    private String decodeUtf8String(Buffer buffer) {
+        return new String(buffer.content(), UTF_8);
+    }
+}

--- a/components/server/src/main/java/com/hotels/styx/server/track/CurrentRequest.java
+++ b/components/server/src/main/java/com/hotels/styx/server/track/CurrentRequest.java
@@ -32,8 +32,8 @@ public class CurrentRequest {
     private boolean requestSent;
 
     public CurrentRequest(LiveHttpRequest request, Supplier<String> stateSupplier) {
-        startingTimeMillies = currentTimeMillis();
-        currentThread = Thread.currentThread();
+        this.startingTimeMillies = currentTimeMillis();
+        this.currentThread = Thread.currentThread();
         this.request = request.toString();
         this.stateSupplier = stateSupplier;
     }

--- a/components/server/src/main/java/com/hotels/styx/server/track/CurrentRequest.java
+++ b/components/server/src/main/java/com/hotels/styx/server/track/CurrentRequest.java
@@ -1,0 +1,68 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.server.track;
+
+import static java.lang.System.currentTimeMillis;
+
+import java.util.function.Supplier;
+import com.hotels.styx.api.LiveHttpRequest;
+
+/**
+ * Bean that represent the current request.
+ */
+public class CurrentRequest {
+
+    private final String request;
+    private final long startingTimeMillies;
+    private volatile Thread currentThread;
+    private final Supplier<String> stateSupplier;
+    private boolean requestSent;
+
+    public CurrentRequest(LiveHttpRequest request, Supplier<String> stateSupplier) {
+        startingTimeMillies = currentTimeMillis();
+        currentThread = Thread.currentThread();
+        this.request = request.toString();
+        this.stateSupplier = stateSupplier;
+    }
+
+    public Thread getCurrentThread() {
+        return currentThread;
+    }
+
+    public void setCurrentThread(Thread currentThread) {
+        this.currentThread = currentThread;
+    }
+
+    public String getRequest() {
+        return request;
+    }
+
+    public long getStartingTimeMillies() {
+        return startingTimeMillies;
+    }
+
+    public String getState() {
+        return stateSupplier.get();
+    }
+
+    public boolean isRequestSent() {
+        return requestSent;
+    }
+
+    public void setRequestSent(boolean requestSent) {
+        this.requestSent = requestSent;
+    }
+}

--- a/components/server/src/main/java/com/hotels/styx/server/track/CurrentRequestTracker.java
+++ b/components/server/src/main/java/com/hotels/styx/server/track/CurrentRequestTracker.java
@@ -1,0 +1,72 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.server.track;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import com.hotels.styx.api.LiveHttpRequest;
+
+/**
+ * Manger class to manage the current requests.
+ */
+public class CurrentRequestTracker {
+
+    private static ConcurrentHashMap<Object, CurrentRequest> currentRequests = new ConcurrentHashMap<>();
+
+    public static final CurrentRequestTracker INSTANCE = new CurrentRequestTracker();
+
+    private CurrentRequestTracker() {
+    }
+
+    public void trackRequest(LiveHttpRequest request, Supplier<String> state) {
+
+        if (currentRequests.containsKey(request.id())) {
+            currentRequests.get(request.id()).setCurrentThread(Thread.currentThread());
+        } else {
+            currentRequests.put(request.id(), new CurrentRequest(request, state));
+        }
+    }
+
+    public void trackRequest(LiveHttpRequest request) {
+
+        if (currentRequests.containsKey(request.id())) {
+            currentRequests.get(request.id()).setCurrentThread(Thread.currentThread());
+        } else {
+            trackRequest(request, () -> "Status NOT Available.");
+        }
+    }
+
+    public void markRequestAsSent(LiveHttpRequest request) {
+
+        if (currentRequests.containsKey(request.id())) {
+            currentRequests.get(request.id()).setRequestSent(true);
+        }
+    }
+
+    public void endTrack(LiveHttpRequest request) {
+        currentRequests.remove(request.id());
+    }
+
+    public Collection<CurrentRequest> getCurrentRequests() {
+        return currentRequests.values();
+    }
+
+    public void clear() {
+        currentRequests.clear();
+    }
+}

--- a/components/server/src/main/java/com/hotels/styx/server/track/CurrentRequestTracker.java
+++ b/components/server/src/main/java/com/hotels/styx/server/track/CurrentRequestTracker.java
@@ -24,7 +24,7 @@ import com.hotels.styx.api.LiveHttpRequest;
 /**
  * Manger class to manage the current requests.
  */
-public class CurrentRequestTracker {
+public class CurrentRequestTracker implements RequestTracker {
 
     private static ConcurrentHashMap<Object, CurrentRequest> currentRequests = new ConcurrentHashMap<>();
 
@@ -34,7 +34,6 @@ public class CurrentRequestTracker {
     }
 
     public void trackRequest(LiveHttpRequest request, Supplier<String> state) {
-
         if (currentRequests.containsKey(request.id())) {
             currentRequests.get(request.id()).setCurrentThread(Thread.currentThread());
         } else {
@@ -43,7 +42,6 @@ public class CurrentRequestTracker {
     }
 
     public void trackRequest(LiveHttpRequest request) {
-
         if (currentRequests.containsKey(request.id())) {
             currentRequests.get(request.id()).setCurrentThread(Thread.currentThread());
         } else {

--- a/components/server/src/main/java/com/hotels/styx/server/track/RequestTracker.java
+++ b/components/server/src/main/java/com/hotels/styx/server/track/RequestTracker.java
@@ -1,0 +1,49 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.server.track;
+
+import com.hotels.styx.api.LiveHttpRequest;
+
+import java.util.function.Supplier;
+
+/**
+ * An interface for tracking requests as they pass through Styx.
+ */
+public interface RequestTracker {
+    RequestTracker NO_OP = new RequestTracker() {
+        @Override
+        public void trackRequest(LiveHttpRequest request, Supplier<String> state) {
+        }
+
+        @Override
+        public void trackRequest(LiveHttpRequest request) {
+        }
+
+        @Override
+        public void markRequestAsSent(LiveHttpRequest request) {
+        }
+
+        @Override
+        public void endTrack(LiveHttpRequest request) {
+
+        }
+    };
+
+    void trackRequest(LiveHttpRequest request, Supplier<String> state);
+    void trackRequest(LiveHttpRequest request);
+    void markRequestAsSent(LiveHttpRequest request);
+    void endTrack(LiveHttpRequest request);
+}

--- a/components/server/src/test/java/com/hotels/styx/server/track/CurrentRequestTrackerTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/track/CurrentRequestTrackerTest.java
@@ -1,0 +1,89 @@
+/*
+  Copyright (C) 2013-2018 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.server.track;
+
+import static com.hotels.styx.api.LiveHttpRequest.get;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.hotels.styx.api.LiveHttpRequest;
+
+public class CurrentRequestTrackerTest {
+
+    LiveHttpRequest req1 = get("/requestId1").build();
+    LiveHttpRequest req2 = get("/requestId2").build();
+
+    @BeforeMethod
+    public void setUp() {
+        CurrentRequestTracker.INSTANCE.clear();
+    }
+
+    @Test
+    public void testTrackRequest() {
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        assertThat(CurrentRequestTracker.INSTANCE.getCurrentRequests().iterator().next().getRequest(), is(req1.toString()));
+    }
+
+    @Test
+    public void testChangeWorkingThread() {
+        Thread.currentThread().setName("thread-1");
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        assertThat("thread-1", is(CurrentRequestTracker.INSTANCE.getCurrentRequests().iterator().next().getCurrentThread().getName()));
+        Thread.currentThread().setName("thread-2");
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        assertThat("thread-2", is(CurrentRequestTracker.INSTANCE.getCurrentRequests().iterator().next().getCurrentThread().getName()));
+    }
+
+    @Test
+    public void testTrackingSameReqMultipleTimesWillNotGenerateMultipleEntries() {
+        assertThat(CurrentRequestTracker.INSTANCE.getCurrentRequests().size(), is(0));
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        assertThat(CurrentRequestTracker.INSTANCE.getCurrentRequests().size(), is(1));
+        assertThat(CurrentRequestTracker.INSTANCE.getCurrentRequests().iterator().next().getRequest(), is(req1.toString()));
+    }
+
+    @Test
+    public void testEndTrack() {
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        assertThat(CurrentRequestTracker.INSTANCE.getCurrentRequests().size(), is(1));
+        assertThat(CurrentRequestTracker.INSTANCE.getCurrentRequests().iterator().next().getRequest(), is(req1.toString()));
+        CurrentRequestTracker.INSTANCE.endTrack(req1);
+        assertThat(CurrentRequestTracker.INSTANCE.getCurrentRequests().size(), is(0));
+    }
+
+    @Test
+    public void testEndTrackWillEffectOneRequest() {
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        CurrentRequestTracker.INSTANCE.trackRequest(req2);
+        assertThat(CurrentRequestTracker.INSTANCE.getCurrentRequests().size(), is(2));
+        CurrentRequestTracker.INSTANCE.endTrack(req1);
+        assertThat(CurrentRequestTracker.INSTANCE.getCurrentRequests().size(), is(1));
+    }
+
+    @Test
+    public void testEndTrackWillEffectTheCorrectRequest() {
+        CurrentRequestTracker.INSTANCE.trackRequest(req1);
+        CurrentRequestTracker.INSTANCE.trackRequest(req2);
+        CurrentRequestTracker.INSTANCE.endTrack(req1);
+        assertThat(CurrentRequestTracker.INSTANCE.getCurrentRequests().iterator().next().getRequest(), is(req2.toString()));
+    }
+}

--- a/docs/user-guide/admin-interface.md
+++ b/docs/user-guide/admin-interface.md
@@ -29,6 +29,8 @@ Note that this endpoint must be externally secured.
 
 * `Threads` - a stack trace dump from all threads. 
 
+* `Current Request` - shows all HTTP requests inside styx and the stack trace for each request, if the request is in WAITING_FOR_RESPONSE state then the stack trace will not be available. 
+
 All endpoints are available from the admin menu:
 
 `http://<STYX_SERVER_URL>/admin/`

--- a/docs/user-guide/admin-interface.md
+++ b/docs/user-guide/admin-interface.md
@@ -29,7 +29,7 @@ Note that this endpoint must be externally secured.
 
 * `Threads` - a stack trace dump from all threads. 
 
-* `Current Request` - shows all HTTP requests inside styx and the stack trace for each request, if the request is in WAITING_FOR_RESPONSE state then the stack trace will not be available. 
+* `Current Request` - shows the state of proxied HTTP requests inside Styx. A stack trace is shown if the request is being processed in the interceptor pipeline.
 
 All endpoints are available from the admin menu:
 


### PR DESCRIPTION
Added a new admin handler that will help in tracking only the current http requests to styx. for example if you noticed that there is a slowness in styx you can open that new admin handler "Current Requests" and it will show only the info of current HttpRequests in styx like uri, method, params ... etc and the running time of these requests, and the stack traces for the associated threads