### PR TITLE
Add maven javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1175,6 +1175,19 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven-javadoc-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
             <executions>


### PR DESCRIPTION
For some reason this plugin was removed from Styx in the transition from 0.7 to 1.0, and its absence seems to be preventing us from releasing to Maven central