### PR TITLE
Add a config option to enable/disable the request tracking feature.

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/ServerConfigSchema.java
+++ b/components/proxy/src/main/java/com/hotels/styx/ServerConfigSchema.java
@@ -145,7 +145,8 @@ final class ServerConfigSchema {
                     optional("responseInfoHeaderFormat", string()),
                     optional("httpPipeline", object(opaque())),
                     optional("logFormat", string()),
-                    optional("userDefined", object(opaque()))
+                    optional("userDefined", object(opaque())),
+                    optional("requestTracking", bool())
             ))
             .build();
 

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/InterceptorPipelineBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/InterceptorPipelineBuilder.java
@@ -36,16 +36,18 @@ public class InterceptorPipelineBuilder {
     private final Environment environment;
     private final Iterable<NamedPlugin> plugins;
     private final HttpHandler handler;
+    private final boolean trackRequests;
 
-    public InterceptorPipelineBuilder(Environment environment, Iterable<NamedPlugin> plugins, HttpHandler handler) {
+    public InterceptorPipelineBuilder(Environment environment, Iterable<NamedPlugin> plugins, HttpHandler handler, boolean trackRequests) {
         this.environment = requireNonNull(environment);
         this.plugins = requireNonNull(plugins);
         this.handler = requireNonNull(handler);
+        this.trackRequests = trackRequests;
     }
 
     public HttpHandler build() {
         List<HttpInterceptor> interceptors = ImmutableList.copyOf(instrument(plugins, environment));
-        return new HttpInterceptorPipeline(interceptors, handler);
+        return new HttpInterceptorPipeline(interceptors, handler, trackRequests);
     }
 
     private static List<InstrumentedPlugin> instrument(Iterable<NamedPlugin> namedPlugins, Environment environment) {

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyServerBuilder.java
@@ -46,9 +46,10 @@ public final class ProxyServerBuilder {
     public HttpServer build() {
         ProxyServerConfig proxyConfig = environment.styxConfig().proxyServerConfig();
         String unwiseCharacters = environment.styxConfig().get(ENCODE_UNWISECHARS).orElse("");
+        boolean requestTracking = environment.configuration().get("requestTracking", Boolean.class).orElse(false);
 
         return new NettyServerBuilderSpec("Proxy", environment.serverEnvironment(),
-                new ProxyConnectorFactory(proxyConfig, environment.metricRegistry(), environment.errorListener(), unwiseCharacters, this::addInfoHeader))
+                new ProxyConnectorFactory(proxyConfig, environment.metricRegistry(), environment.errorListener(), unwiseCharacters, this::addInfoHeader, requestTracking))
                 .toNettyServerBuilder(proxyConfig)
                 .httpHandler(httpHandler)
                 // register health check

--- a/components/proxy/src/main/java/com/hotels/styx/routing/StaticPipelineFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/StaticPipelineFactory.java
@@ -36,17 +36,26 @@ public class StaticPipelineFactory implements HttpPipelineFactory {
     private final Environment environment;
     private final Registry<BackendService> registry;
     private final Iterable<NamedPlugin> plugins;
+    private final boolean trackRequests;
 
     @VisibleForTesting
-    StaticPipelineFactory(BackendServiceClientFactory clientFactory, Environment environment, Registry<BackendService> registry, Iterable<NamedPlugin> plugins) {
+    StaticPipelineFactory(BackendServiceClientFactory clientFactory,
+                          Environment environment,
+                          Registry<BackendService> registry,
+                          Iterable<NamedPlugin> plugins,
+                          boolean trackRequests) {
         this.clientFactory = clientFactory;
         this.environment = environment;
         this.registry = registry;
         this.plugins = plugins;
+        this.trackRequests = trackRequests;
     }
 
-    public StaticPipelineFactory(Environment environment, Registry<BackendService> registry, Iterable<NamedPlugin> plugins) {
-        this(createClientFactory(environment), environment, registry, plugins);
+    public StaticPipelineFactory(Environment environment,
+                                 Registry<BackendService> registry,
+                                 Iterable<NamedPlugin> plugins,
+                                 boolean trackRequests) {
+        this(createClientFactory(environment), environment, registry, plugins, trackRequests);
     }
 
     private static BackendServiceClientFactory createClientFactory(Environment environment) {
@@ -59,6 +68,6 @@ public class StaticPipelineFactory implements HttpPipelineFactory {
         registry.addListener(backendServicesRouter);
         RouteHandlerAdapter router = new RouteHandlerAdapter(backendServicesRouter);
 
-        return new InterceptorPipelineBuilder(environment, plugins, router).build();
+        return new InterceptorPipelineBuilder(environment, plugins, router, trackRequests).build();
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/StyxConfigTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/StyxConfigTest.java
@@ -15,11 +15,9 @@
  */
 package com.hotels.styx;
 
-import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig;
 import com.hotels.styx.proxy.ProxyServerConfig;
 import org.testng.annotations.Test;
 
-import static com.hotels.styx.StartupConfig.defaultStartupConfig;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
 import static java.lang.Runtime.getRuntime;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/InterceptorPipelineBuilderTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/InterceptorPipelineBuilderTest.java
@@ -71,7 +71,7 @@ public class InterceptorPipelineBuilderTest {
 
     @Test
     public void buildsPipelineWithInterceptors() throws Exception {
-        HttpHandler pipeline = new InterceptorPipelineBuilder(environment, plugins, handler).build();
+        HttpHandler pipeline = new InterceptorPipelineBuilder(environment, plugins, handler, false).build();
         LiveHttpResponse response = pipeline.handle(get("/foo").build(), HttpInterceptorContext.create()).asCompletableFuture().get();
 
         assertThat(response.header("plug1"), isValue("1"));

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/StyxProxyTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/StyxProxyTest.java
@@ -78,7 +78,7 @@ public class StyxProxyTest extends SSLSetup {
 
         HttpServer server = NettyServerBuilder.newBuilder()
                 .setHttpConnector(connector(0))
-                .httpHandler(new HttpInterceptorPipeline(ImmutableList.of(echoInterceptor), new StandardHttpRouter()))
+                .httpHandler(new HttpInterceptorPipeline(ImmutableList.of(echoInterceptor), new StandardHttpRouter(), false))
                 .build();
         server.startAsync().awaitRunning();
         assertThat("Server should be running", server.isRunning());

--- a/components/proxy/src/test/java/com/hotels/styx/routing/StaticPipelineBuilderTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/routing/StaticPipelineBuilderTest.java
@@ -63,7 +63,7 @@ public class StaticPipelineBuilderTest {
     @Test
     public void buildsInterceptorPipelineForBackendServices() throws Exception {
 
-        HttpHandler handler = new StaticPipelineFactory(clientFactory, environment, registry, ImmutableList.of()).build();
+        HttpHandler handler = new StaticPipelineFactory(clientFactory, environment, registry, ImmutableList.of(), false).build();
         LiveHttpResponse response = handler.handle(get("/foo").build(), HttpInterceptorContext.create()).asCompletableFuture().get();
         assertThat(response.status(), is(OK));
     }
@@ -75,7 +75,7 @@ public class StaticPipelineBuilderTest {
                 interceptor("Test-B", appendResponseHeader("X-From-Plugin", "B"))
         );
 
-        HttpHandler handler = new StaticPipelineFactory(clientFactory, environment, registry, plugins).build();
+        HttpHandler handler = new StaticPipelineFactory(clientFactory, environment, registry, plugins, false).build();
 
         LiveHttpResponse response = handler.handle(get("/foo").build(), HttpInterceptorContext.create()).asCompletableFuture().get();
         assertThat(response.status(), is(OK));

--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -22,9 +22,9 @@ import com.hotels.styx.api.ByteStream;
 import com.hotels.styx.api.ContentOverflowException;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
+import com.hotels.styx.api.HttpResponseStatus;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
-import com.hotels.styx.api.HttpResponseStatus;
 import com.hotels.styx.api.MetricRegistry;
 import com.hotels.styx.api.exceptions.NoAvailableHostsException;
 import com.hotels.styx.api.exceptions.OriginUnreachableException;
@@ -45,8 +45,6 @@ import com.hotels.styx.server.HttpInterceptorContext;
 import com.hotels.styx.server.NoServiceConfiguredException;
 import com.hotels.styx.server.RequestProgressListener;
 import com.hotels.styx.server.RequestTimeoutException;
-import com.hotels.styx.server.track.CurrentRequestTracker;
-
 import com.hotels.styx.server.track.RequestTracker;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -715,7 +713,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
             return this;
         }
 
-        public Builder requestTracker(CurrentRequestTracker tracker) {
+        public Builder requestTracker(RequestTracker tracker) {
             this.tracker = requireNonNull(tracker);
             return this;
         }

--- a/docs/user-guide/admin-interface.md
+++ b/docs/user-guide/admin-interface.md
@@ -29,7 +29,9 @@ Note that this endpoint must be externally secured.
 
 * `Threads` - a stack trace dump from all threads. 
 
-* `Current Request` - shows the state of proxied HTTP requests inside Styx. A stack trace is shown if the request is being processed in the interceptor pipeline.
+* `Current Request` - shows the state of proxied HTTP requests inside Styx. 
+   A stack trace is shown if the request is being processed in the interceptor pipeline.
+   This feature must be activated by `requestTracking` flag in the Styx configuration.
 
 All endpoints are available from the admin menu:
 

--- a/docs/user-guide/configure-overview.md
+++ b/docs/user-guide/configure-overview.md
@@ -130,6 +130,10 @@ using environment variables with the same name as the property.
         name: "X-Styx-Origin-Id"
       requestId:
         name: "X-Styx-Request-Id"
+        
+    # Enables request tracking. This is a debugging feature that shows information about
+    # each proxied request. Accepts a boolean value (true/false).
+    requestTracking: false
  ```
 
 Without the comments, it looks like this:
@@ -193,4 +197,6 @@ Without the comments, it looks like this:
         name: "X-Styx-Origin-Id"
       requestId:
         name: "X-Styx-Request-Id"
+        
+    requestTracking: false
 ```


### PR DESCRIPTION
This adds a new Styx configuration option `requestTracking` to enable or disable the new request tracking feature. It takes a boolean value `true` to enable and `false` to disable the feature. It defaults to `false`.
