### PR TITLE
Deprecate Rx.Java from ConnectionPool and its consumers

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/BackendServiceClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/BackendServiceClient.java
@@ -17,7 +17,7 @@ package com.hotels.styx.client;
 
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
-import rx.Observable;
+import org.reactivestreams.Publisher;
 
 /**
  * HTTP Client that returns an observable of response.
@@ -33,5 +33,5 @@ public interface BackendServiceClient {
      * In order to cancel the ongoing request, just unsubscribe from it.
      *
      */
-    Observable<LiveHttpResponse> sendRequest(LiveHttpRequest request);
+    Publisher<LiveHttpResponse> sendRequest(LiveHttpRequest request);
 }

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/ConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/ConnectionPool.java
@@ -15,13 +15,12 @@
  */
 package com.hotels.styx.client.connectionpool;
 
-import com.hotels.styx.client.Connection;
 import com.hotels.styx.api.extension.Origin;
-import rx.Observable;
+import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
+import com.hotels.styx.client.Connection;
+import org.reactivestreams.Publisher;
 
 import java.io.Closeable;
-import java.util.function.Function;
-import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
 
 /**
  * A pool of connections.
@@ -116,7 +115,7 @@ public interface ConnectionPool extends Closeable {
      *
      * @return the borrowed connection
      */
-    Observable<Connection> borrowConnection();
+    Publisher<Connection> borrowConnection();
 
     /**
      * Returns back the connection to the host's pool. May close the connection if the
@@ -157,14 +156,6 @@ public interface ConnectionPool extends Closeable {
      * @return the pool settings
      */
     ConnectionPoolSettings settings();
-
-    default <T> Observable<T> withConnection(Function<Connection, Observable<T>> task) {
-        return borrowConnection()
-                .flatMap(connection ->
-                        task.apply(connection)
-                                .doOnCompleted(() -> returnConnection(connection))
-                                .doOnError(throwable -> closeConnection(connection)));
-    }
 
     /**
      * Closes this pool and releases any system resources associated with it.

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.getLogger;
-import static rx.RxReactiveStreams.toObservable;
 
 /**
  * A connection pool implementation.
@@ -72,12 +71,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
     }
 
     @Override
-    public Observable<Connection> borrowConnection() {
-        return toObservable(borrowConnection2());
-    }
-
-    @VisibleForTesting
-    Publisher<Connection> borrowConnection2() {
+    public Publisher<Connection> borrowConnection() {
         return Mono.<Connection>create(sink -> {
             Connection connection = dequeue();
             if (connection != null) {

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/StatsReportingConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/StatsReportingConnectionPool.java
@@ -16,12 +16,12 @@
 package com.hotels.styx.client.connectionpool;
 
 import com.codahale.metrics.Gauge;
-import com.hotels.styx.client.Connection;
-import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.MetricRegistry;
+import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
+import com.hotels.styx.client.Connection;
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
-import rx.Observable;
 
 import static com.hotels.styx.client.applications.metrics.OriginMetrics.originMetricsScope;
 import static java.util.Arrays.asList;
@@ -46,7 +46,7 @@ class StatsReportingConnectionPool implements ConnectionPool {
     }
 
     @Override
-    public Observable borrowConnection() {
+    public Publisher<Connection> borrowConnection() {
         return connectionPool.borrowConnection();
     }
 

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/BackendServiceClientSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/BackendServiceClientSpec.scala
@@ -135,8 +135,7 @@ class BackendServiceClientSpec extends FunSuite with BeforeAndAfterAll with Matc
     val duration = System.currentTimeMillis() - start.get()
 
     assert(maybeResponse.failed.get.isInstanceOf[ResponseTimeoutException], "- Client emitted an incorrect exception!")
-    println("responseTimeout: " + duration)
-    duration shouldBe duration +- 250
+    duration shouldBe responseTimeout.toLong +- 250
   }
 
   def time[A](codeBlock: => A) = {

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/BackendServiceClientSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/BackendServiceClientSpec.scala
@@ -15,21 +15,22 @@
  */
 package com.hotels.styx.client
 
+import java.util.concurrent.atomic.AtomicLong
+
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.google.common.base.Charsets._
+import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.LiveHttpRequest.get
+import com.hotels.styx.api.LiveHttpResponse
+import com.hotels.styx.api.exceptions.ResponseTimeoutException
 import com.hotels.styx.api.extension.Origin._
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancer
-import com.hotels.styx.api.extension.{ActiveOrigins, Origin}
-import com.hotels.styx.api.exceptions.ResponseTimeoutException
-import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.extension.service.BackendService
+import com.hotels.styx.api.extension.{ActiveOrigins, Origin}
 import com.hotels.styx.client.OriginsInventory.newOriginsInventoryBuilder
