### PR TITLE
Refactor StyxHostHttpClient

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
@@ -57,7 +57,6 @@ import static com.hotels.styx.api.extension.RemoteHost.remoteHost;
 import static com.hotels.styx.client.OriginsInventory.OriginState.ACTIVE;
 import static com.hotels.styx.client.OriginsInventory.OriginState.DISABLED;
 import static com.hotels.styx.client.OriginsInventory.OriginState.INACTIVE;
-import static com.hotels.styx.client.StyxHeaderConfig.ORIGIN_ID_DEFAULT;
 import static com.hotels.styx.client.connectionpool.ConnectionPools.simplePoolFactory;
 import static com.hotels.styx.common.StyxFutures.await;
 import static java.util.Collections.emptyMap;
@@ -542,7 +541,7 @@ public final class OriginsInventory
             await(originHealthMonitor.start());
 
             if (hostClientFactory == null) {
-                hostClientFactory = (ConnectionPool connectionPool) -> StyxHostHttpClient.create(appId, connectionPool.getOrigin().id(), ORIGIN_ID_DEFAULT, connectionPool);
+                hostClientFactory = (ConnectionPool connectionPool) -> StyxHostHttpClient.create(connectionPool);
             }
 
             OriginsInventory originsInventory = new OriginsInventory(

--- a/components/client/src/main/java/com/hotels/styx/client/StyxHostHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHostHttpClient.java
@@ -22,8 +22,6 @@ import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancingMetricSuppli
 import com.hotels.styx.client.connectionpool.ConnectionPool;
 import rx.Observable;
 
-import java.util.Optional;
-
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -45,7 +43,7 @@ public class StyxHostHttpClient implements BackendServiceClient, LoadBalancingMe
     @Override
     public Observable<LiveHttpResponse> sendRequest(LiveHttpRequest request) {
         return transport
-                .send(request, Optional.of(pool))
+                .send(request, pool)
                 .response();
     }
 

--- a/components/client/src/main/java/com/hotels/styx/client/StyxHostHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHostHttpClient.java
@@ -17,10 +17,9 @@ package com.hotels.styx.client;
 
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
-import com.hotels.styx.api.Id;
-import com.hotels.styx.client.connectionpool.ConnectionPool;
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancingMetric;
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancingMetricSupplier;
+import com.hotels.styx.client.connectionpool.ConnectionPool;
 import rx.Observable;
 
 import java.util.Optional;
@@ -32,23 +31,21 @@ import static java.util.Objects.requireNonNull;
  */
 public class StyxHostHttpClient implements BackendServiceClient, LoadBalancingMetricSupplier {
     private final Transport transport;
-    private final Id originId;
     private final ConnectionPool pool;
 
-    public StyxHostHttpClient(Id originId, ConnectionPool pool, Transport transport) {
-        this.originId = requireNonNull(originId);
-        this.pool = requireNonNull(pool);
+    StyxHostHttpClient(ConnectionPool pool, Transport transport) {
         this.transport = requireNonNull(transport);
+        this.pool = requireNonNull(pool);
     }
 
-    public static StyxHostHttpClient create(Id appId, Id originId, CharSequence headerName, ConnectionPool pool) {
-        return new StyxHostHttpClient(originId, pool, new Transport(appId, headerName));
+    public static StyxHostHttpClient create(ConnectionPool pool) {
+        return new StyxHostHttpClient(pool, new Transport());
     }
 
     @Override
     public Observable<LiveHttpResponse> sendRequest(LiveHttpRequest request) {
         return transport
-                .send(request, Optional.of(pool), originId)
+                .send(request, Optional.of(pool))
                 .response();
     }
 

--- a/components/client/src/main/java/com/hotels/styx/client/Transport.java
+++ b/components/client/src/main/java/com/hotels/styx/client/Transport.java
@@ -43,7 +43,7 @@ class Transport {
                 });
             }
 
-            private synchronized void closeIfConnected(ConnectionPool connectionPool, Connection connection) {
+            private void closeIfConnected(ConnectionPool connectionPool, Connection connection) {
                 connectionPool.closeConnection(connection);
             }
 

--- a/components/client/src/main/java/com/hotels/styx/client/Transport.java
+++ b/components/client/src/main/java/com/hotels/styx/client/Transport.java
@@ -47,7 +47,7 @@ class Transport {
                 connectionPool.closeConnection(connection);
             }
 
-            private synchronized void returnIfConnected(ConnectionPool connectionPool, Connection connection) {
+            private void returnIfConnected(ConnectionPool connectionPool, Connection connection) {
                 connectionPool.returnConnection(connection);
             }
         };

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxHostHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxHostHttpClientTest.java
@@ -16,14 +16,15 @@
 package com.hotels.styx.client;
 
 import com.hotels.styx.api.HttpRequest;
-import com.hotels.styx.api.Id;
+import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.client.connectionpool.ConnectionPool;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import com.hotels.styx.api.LiveHttpRequest;
+import rx.Observable;
 
 import java.util.Optional;
 
+import static com.hotels.styx.api.LiveHttpResponse.response;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -43,21 +44,24 @@ public class StyxHostHttpClientTest {
     public void sendsRequestUsingTransport() {
         ConnectionPool pool = mock(ConnectionPool.class);
         Transport transport = mock(Transport.class);
-        when(transport.send(any(LiveHttpRequest.class), any(Optional.class), any(Id.class))).thenReturn(mock(HttpTransaction.class));
+        HttpTransaction transaction = mock(HttpTransaction.class);
 
-        new StyxHostHttpClient(Id.id("app-01"), pool, transport)
+        when(transport.send(any(LiveHttpRequest.class), any(Optional.class))).thenReturn(transaction);
+        when(transaction.response()).thenReturn(Observable.just(response().build()));
+
+        new StyxHostHttpClient(pool, transport)
                 .sendRequest(request);
 
-        verify(transport).send(eq(request), eq(Optional.of(pool)), eq(Id.id("app-01")));
+        verify(transport).send(eq(request), eq(Optional.of(pool)));
     }
 
     @Test
     public void closesTheConnectionPool() {
         ConnectionPool pool = mock(ConnectionPool.class);
         Transport transport = mock(Transport.class);
-        when(transport.send(any(LiveHttpRequest.class), any(Optional.class), any(Id.class))).thenReturn(mock(HttpTransaction.class));
+        when(transport.send(any(LiveHttpRequest.class), any(Optional.class))).thenReturn(mock(HttpTransaction.class));
 
-        StyxHostHttpClient hostClient = new StyxHostHttpClient(Id.id("app-01"), pool, transport);
+        StyxHostHttpClient hostClient = new StyxHostHttpClient(pool, transport);
 
         hostClient.close();
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxHostHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxHostHttpClientTest.java
@@ -22,8 +22,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import rx.Observable;
 
-import java.util.Optional;
-
 import static com.hotels.styx.api.LiveHttpResponse.response;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -46,20 +44,20 @@ public class StyxHostHttpClientTest {
         Transport transport = mock(Transport.class);
         HttpTransaction transaction = mock(HttpTransaction.class);
 
-        when(transport.send(any(LiveHttpRequest.class), any(Optional.class))).thenReturn(transaction);
+        when(transport.send(any(LiveHttpRequest.class), any(ConnectionPool.class))).thenReturn(transaction);
         when(transaction.response()).thenReturn(Observable.just(response().build()));
 
         new StyxHostHttpClient(pool, transport)
                 .sendRequest(request);
 
-        verify(transport).send(eq(request), eq(Optional.of(pool)));
+        verify(transport).send(eq(request), eq(pool));
     }
 
     @Test
     public void closesTheConnectionPool() {
         ConnectionPool pool = mock(ConnectionPool.class);
         Transport transport = mock(Transport.class);
-        when(transport.send(any(LiveHttpRequest.class), any(Optional.class))).thenReturn(mock(HttpTransaction.class));
+        when(transport.send(any(LiveHttpRequest.class), any(ConnectionPool.class))).thenReturn(mock(HttpTransaction.class));
 
         StyxHostHttpClient hostClient = new StyxHostHttpClient(pool, transport);
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/TransportTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/TransportTest.java
@@ -64,7 +64,7 @@ public class TransportTest {
     public void setUp() {
         request = get("/").build();
         response = LiveHttpResponse.response(OK).build();
-        transport = new Transport(id("x"), X_STYX_ORIGIN_ID);
+        transport = new Transport();
         responseProvider = PublishSubject.create();
         subscriber = new TestSubscriber<>();
     }
@@ -74,7 +74,7 @@ public class TransportTest {
         Connection connection = mockConnection(just(response));
         ConnectionPool pool = mockPool(connection);
 
-        HttpTransaction transaction = transport.send(request, Optional.of(pool), APP_ID);
+        HttpTransaction transaction = transport.send(request, Optional.of(pool));
 
         transaction.response()
                 .toBlocking()
@@ -91,7 +91,7 @@ public class TransportTest {
         Connection connection = mockConnection(just(response));
         ConnectionPool pool = mockPool(connection);
 
-        transport.send(request, Optional.of(pool), APP_ID)
+        transport.send(request, Optional.of(pool))
                 .response()
                 .subscribe(subscriber);
 
@@ -109,7 +109,7 @@ public class TransportTest {
         Connection connection = mockConnection(PublishSubject.create());
         ConnectionPool pool = mockPool(connection);
 
-        transport.send(request, Optional.of(pool), APP_ID)
+        transport.send(request, Optional.of(pool))
                 .response()
                 .subscribe(subscriber);
 
@@ -132,7 +132,7 @@ public class TransportTest {
         Connection connection = mockConnection(responseProvider);
         ConnectionPool pool = mockPool(connection);
 
-        transport.send(request, Optional.of(pool), APP_ID)
+        transport.send(request, Optional.of(pool))
                 .response()
                 .subscribe(subscriber);
 
@@ -153,7 +153,7 @@ public class TransportTest {
         Connection connection = mockConnection(responseProvider);
         ConnectionPool pool = mockPool(connection);
 
-        transport.send(request, Optional.of(pool), APP_ID)
+        transport.send(request, Optional.of(pool))
                 .response()
                 .subscribe(subscriber);
 
@@ -170,7 +170,7 @@ public class TransportTest {
         Connection connection = mockConnection(Observable.empty());
         ConnectionPool pool = mockPool(connection);
 
-        transport.send(request, Optional.of(pool), APP_ID)
+        transport.send(request, Optional.of(pool))
                 .response()
                 .subscribe(subscriber);
 
@@ -185,7 +185,7 @@ public class TransportTest {
         Connection connection = mockConnection(Observable.error(new RuntimeException()));
         ConnectionPool pool = mockPool(connection);
 
-        transport.send(request, Optional.of(pool), APP_ID)
+        transport.send(request, Optional.of(pool))
                 .response()
                 .subscribe(subscriber);
 
@@ -201,7 +201,7 @@ public class TransportTest {
         Connection connection = mockConnection(Observable.just(LiveHttpResponse.response(OK).body(new ByteStream(testPublisher)).build()));
         ConnectionPool pool = mockPool(connection);
 
-        transport.send(request, Optional.of(pool), APP_ID)
+        transport.send(request, Optional.of(pool))
                 .response()
                 .subscribe(subscriber);
 
@@ -225,7 +225,7 @@ public class TransportTest {
                 .body(new ByteStream(toPublisher(Observable.from(ImmutableList.of(chunk1, chunk2, chunk3)))))
                 .build();
 
-        transport.send(aRequest, Optional.empty(), APP_ID)
+        transport.send(aRequest, Optional.empty())
                 .response()
                 .subscribe(subscriber);
 
@@ -237,7 +237,7 @@ public class TransportTest {
     @Test
     public void emitsNoAvailableHostsExceptionWhenPoolIsNotProvided() {
 
-        transport.send(request, Optional.empty(), APP_ID)
+        transport.send(request, Optional.empty())
                 .response()
                 .subscribe(subscriber);
 

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
@@ -132,7 +132,7 @@ public class BackendServicesRouter implements HttpRouter, Registry.ChangeListene
 
             StyxHostHttpClient.Factory hostClientFactory = (ConnectionPool connectionPool) -> {
                 StyxHeaderConfig headerConfig = environment.styxConfig().styxHeaderConfig();
-                return StyxHostHttpClient.create(backendService.id(), connectionPool.getOrigin().id(), headerConfig.originIdHeaderName(), connectionPool);
+                return StyxHostHttpClient.create(connectionPool);
             };
 
             OriginsInventory inventory = new OriginsInventory.Builder(backendService.id())

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/StyxBackendServiceClientFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/StyxBackendServiceClientFactory.java
@@ -16,11 +16,11 @@
 package com.hotels.styx.proxy;
 
 import com.hotels.styx.Environment;
-import com.hotels.styx.client.BackendServiceClient;
+import com.hotels.styx.api.configuration.Configuration;
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancer;
 import com.hotels.styx.api.extension.retrypolicy.spi.RetryPolicy;
-import com.hotels.styx.api.configuration.Configuration;
 import com.hotels.styx.api.extension.service.BackendService;
+import com.hotels.styx.client.BackendServiceClient;
 import com.hotels.styx.client.OriginRestrictionLoadBalancingStrategy;
 import com.hotels.styx.client.OriginStatsFactory;
 import com.hotels.styx.client.OriginsInventory;
@@ -50,6 +50,7 @@ public class StyxBackendServiceClientFactory implements BackendServiceClientFact
     @Override
     public BackendServiceClient createClient(BackendService backendService, OriginsInventory originsInventory, OriginStatsFactory originStatsFactory) {
         Configuration styxConfig = environment.configuration();
+
         String originRestrictionCookie = styxConfig.get("originRestrictionCookie").orElse(null);
         boolean stickySessionEnabled = backendService.stickySessionConfig().stickySessionEnabled();
 
@@ -80,6 +81,7 @@ public class StyxBackendServiceClientFactory implements BackendServiceClientFact
                 .rewriteRules(backendService.rewrites())
                 .originStatsFactory(originStatsFactory)
                 .originsRestrictionCookieName(originRestrictionCookie)
+                .originIdHeader(environment.styxConfig().styxHeaderConfig().originIdHeaderName())
                 .build();
     }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/ErrorMetricsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/ErrorMetricsSpec.scala
@@ -13,21 +13,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-/**
-  * Copyright (C) 2013-2018 Expedia Inc.
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
 package com.hotels.styx.plugins
 
 import java.lang.Thread.sleep
@@ -182,7 +167,6 @@ class ErrorMetricsSpec extends FunSpec
 
       eventually(timeout(1.second)) {
         assert(originErrorMetric == 1)
-        println("metrics: " + styxServer.metricsSnapshot)
       }
 
       sleep(1000)


### PR DESCRIPTION
Move functionality up into `StyxBackendServiceClient`:
- Origin ID header attachment
- Application name in the exceptions

Rationale: to make it easier to expose `StyxHostHttpClient` as a reusable component for 3rd party projects. Specifically, this improvement removes classes like `Origin` from the API and removes Styx proxy specific functionality like attaching origin IDs to HTTP responses.
