### PR TITLE
Tidy up HttpPipelineHandler log messages.

### DIFF
--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -313,6 +313,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
         statsSink.onComplete(ongoingRequest.id(), ongoingResponse.status().code());
         if (ongoingRequest.keepAlive()) {
             ongoingRequest = null;
+            ongoingResponse = null;
 
             if (prematureRequest != null) {
                 eventProcessor.submit(new RequestReceivedEvent(prematureRequest, ctx));


### PR DESCRIPTION
Fixes issue: #335.

Removes `ongoingResponse`, when necessary, from HttpPipelineHandler log messages.

The fix is to nullify `ongoingResponse` when the pipeline handler FSM transitions back to `ACCEPTING_REQUESTS`.