-import StyxBackendServiceClient._
-import com.hotels.styx.api.LiveHttpResponse
+import com.hotels.styx.client.StyxBackendServiceClient._
 import com.hotels.styx.client.loadbalancing.strategies.BusyConnectionsStrategy
-import com.hotels.styx.support.api.BlockingObservables.{waitForResponse, waitForStreamingResponse}
 import com.hotels.styx.support.server.FakeHttpServer
 import com.hotels.styx.support.server.UrlMatchingStrategies._
 import io.netty.buffer.Unpooled._
@@ -38,9 +39,13 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.HttpHeaders.Names._
 import io.netty.handler.codec.http.HttpVersion._
 import io.netty.handler.codec.http._
+import org.reactivestreams.Subscription
 import org.scalatest._
 import org.scalatest.mock.MockitoSugar
+import reactor.core.publisher.Mono
 import rx.observers.TestSubscriber
+
+import scala.util.Try
 
 class BackendServiceClientSpec extends FunSuite with BeforeAndAfterAll with Matchers with BeforeAndAfter with MockitoSugar {
   var webappOrigin: Origin = _
@@ -82,7 +87,7 @@ class BackendServiceClientSpec extends FunSuite with BeforeAndAfterAll with Matc
 
   test("Emits an HTTP response even when content observable remains un-subscribed.") {
     originOneServer.stub(urlStartingWith("/"), response200OkWithContentLengthHeader("Test message body."))
-    val response = waitForResponse(client.sendRequest(get("/foo/1").build()))
+    val response = Mono.from(client.sendRequest(get("/foo/1").build())).block()
     assert(response.status() == OK, s"\nDid not get response with 200 OK status.\n$response\n")
   }
 
@@ -90,7 +95,11 @@ class BackendServiceClientSpec extends FunSuite with BeforeAndAfterAll with Matc
   test("Emits an HTTP response containing Content-Length from persistent connection that stays open.") {
     originOneServer.stub(urlStartingWith("/"), response200OkWithContentLengthHeader("Test message body."))
 
-    val response = waitForResponse(client.sendRequest(get("/foo/2").build()))
+    val response = Mono.from(client.sendRequest(get("/foo/2").build()))
+      .flatMap((liveHttpResponse: LiveHttpResponse) => {
+        Mono.from(liveHttpResponse.aggregate(10000))
+      })
+      .block()
 
     assert(response.status() == OK, s"\nDid not get response with 200 OK status.\n$response\n")
     assert(response.bodyAs(UTF_8) == "Test message body.", s"\nReceived wrong/unexpected response body.")
@@ -100,26 +109,34 @@ class BackendServiceClientSpec extends FunSuite with BeforeAndAfterAll with Matc
   ignore("Determines response content length from server closing the connection.") {
     // originRespondingWith(response200OkFollowedFollowedByServerConnectionClose("Test message body."))
 
-    val response = waitForResponse(client.sendRequest(get("/foo/3").build()))
-    assert(response.status() == OK, s"\nDid not get response with 200 OK status.\n$response\n")
+    val response = Mono.from(client.sendRequest(get("/foo/3").build()))
+      .flatMap((liveHttpResponse: LiveHttpResponse) => {
+        Mono.from(liveHttpResponse.aggregate(10000))
+      })
+      .block()
 
+    assert(response.status() == OK, s"\nDid not get response with 200 OK status.\n$response\n")
     assert(response.body().nonEmpty, s"\nResponse body is absent.")
     assert(response.bodyAs(UTF_8) == "Test message body.", s"\nIncorrect response body.")
   }
 
   test("Emits onError when origin responds too slowly") {
+    val start = new AtomicLong()
     originOneServer.stub(urlStartingWith("/"), aResponse
       .withStatus(OK.code())
       .withFixedDelay(3000))
 
-    client.sendRequest(get("/foo/4").build()).subscribe(testSubscriber)
-    val duration = time {
-      testSubscriber.awaitTerminalEvent()
+    val maybeResponse = Try {
+      Mono.from(client.sendRequest(get("/foo/4").build()))
+        .doOnSubscribe((t: Subscription) => start.set(System.currentTimeMillis()))
+        .block()
     }
 
-    assert(testSubscriber.getOnErrorEvents.get(0).isInstanceOf[ResponseTimeoutException], "- Client emitted an incorrect exception!")
+    val duration = System.currentTimeMillis() - start.get()
+
+    assert(maybeResponse.failed.get.isInstanceOf[ResponseTimeoutException], "- Client emitted an incorrect exception!")
     println("responseTimeout: " + duration)
-    duration shouldBe responseTimeout +- 250
+    duration shouldBe duration +- 250
   }
 
   def time[A](codeBlock: => A) = {
@@ -128,12 +145,11 @@ class BackendServiceClientSpec extends FunSuite with BeforeAndAfterAll with Matc
     ((System.nanoTime - s) / 1e6).asInstanceOf[Int]
   }
 
-  private def response200OkWithContentLengthHeader(content: String): ResponseDefinitionBuilder = {
-    return aResponse
+  private def response200OkWithContentLengthHeader(content: String): ResponseDefinitionBuilder = aResponse
       .withStatus(OK.code())
       .withHeader(CONTENT_LENGTH, content.length.toString)
       .withBody(content)
-  }
+
 
   def response200OkFollowedFollowedByServerConnectionClose(content: String): (ChannelHandlerContext, Any) => Any = {
     (ctx: ChannelHandlerContext, msg: scala.Any) => {

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/RetryHandlingSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/RetryHandlingSpec.scala
@@ -120,7 +120,6 @@ class RetryHandlingSpec extends FunSuite with BeforeAndAfterAll with Matchers wi
     activeOrigins,
     new RoundRobinStrategy(activeOrigins, activeOrigins.snapshot()))
 
-  // TODO: fix them
   test("retries the next available origin on failure") {
     val backendService = new BackendService.Builder()
       .origins(unhealthyOriginOne, unhealthyOriginTwo, unhealthyOriginThree, healthyOriginTwo)

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/RetryHandlingSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/RetryHandlingSpec.scala
@@ -22,19 +22,18 @@ import java.util.concurrent.atomic.AtomicInteger
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH
+import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.LiveHttpRequest
 import com.hotels.styx.api.LiveHttpRequest.get
-import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.extension.Origin._
 import com.hotels.styx.api.extension.service.{BackendService, StickySessionConfig}
 import com.hotels.styx.api.extension.{ActiveOrigins, Origin}
 import com.hotels.styx.client.OriginsInventory.newOriginsInventoryBuilder
-import StyxBackendServiceClient.newHttpClientBuilder
+import com.hotels.styx.client.StyxBackendServiceClient.newHttpClientBuilder
 import com.hotels.styx.client.loadbalancing.strategies.RoundRobinStrategy
 import com.hotels.styx.client.retry.RetryNTimes
 import com.hotels.styx.client.stickysession.StickySessionLoadBalancingStrategy
 import com.hotels.styx.common.FreePorts.freePort
-import com.hotels.styx.support.api.BlockingObservables.waitForResponse
 import com.hotels.styx.support.server.FakeHttpServer
 import com.hotels.styx.support.server.UrlMatchingStrategies._
 import io.netty.channel.ChannelHandlerContext
@@ -42,6 +41,7 @@ import io.netty.handler.codec.http.HttpHeaders.Names._
 import io.netty.handler.codec.http.HttpHeaders.Values._
 import io.netty.handler.codec.http.LastHttpContent
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
+import reactor.core.publisher.Mono
 
 class RetryHandlingSpec extends FunSuite with BeforeAndAfterAll with Matchers with OriginSupport {
 
@@ -120,6 +120,7 @@ class RetryHandlingSpec extends FunSuite with BeforeAndAfterAll with Matchers wi
     activeOrigins,
     new RoundRobinStrategy(activeOrigins, activeOrigins.snapshot()))
 
+  // TODO: fix them
   test("retries the next available origin on failure") {
     val backendService = new BackendService.Builder()
       .origins(unhealthyOriginOne, unhealthyOriginTwo, unhealthyOriginThree, healthyOriginTwo)
@@ -130,7 +131,7 @@ class RetryHandlingSpec extends FunSuite with BeforeAndAfterAll with Matchers wi
       .loadBalancer(stickySessionStrategy(activeOrigins(backendService)))
       .build
 
-    val response = waitForResponse(client.sendRequest(get("/version.txt").build))
+    val response = Mono.from(client.sendRequest(get("/version.txt").build)).block()
     response.status() should be (OK)
   }
 
@@ -161,7 +162,7 @@ class RetryHandlingSpec extends FunSuite with BeforeAndAfterAll with Matchers wi
 
     val request: LiveHttpRequest = get("/version.txt").build
 
-    val response = waitForResponse(client.sendRequest(request))
+    val response = Mono.from(client.sendRequest(request)).block()
 
     val cookie = response.cookie("styx_origin_generic-app").get()
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/SimpleConnectionPoolStressTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/SimpleConnectionPoolStressTest.java
@@ -22,10 +22,10 @@ import com.hotels.styx.client.Connection;
 import com.hotels.styx.client.connectionpool.stubs.StubConnectionFactory;
 import com.hotels.styx.support.MultithreadedStressTester;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import java.util.Random;
 
-import static com.hotels.styx.support.api.BlockingObservables.getFirst;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -71,7 +71,7 @@ public class SimpleConnectionPoolStressTest {
     }
 
     private Connection borrowConnectionSynchronously() {
-        return getFirst(pool.borrowConnection());
+        return Mono.from(pool.borrowConnection()).block();
     }
 
 }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/StubConnectionPool.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/StubConnectionPool.java
@@ -16,16 +16,16 @@
 package com.hotels.styx.client.netty.connectionpool;
 
 import com.google.common.base.Objects;
+import com.hotels.styx.api.extension.Origin;
+import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
 import com.hotels.styx.client.Connection;
 import com.hotels.styx.client.connectionpool.ConnectionPool;
-import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
-import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.client.connectionpool.stubs.StubConnectionFactory;
-import rx.Observable;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
 
 import static com.google.common.base.Objects.toStringHelper;
 import static com.hotels.styx.api.extension.service.ConnectionPoolSettings.defaultConnectionPoolSettings;
-import static rx.Observable.just;
 
 public class StubConnectionPool implements ConnectionPool, Comparable<ConnectionPool> {
     private Connection connection;
@@ -48,11 +48,6 @@ public class StubConnectionPool implements ConnectionPool, Comparable<Connection
         this.settings = defaultConnectionPoolSettings();
     }
 
-    public StubConnectionPool(Origin origin_one, ConnectionPoolSettings settings) {
-        this.origin = origin_one;
-        this.settings = settings;
-    }
-
     @Override
     public int compareTo(ConnectionPool other) {
         return this.connection.getOrigin().hostAndPortString().compareTo(other.getOrigin().hostAndPortString());
@@ -64,8 +59,8 @@ public class StubConnectionPool implements ConnectionPool, Comparable<Connection
     }
 
     @Override
-    public Observable<Connection> borrowConnection() {
-        return just(connection);
+    public Publisher<Connection> borrowConnection() {
+        return Flux.just(connection);
     }
 
     @Override

--- a/components/common/src/test/java/com/hotels/styx/api/ResponseEventListenerTest.java
+++ b/components/common/src/test/java/com/hotels/styx/api/ResponseEventListenerTest.java
@@ -15,24 +15,20 @@
  */
 package com.hotels.styx.api;
 
+import org.reactivestreams.Publisher;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import reactor.core.publisher.EmitterProcessor;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-import reactor.test.publisher.TestPublisher;
-import rx.Observable;
-import rx.observers.TestSubscriber;
-import rx.subjects.PublishSubject;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.hotels.styx.api.LiveHttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static com.hotels.styx.api.LiveHttpResponse.response;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -53,59 +49,36 @@ public class ResponseEventListenerTest {
 
     @Test
     public void doesntFireUnnecessaryEvents() {
-        Observable<LiveHttpResponse> publisher = Observable.just(response(OK).body(new ByteStream(Flux.just(new Buffer("hey", UTF_8)))).build());
-        TestSubscriber<LiveHttpResponse> subscriber = TestSubscriber.create();
+        Mono<LiveHttpResponse> publisher = Mono.just(response(OK).body(new ByteStream(Flux.just(new Buffer("hey", UTF_8)))).build());
 
-        Observable<LiveHttpResponse> response = ResponseEventListener.from(publisher)
+        Flux<LiveHttpResponse> listener = ResponseEventListener.from(publisher)
                 .whenCancelled(() -> cancelled.set(true))
                 .whenResponseError(cause -> responseError.set(cause))
                 .whenContentError(cause -> contentError.set(cause))
                 .whenCompleted(() -> completed.set(true))
                 .apply();
 
-        response.subscribe(subscriber);
-
-        subscriber.getOnNextEvents().get(0).consume();
-
-        assertFalse(cancelled.get());
-        assertNull(responseError.get());
-        assertNull(contentError.get());
-        assertTrue(completed.get());
+        StepVerifier.create(listener)
+                .consumeNextWith(LiveHttpMessage::consume)
+                .then(() -> {
+                    assertFalse(cancelled.get());
+                    assertNull(responseError.get());
+                    assertNull(contentError.get());
+                    assertTrue(completed.get());
+                })
+                .verifyComplete();
     }
 
     @Test
     public void firesWhenResponseIsCancelledBeforeHeaders() {
-        PublishSubject<LiveHttpResponse> publisher = PublishSubject.create();
-        TestSubscriber<LiveHttpResponse> subscriber = TestSubscriber.create(0);
+        EmitterProcessor<LiveHttpResponse> publisher = EmitterProcessor.create();
 
-        Observable<LiveHttpResponse> response = ResponseEventListener.from(publisher)
+        Flux<LiveHttpResponse> listener = ResponseEventListener.from(publisher)
                 .whenCancelled(() -> cancelled.set(true))
                 .apply();
 
-        response.subscribe(subscriber);
-
-        subscriber.unsubscribe();
-
-        assertTrue(cancelled.get());
-    }
-
-    @Test
-    public void firesWhenContentCancelled() {
-        TestPublisher<Buffer> contentPublisher = TestPublisher.create();
-
-        LiveHttpResponse response = ResponseEventListener.from(
-                Observable.just(response(OK)
-                        .body(new ByteStream(contentPublisher))
-                        .build()))
-                .whenCancelled(() -> cancelled.set(true))
-                .apply()
-                .toBlocking()
-                .first();
-
-        assertThat(cancelled.get(), is(false));
-
-        StepVerifier.create(response.body())
-                .then(() -> assertThat(cancelled.get(), is(false)))
+        StepVerifier.create(listener)
+                .expectNextCount(0)
                 .thenCancel()
                 .verify();
 
@@ -113,37 +86,59 @@ public class ResponseEventListenerTest {
     }
 
     @Test
-    public void firesOnResponseError() {
-        Observable<LiveHttpResponse> publisher = Observable.error(new RuntimeException());
-        TestSubscriber<LiveHttpResponse> subscriber = TestSubscriber.create();
+    public void firesWhenContentCancelled() {
+        EmitterProcessor<Buffer> contentPublisher = EmitterProcessor.create();
 
-        Observable<LiveHttpResponse> response = ResponseEventListener.from(publisher)
+        Flux<LiveHttpResponse> listener = ResponseEventListener.from(
+                Flux.just(response(OK)
+                        .body(new ByteStream(contentPublisher))
+                        .build()))
+                .whenCancelled(() -> cancelled.set(true))
+                .apply();
+
+        StepVerifier.create(listener)
+                .consumeNextWith(response ->
+                        StepVerifier.create(response.body())
+                                .then(() -> assertFalse(cancelled.get()))
+                                .thenCancel()
+                                .verify())
+                .verifyComplete();
+
+        assertTrue(cancelled.get());
+    }
+
+    @Test
+    public void firesOnResponseError() {
+        Mono<LiveHttpResponse> publisher = Mono.error(new RuntimeException());
+
+        Flux<LiveHttpResponse> listener = ResponseEventListener.from(publisher)
                 .whenResponseError(cause -> responseError.set(cause))
                 .apply();
 
-        response.subscribe(subscriber);
+        StepVerifier.create(listener)
+                .expectError(RuntimeException.class)
+                .verify();
 
         assertTrue(responseError.get() instanceof RuntimeException);
     }
 
     @Test
     public void ignoresResponseErrorAfterHeaders() {
-        TestSubscriber<LiveHttpResponse> subscriber = TestSubscriber.create();
-        Observable<LiveHttpResponse> publisher = Observable.just(
+        Flux<LiveHttpResponse> publisher = Flux.just(
                 response(OK)
                         .body(new ByteStream(Flux.just(new Buffer("hey", UTF_8))))
                         .build())
-                .concatWith(Observable.error(new RuntimeException()));
+                .concatWith(Flux.error(new RuntimeException()));
 
-        Observable<LiveHttpResponse> response = ResponseEventListener.from(publisher)
+        Publisher<LiveHttpResponse> listener = ResponseEventListener.from(publisher)
                 .whenCancelled(() -> cancelled.set(true))
                 .whenResponseError(cause -> responseError.set(cause))
                 .whenContentError(cause -> contentError.set(cause))
                 .apply();
 
-        response.subscribe(subscriber);
-
-        subscriber.getOnNextEvents().get(0).consume();
+        StepVerifier.create(listener)
+                .consumeNextWith(LiveHttpMessage::consume)
+                .verifyError();
 
         assertFalse(cancelled.get());
         assertNull(responseError.get());
@@ -152,35 +147,33 @@ public class ResponseEventListenerTest {
 
     @Test
     public void firesResponseContentError() {
-        Observable<LiveHttpResponse> publisher = Observable.just(
+        Mono<LiveHttpResponse> publisher = Mono.just(
                 response(OK)
                         .body(new ByteStream(Flux.error(new RuntimeException())))
                         .build());
 
-        LiveHttpResponse response = ResponseEventListener.from(publisher)
+        Publisher<LiveHttpResponse> listener = ResponseEventListener.from(publisher)
                 .whenContentError(cause -> responseError.set(cause))
-                .apply()
-                .toBlocking()
-                .first();
+                .apply();
 
-        response.consume();
+        StepVerifier.create(listener)
+                .consumeNextWith(LiveHttpMessage::consume)
+                .verifyComplete();
 
         assertTrue(responseError.get() instanceof RuntimeException);
     }
 
     @Test
     public void firesErrorWhenResponseCompletesWithoutHeaders() {
-        TestSubscriber<LiveHttpResponse> testSubscriber = new TestSubscriber<>();
-        Observable<LiveHttpResponse> publisher = Observable.empty();
 
-        ResponseEventListener.from(publisher)
+        Publisher<LiveHttpResponse> listener = ResponseEventListener.from(Mono.empty())
                 .whenResponseError(cause -> responseError.set(cause))
-                .apply()
-                .toBlocking()
-                .subscribe(testSubscriber);
+                .apply();
 
-        testSubscriber.awaitTerminalEvent();
-        assertEquals(testSubscriber.getOnCompletedEvents().size(), 1);
+        StepVerifier.create(listener)
+                .expectNextCount(0)
+                .verifyComplete();
+
         assertTrue(responseError.get() instanceof RuntimeException);
     }
 }

--- a/components/common/src/test/java/com/hotels/styx/api/ResponseEventListenerTest.java
+++ b/components/common/src/test/java/com/hotels/styx/api/ResponseEventListenerTest.java
@@ -48,7 +48,7 @@ public class ResponseEventListenerTest {
     }
 
     @Test
-    public void doesntFireUnnecessaryEvents() {
+    public void doesntFireEventsThatNeverOccurred() {
         Mono<LiveHttpResponse> publisher = Mono.just(response(OK).body(new ByteStream(Flux.just(new Buffer("hey", UTF_8)))).build());
 
         Flux<LiveHttpResponse> listener = ResponseEventListener.from(publisher)

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/BackendServicesRouter.java
@@ -57,7 +57,6 @@ import static java.util.Comparator.naturalOrder;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.slf4j.LoggerFactory.getLogger;
-import static rx.RxReactiveStreams.toPublisher;
 
 /**
  * A {@link HttpHandler} implementation.
@@ -208,7 +207,7 @@ public class BackendServicesRouter implements HttpRouter, Registry.ChangeListene
 
     private HttpHandler newClientHandler(BackendService backendService, OriginsInventory originsInventory, OriginStatsFactory originStatsFactory) {
         BackendServiceClient client = clientFactory.createClient(backendService, originsInventory, originStatsFactory);
-        return (request, context) -> new Eventual<>(toPublisher(client.sendRequest(request)));
+        return (request, context) -> new Eventual<>(client.sendRequest(request));
     }
 
     private static OriginHealthCheckFunction originHealthCheckFunction(

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
@@ -44,7 +44,6 @@ import static com.hotels.styx.client.HttpRequestOperationFactory.Builder.httpReq
 import static com.hotels.styx.routing.config.RoutingSupport.append;
 import static com.hotels.styx.routing.config.RoutingSupport.missingAttributeError;
 import static java.lang.String.join;
-import static rx.RxReactiveStreams.toPublisher;
 
 /**
  * Routing object that proxies a request to a configured backend.
@@ -58,7 +57,7 @@ public class ProxyToBackend implements HttpHandler {
 
     @Override
     public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
-        return new Eventual<>(toPublisher(client.sendRequest(request)));
+        return new Eventual<>(client.sendRequest(request));
     }
 
     /**

--- a/components/proxy/src/test/java/com/hotels/styx/admin/tasks/StubConnectionPool.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/tasks/StubConnectionPool.java
@@ -15,11 +15,11 @@
  */
 package com.hotels.styx.admin.tasks;
 
-import com.hotels.styx.client.Connection;
-import com.hotels.styx.client.connectionpool.ConnectionPool;
 import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
-import rx.Observable;
+import com.hotels.styx.client.Connection;
+import com.hotels.styx.client.connectionpool.ConnectionPool;
+import org.reactivestreams.Publisher;
 
 /**
  * Stub implementation of a ConnectionPool.
@@ -37,7 +37,7 @@ public class StubConnectionPool implements ConnectionPool {
     }
 
     @Override
-    public Observable<Connection> borrowConnection() {
+    public Publisher<Connection> borrowConnection() {
         return null;
     }
 

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/BackendServicesRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/BackendServicesRouterTest.java
@@ -16,28 +16,29 @@
 package com.hotels.styx.proxy;
 
 import com.hotels.styx.Environment;
-import com.hotels.styx.client.BackendServiceClient;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
+import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
-import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.api.extension.service.BackendService;
 import com.hotels.styx.api.extension.service.spi.Registry;
+import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
+import com.hotels.styx.client.BackendServiceClient;
 import com.hotels.styx.client.OriginStatsFactory;
 import com.hotels.styx.client.OriginsInventory;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import rx.Observable;
+import reactor.core.publisher.Flux;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
+import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpResponse.response;
 import static com.hotels.styx.api.extension.Origin.newOriginBuilder;
-import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.extension.service.BackendService.newBackendServiceBuilder;
 import static com.hotels.styx.client.StyxHeaderConfig.ORIGIN_ID_DEFAULT;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
@@ -51,8 +52,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static rx.Observable.just;
-import com.hotels.styx.api.LiveHttpRequest;
 
 public class BackendServicesRouterTest {
     private static final String APP_A = "appA";
@@ -345,8 +344,8 @@ public class BackendServicesRouterTest {
                 .build();
     }
 
-    private static Observable<LiveHttpResponse> responseWithOriginIdHeader(BackendService backendService) {
-        return just(response(OK)
+    private static Flux<LiveHttpResponse> responseWithOriginIdHeader(BackendService backendService) {
+        return Flux.just(response(OK)
                 .header(ORIGIN_ID_DEFAULT, backendService.id())
                 .build());
     }

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/StyxBackendServiceClientFactoryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/StyxBackendServiceClientFactoryTest.java
@@ -34,6 +34,7 @@ import com.hotels.styx.client.StyxBackendServiceClient;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpResponse.response;
@@ -128,9 +129,9 @@ public class StyxBackendServiceClientFactoryTest {
         LiveHttpRequest requestx = get("/some-req").cookies(requestCookie(STICKY_COOKIE, id("x").toString())).build();
         LiveHttpRequest requesty = get("/some-req").cookies(requestCookie(STICKY_COOKIE, id("y").toString())).build();
 
-        LiveHttpResponse responsez = styxBackendServiceClient.sendRequest(requestz).toBlocking().first();
-        LiveHttpResponse responsex = styxBackendServiceClient.sendRequest(requestx).toBlocking().first();
-        LiveHttpResponse responsey = styxBackendServiceClient.sendRequest(requesty).toBlocking().first();
+        LiveHttpResponse responsez = Mono.from(styxBackendServiceClient.sendRequest(requestz)).block();
+        LiveHttpResponse responsex = Mono.from(styxBackendServiceClient.sendRequest(requestx)).block();
+        LiveHttpResponse responsey = Mono.from(styxBackendServiceClient.sendRequest(requesty)).block();
 
         assertThat(responsex.header("X-Origin-Id").get(), is("x"));
         assertThat(responsey.header("X-Origin-Id").get(), is("y"));
@@ -173,9 +174,9 @@ public class StyxBackendServiceClientFactoryTest {
         LiveHttpRequest requestx = get("/some-req").cookies(requestCookie(ORIGINS_RESTRICTION_COOKIE, id("x").toString())).build();
         LiveHttpRequest requesty = get("/some-req").cookies(requestCookie(ORIGINS_RESTRICTION_COOKIE, id("y").toString())).build();
 
-        LiveHttpResponse responsez = styxBackendServiceClient.sendRequest(requestz).toBlocking().first();
-        LiveHttpResponse responsex = styxBackendServiceClient.sendRequest(requestx).toBlocking().first();
-        LiveHttpResponse responsey = styxBackendServiceClient.sendRequest(requesty).toBlocking().first();
+        LiveHttpResponse responsez = Mono.from(styxBackendServiceClient.sendRequest(requestz)).block();
+        LiveHttpResponse responsex = Mono.from(styxBackendServiceClient.sendRequest(requestx)).block();
+        LiveHttpResponse responsey = Mono.from(styxBackendServiceClient.sendRequest(requesty)).block();
 
         assertThat(responsex.header("X-Origin-Id").get(), is("x"));
         assertThat(responsey.header("X-Origin-Id").get(), is("y"));

--- a/components/proxy/src/test/java/com/hotels/styx/routing/StaticPipelineBuilderTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/routing/StaticPipelineBuilderTest.java
@@ -28,6 +28,7 @@ import com.hotels.styx.proxy.plugin.NamedPlugin;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -42,8 +43,6 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
-import static rx.Observable.just;
-
 
 public class StaticPipelineBuilderTest {
 
@@ -55,7 +54,7 @@ public class StaticPipelineBuilderTest {
     @BeforeMethod
     public void staticPipelineBuilderTest() {
         environment = new Environment.Builder().build();
-        clientFactory = (backendService, originsInventory, originStatsFactory) -> request -> just(response(OK).build());
+        clientFactory = (backendService, originsInventory, originStatsFactory) -> request -> Mono.just(response(OK).build());
         registry = backendRegistry(newBackendServiceBuilder().origins(newOriginBuilder("localhost", 0).build())
                 .path("/foo").build());
     }

--- a/components/proxy/src/test/scala/com/hotels/styx/routing/ScalaStyxPlugin.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/routing/ScalaStyxPlugin.scala
@@ -18,10 +18,7 @@ package com.hotels.styx.routing
 import com.hotels.styx.api.HttpInterceptor.Context
 import com.hotels.styx.api._
 import com.hotels.styx.api.plugins.spi.Plugin
-import com.hotels.styx.client.BackendServiceClient
-import com.hotels.styx.routing.ImplicitScalaRxConversions.toJavaObservable
 import rx.lang.scala.Observable
-import rx.{Observable => JavaObservable}
 
 private class ChainAdapter(javaChain: HttpInterceptor.Chain) {
   def proceed(request: LiveHttpRequest): Eventual[LiveHttpResponse] = javaChain.proceed(request)
@@ -44,10 +41,6 @@ class PluginAdapter(scalaInterceptor: (LiveHttpRequest, ChainAdapter) => Eventua
     scalaInterceptor(request, new ChainAdapter(chain))
 }
 
-class HttpClientAdapter(sendRequest: LiveHttpRequest => Observable[LiveHttpResponse]) extends BackendServiceClient {
-  override def sendRequest(request: LiveHttpRequest): JavaObservable[LiveHttpResponse] =
-    toJavaObservable(sendRequest(request))
-}
 
 class HttpHandlerAdapter(handler: (LiveHttpRequest, Context) => Eventual[LiveHttpResponse]) extends HttpHandler {
   override def handle(request: LiveHttpRequest, context: Context): Eventual[LiveHttpResponse] = handler(request, context)

--- a/components/server/src/main/java/com/hotels/styx/server/routing/routes/ProxyToBackendRoute.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/routes/ProxyToBackendRoute.java
@@ -23,7 +23,6 @@ import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.client.BackendServiceClient;
 
 import static java.util.Objects.requireNonNull;
-import static rx.RxReactiveStreams.toPublisher;
 
 /**
  * A HTTP router route which proxies to Styx backend application.
@@ -41,6 +40,6 @@ public final class ProxyToBackendRoute implements HttpHandler {
 
     @Override
     public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
-        return new Eventual<>(toPublisher(client.sendRequest(request)));
+        return new Eventual<>(client.sendRequest(request));
     }
 }

--- a/components/server/src/test/java/com/hotels/styx/server/routing/routes/ProxyToBackendRouteTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/routing/routes/ProxyToBackendRouteTest.java
@@ -15,27 +15,27 @@
  */
 package com.hotels.styx.server.routing.routes;
 
-import com.hotels.styx.client.BackendServiceClient;
+import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.client.BackendServiceClient;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.Test;
-import rx.Observable;
+import reactor.core.publisher.Flux;
 
+import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpResponse.response;
-import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import com.hotels.styx.api.LiveHttpRequest;
 
 public class ProxyToBackendRouteTest {
     @Test
     public void proxiesUsingClient() throws Exception {
         BackendServiceClient client = mock(BackendServiceClient.class);
-        when(client.sendRequest(any(LiveHttpRequest.class))).thenReturn(Observable.just(response(OK).build()));
+        when(client.sendRequest(any(LiveHttpRequest.class))).thenReturn(Flux.just(response(OK).build()));
 
         ProxyToBackendRoute proxy = ProxyToBackendRoute.proxyToBackend(client);
 

--- a/support/api-testsupport/src/main/java/com/hotels/styx/support/api/BlockingObservables.java
+++ b/support/api-testsupport/src/main/java/com/hotels/styx/support/api/BlockingObservables.java
@@ -26,6 +26,9 @@ import java.util.concurrent.ExecutionException;
 import static java.lang.Thread.currentThread;
 import static rx.RxReactiveStreams.toObservable;
 
+
+// TODO: This class needs to be removed once we have migrated over to Reactor/Flux.
+
 public final class BlockingObservables {
 
     public static <T> T getFirst(Observable<T> observable) {
@@ -59,12 +62,6 @@ public final class BlockingObservables {
                 .flatMap(response -> toObservable(response.aggregate(120*1024)))
                 .toBlocking()
                 .single();
-    }
-
-    public static LiveHttpResponse waitForStreamingResponse(Observable<LiveHttpResponse> responseObs) {
-        return responseObs
-                .toBlocking()
-                .first();
     }
 
     private BlockingObservables() {

--- a/system-tests/e2e-suite/pom.xml
+++ b/system-tests/e2e-suite/pom.xml
@@ -122,6 +122,11 @@
       <artifactId>scalatest_${scala.version}</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
Migrate `ConnectionPool` interface and its consumers from Rx.Java to Reactor/Flux. 
Also migrate `BackendServiceClient` and `ResponseEventListener` classes to Reactor/Flux.
