### PR TITLE
Deprecate Rx.Java from Connection.Factory.

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/Connection.java
+++ b/components/client/src/main/java/com/hotels/styx/client/Connection.java
@@ -18,6 +18,7 @@ package com.hotels.styx.client;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.extension.Origin;
+import reactor.core.publisher.Mono;
 import rx.Observable;
 
 import java.io.Closeable;
@@ -39,7 +40,7 @@ public interface Connection extends Closeable {
          * @param connectionSettings connection pool configuration
          * @return the newly created connection
          */
-        Observable<Connection> createConnection(Origin origin, ConnectionSettings connectionSettings);
+        Mono<Connection> createConnection(Origin origin, ConnectionSettings connectionSettings);
     }
 
     /**

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/ExpiringConnectionFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/ExpiringConnectionFactory.java
@@ -16,10 +16,10 @@
 package com.hotels.styx.client.connectionpool;
 
 import com.google.common.base.Ticker;
+import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.client.Connection;
 import com.hotels.styx.client.ConnectionSettings;
-import com.hotels.styx.api.extension.Origin;
-import rx.Observable;
+import reactor.core.publisher.Mono;
 
 import java.util.function.Supplier;
 
@@ -41,7 +41,7 @@ public class ExpiringConnectionFactory implements Connection.Factory {
     }
 
     @Override
-    public Observable<Connection> createConnection(Origin origin, ConnectionSettings connectionSettings) {
+    public Mono<Connection> createConnection(Origin origin, ConnectionSettings connectionSettings) {
         return connectionFactory
                 .createConnection(origin, connectionSettings)
                 .map(this::decorate);

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
@@ -25,7 +25,6 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
-import rx.Observable;
 
 import java.time.Duration;
 import java.util.Queue;
@@ -108,13 +107,13 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
                 );
     }
 
-    private Observable<Connection> newConnection(int attempts) {
+    private Mono<Connection> newConnection(int attempts) {
         if (attempts > 0) {
             return this.connectionFactory.createConnection(this.origin, this.connectionSettings)
-                    .onErrorResumeNext(cause -> newConnection(attempts - 1))
+                    .onErrorResume(cause -> newConnection(attempts - 1))
                     .doOnNext(it -> it.addConnectionListener(SimpleConnectionPool.this));
         } else {
-            return Observable.error(new RuntimeException("Unable to create connection"));
+            return Mono.error(new RuntimeException("Unable to create connection"));
         }
     }
 

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/stubs/StubConnectionFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/stubs/StubConnectionFactory.java
@@ -16,11 +16,12 @@
 package com.hotels.styx.client.connectionpool.stubs;
 
 import com.hotels.styx.api.LiveHttpRequest;
-import com.hotels.styx.api.extension.Announcer;
 import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.api.extension.Announcer;
+import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.client.Connection;
 import com.hotels.styx.client.ConnectionSettings;
-import com.hotels.styx.api.extension.Origin;
+import reactor.core.publisher.Mono;
 import rx.Observable;
 
 import static com.google.common.base.Objects.toStringHelper;
@@ -30,10 +31,9 @@ import static com.google.common.base.Objects.toStringHelper;
  */
 public class StubConnectionFactory implements Connection.Factory {
     @Override
-    public Observable<Connection> createConnection(Origin origin, ConnectionSettings connectionPoolConfiguration) {
-        return Observable.create(subscriber -> {
-            subscriber.onNext(new StubConnection(origin));
-            subscriber.onCompleted();
+    public Mono<Connection> createConnection(Origin origin, ConnectionSettings connectionPoolConfiguration) {
+        return Mono.create(sink -> {
+            sink.success(new StubConnection(origin));
         });
     }
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxHttpClientTest.java
@@ -28,7 +28,7 @@ import org.mockito.ArgumentCaptor;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import rx.Observable;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.ExecutionException;
 
@@ -37,9 +37,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static com.hotels.styx.api.HttpRequest.get;
 import static com.hotels.styx.api.HttpHeaderNames.HOST;
 import static com.hotels.styx.api.HttpHeaderNames.USER_AGENT;
+import static com.hotels.styx.api.HttpRequest.get;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.common.StyxFutures.await;
 import static com.hotels.styx.support.server.UrlMatchingStrategies.urlStartingWith;
@@ -327,7 +327,7 @@ public class StyxHttpClientTest {
     private static NettyConnectionFactory mockConnectionFactory() {
         NettyConnectionFactory factory = mock(NettyConnectionFactory.class);
         when(factory.createConnection(any(Origin.class), any(ConnectionSettings.class), any(SslContext.class)))
-                .thenReturn(Observable.just(mock(Connection.class)));
+                .thenReturn(Mono.just(mock(Connection.class)));
         return factory;
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/StyxBackendServiceClientFactoryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/StyxBackendServiceClientFactoryTest.java
@@ -53,7 +53,6 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static rx.Observable.just;
 
 public class StyxBackendServiceClientFactoryTest {
     private Environment environment;
@@ -71,7 +70,7 @@ public class StyxBackendServiceClientFactoryTest {
                 .build();
 
         when(connectionFactory.createConnection(any(Origin.class), any(ConnectionSettings.class)))
-                .thenReturn(just(mock(Connection.class)));
+                .thenReturn(Mono.just(mock(Connection.class)));
     }
 
     @Test


### PR DESCRIPTION
Deprecates Rx.Java from Connection Factory in favour of Reactor Core.
