### PR TITLE
Fix an incorrect perf test URL.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ RATE=3000
 TIMES=3
 DURATION=30
 CONNECTIONS=200
-ENDPOINT=http://localhost:8080/lp/demo
-SSL_ENDPOINT=https://localhost:8443/lp/demo
+ENDPOINT=http://localhost:8080/landing/demo
+SSL_ENDPOINT=https://localhost:8443/landing/demo
 LOAD_TEST_TOOL=scripts/load-test-tool/load_test.py
 PERF_DIR=system-tests/performance
 


### PR DESCRIPTION
The path prefix for `wrk2` load generator in Styx integrated perf test environment is incorrect. This PR applies the correct prefix that should be `landing`.
