### PR TITLE
Reduce visibility of `ByteStream.aggregate`

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/ByteStream.java
+++ b/components/api/src/main/java/com/hotels/styx/api/ByteStream.java
@@ -132,7 +132,7 @@ public class ByteStream implements Publisher<Buffer> {
      * @param maxContentBytes maximum size for the aggregated buffer
      * @return a future of aggregated buffer
      */
-    public CompletableFuture<Buffer> aggregate(int maxContentBytes) {
+    CompletableFuture<Buffer> aggregate(int maxContentBytes) {
         return new ByteStreamAggregator(this.stream, maxContentBytes)
                 .apply();
     }

--- a/components/client/src/main/java/com/hotels/styx/client/Transport.java
+++ b/components/client/src/main/java/com/hotels/styx/client/Transport.java
@@ -84,7 +84,7 @@ class Transport {
                 .map(ConnectionPool::borrowConnection)
                 .orElseGet(() -> {
                     // Aggregates an empty body:
-                    request.body().drop().aggregate(1);
+                    request.consume();
                     return Observable.error(new NoAvailableHostsException(appId));
                 });
     }


### PR DESCRIPTION
Styx `Buffer` objects are underpinned by reference counted Netty `ByteBuf` objects. `ByteStream.aggregate` allows API users to consume them, but offers no way down reference them.

Therefore, let's make this package private for now so that end-users cannot accidentally leak direct memory.
