### PR TITLE
Remove 'asCompletableFuture' method from Styx Eventual.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/Eventual.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Eventual.java
@@ -19,7 +19,6 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Mono;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
@@ -112,15 +111,6 @@ public final class Eventual<T> implements Publisher<T> {
     public Eventual<T> onError(Function<Throwable, ? extends Eventual<? extends T>> errorHandler) {
         return fromMono(Mono.from(publisher)
                 .onErrorResume(value -> Mono.from(errorHandler.apply(value))));
-    }
-
-    /**
-     * Converts this object to a {@link CompletableFuture}.
-     *
-     * @return a completable future
-     */
-    public CompletableFuture<T> asCompletableFuture() {
-        return Mono.from(publisher).toFuture();
     }
 
     /**

--- a/components/api/src/test/java/com/hotels/styx/api/EventualTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/EventualTest.java
@@ -17,47 +17,26 @@ package com.hotels.styx.api;
 
 import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.testng.Assert.assertEquals;
 
 public class EventualTest {
 
     @Test
-    public void createFromPublisher() throws ExecutionException, InterruptedException {
-        String value = new Eventual<>(Flux.just("hello"))
-                .asCompletableFuture()
-                .get();
-
+    public void createFromPublisher() {
+        String value = Mono.from(new Eventual<>(Flux.just("hello"))).block();
         assertEquals(value, "hello");
     }
 
     @Test
-    public void publishesOnlyOneElement() throws ExecutionException, InterruptedException {
-        AtomicInteger i = new AtomicInteger();
-        String value = new Eventual<>(Flux.just("hello", "world"))
-                .map(x -> {
-                    i.incrementAndGet();
-                    return x;
-                })
-                .asCompletableFuture()
-                .get();
-
-        assertEquals(i.get(), 1);
-        assertEquals(value, "hello");
-    }
-
-    @Test
-    public void createFromValue() throws ExecutionException, InterruptedException {
-        String value = Eventual.of("x")
-                .asCompletableFuture()
-                .get();
-
-        assertEquals(value, "x");
+    public void createFromValue() {
+        StepVerifier.create(Eventual.of("x"))
+                .expectNext("x")
+                .verifyComplete();
     }
 
     @Test
@@ -84,13 +63,10 @@ public class EventualTest {
     }
 
     @Test
-    public void mapsValues() throws ExecutionException, InterruptedException {
-        String value = new Eventual<>(Flux.just("hello"))
-                .map(String::toUpperCase)
-                .asCompletableFuture()
-                .get();
-
-        assertEquals(value, "HELLO");
+    public void mapsValues() {
+        StepVerifier.create(new Eventual<>(Flux.just("hello")).map(String::toUpperCase))
+                .expectNext("HELLO")
+                .verifyComplete();
     }
 
     @Test

--- a/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
@@ -74,12 +74,9 @@ public class HttpRequestTest {
                 header("Cookie", "CookieName=CookieValue")));
         assertThat(streaming.cookies(), contains(requestCookie("CookieName", "CookieValue")));
 
-        String body = streaming.aggregate(0x10000)
-                .asCompletableFuture()
-                .get()
-                .bodyAs(UTF_8);
-
-        assertThat(body, is("foobar"));
+        StepVerifier.create(streaming.aggregate(0x10000).map(it -> it.bodyAs(UTF_8)))
+                .expectNext("foobar")
+                .verifyComplete();
     }
 
     @Test(dataProvider = "emptyBodyRequests")

--- a/components/api/src/test/java/com/hotels/styx/api/LiveHttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/LiveHttpRequestTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -63,9 +64,9 @@ public class LiveHttpRequestTest {
                 .cookies(requestCookie("CookieName", "CookieValue"))
                 .build();
 
-        HttpRequest full = streamingRequest.aggregate(0x1000)
-                .asCompletableFuture()
-                .get();
+
+
+        HttpRequest full = Mono.from(streamingRequest.aggregate(0x1000)).block();
 
         assertThat(full.method(), is(POST));
         assertThat(full.url(), is(url("/foo/bar").build()));
@@ -85,9 +86,7 @@ public class LiveHttpRequestTest {
                 .body(new ByteStream(Flux.just(content)))
                 .build();
 
-        HttpRequest fullRequest = original.aggregate(100)
-                .asCompletableFuture()
-                .get();
+        HttpRequest fullRequest = Mono.from(original.aggregate(100)).block();
 
         assertThat(content.delegate().refCnt(), is(0));
 
@@ -96,10 +95,7 @@ public class LiveHttpRequestTest {
 
     @Test(dataProvider = "emptyBodyRequests")
     public void encodesToStreamingHttpRequestWithEmptyBody(LiveHttpRequest streamingRequest) throws Exception {
-        HttpRequest full = streamingRequest.aggregate(0x1000)
-                .asCompletableFuture()
-                .get();
-
+        HttpRequest full = Mono.from(streamingRequest.aggregate(0x1000)).block();
         assertThat(full.body(), is(new byte[0]));
     }
 

--- a/components/api/src/test/java/com/hotels/styx/api/extension/service/spi/AbstractStyxServiceTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/extension/service/spi/AbstractStyxServiceTest.java
@@ -15,9 +15,12 @@
  */
 package com.hotels.styx.api.extension.service.spi;
 
+import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.LiveHttpRequest;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -41,11 +44,8 @@ public class AbstractStyxServiceTest {
     public void exposesNameAndStatusViaAdminInterface() throws ExecutionException, InterruptedException {
         DerivedStyxService service = new DerivedStyxService("derived-service", new CompletableFuture<>());
 
-        HttpResponse response =
-                service.adminInterfaceHandlers().get("status").handle(get, MOCK_CONTEXT)
-                        .flatMap(r -> r.aggregate(1024))
-                .asCompletableFuture()
-                .get();
+        HttpResponse response = Mono.from(service.adminInterfaceHandlers().get("status").handle(get, MOCK_CONTEXT)
+                        .flatMap(r -> r.aggregate(1024))).block();
 
         assertThat(response.bodyAs(UTF_8), is("{ name: \"derived-service\" status: \"CREATED\" }"));
     }

--- a/components/common/src/test/java/com/hotels/styx/common/http/handler/HttpMethodFilteringHandlerTest.java
+++ b/components/common/src/test/java/com/hotels/styx/common/http/handler/HttpMethodFilteringHandlerTest.java
@@ -21,11 +21,12 @@ import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
-import static com.hotels.styx.api.LiveHttpRequest.post;
 import static com.hotels.styx.api.HttpMethod.GET;
 import static com.hotels.styx.api.HttpMethod.POST;
 import static com.hotels.styx.api.HttpResponseStatus.METHOD_NOT_ALLOWED;
+import static com.hotels.styx.api.LiveHttpRequest.post;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
@@ -51,7 +52,7 @@ public class HttpMethodFilteringHandlerTest {
         HttpMethodFilteringHandler post = new HttpMethodFilteringHandler(GET, handler);
 
         LiveHttpRequest request = post("/some-uri").build();
-        LiveHttpResponse response = post.handle(request, HttpInterceptorContext.create()).asCompletableFuture().get();
+        LiveHttpResponse response = Mono.from(post.handle(request, HttpInterceptorContext.create())).block();
 
         assertThat(response.status(), is(METHOD_NOT_ALLOWED));
     }

--- a/components/common/src/test/java/com/hotels/styx/common/http/handler/StaticBodyHttpHandlerTest.java
+++ b/components/common/src/test/java/com/hotels/styx/common/http/handler/StaticBodyHttpHandlerTest.java
@@ -20,10 +20,11 @@ import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
-import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,13 +32,11 @@ import static org.hamcrest.Matchers.is;
 
 public class StaticBodyHttpHandlerTest {
     @Test
-    public void respondsWithStaticBody() throws Exception {
+    public void respondsWithStaticBody() {
         StaticBodyHttpHandler handler = new StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, "foo", UTF_8);
 
-        LiveHttpResponse response = handler.handle(get("/").build(), HttpInterceptorContext.create()).asCompletableFuture().get();
-        HttpResponse fullResponse = response.aggregate(1024)
-                .asCompletableFuture()
-                .get();
+        LiveHttpResponse response = Mono.from(handler.handle(get("/").build(), HttpInterceptorContext.create())).block();
+        HttpResponse fullResponse = Mono.from(response.aggregate(1024)).block();
 
         assertThat(fullResponse.status(), is(OK));
         assertThat(fullResponse.contentType(), isValue(PLAIN_TEXT_UTF_8.toString()));

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/IndexHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/IndexHandlerTest.java
@@ -18,11 +18,11 @@ package com.hotels.styx.admin.handlers;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import static com.hotels.styx.admin.handlers.IndexHandler.Link.link;
-import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
-import static com.hotels.styx.support.api.BlockingObservables.getFirst;
+import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.support.api.matchers.HttpResponseBodyMatcher.hasBody;
 import static com.hotels.styx.support.api.matchers.HttpStatusMatcher.hasStatus;
 import static java.util.Arrays.asList;
@@ -34,7 +34,7 @@ public class IndexHandlerTest {
 
     @Test
     public void printsTheRegisteredPaths() {
-        LiveHttpResponse response = getFirst(handler.handle(get("/admin").build(), HttpInterceptorContext.create()));
+        LiveHttpResponse response = Mono.from(handler.handle(get("/admin").build(), HttpInterceptorContext.create())).block();
         assertThat(response, hasStatus(OK));
         assertThat(response.contentType().get(), is("text/html; charset=utf-8"));
         assertThat(response, hasBody(

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/JVMMetricsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/JVMMetricsHandlerTest.java
@@ -16,8 +16,8 @@
 package com.hotels.styx.admin.handlers;
 
 import com.codahale.metrics.Gauge;
-import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.hamcrest.Description;
@@ -26,15 +26,15 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 
 import static com.google.common.collect.Iterables.all;
 import static com.hotels.styx.admin.handlers.JVMMetricsHandlerTest.StringsContains.containsStrings;
 import static com.hotels.styx.api.HttpHeaderValues.APPLICATION_JSON;
-import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
-import static com.hotels.styx.support.api.BlockingObservables.getFirst;
+import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.support.api.matchers.HttpResponseBodyMatcher.hasBody;
 import static com.hotels.styx.support.api.matchers.HttpResponseStatusMatcher.hasStatus;
 import static java.util.Arrays.asList;
@@ -90,7 +90,7 @@ public class JVMMetricsHandlerTest {
     }
 
     private LiveHttpResponse call(LiveHttpRequest request) {
-        return getFirst(handler.handle(request, HttpInterceptorContext.create()));
+        return Mono.from(handler.handle(request, HttpInterceptorContext.create())).block();
     }
 
     static class StringsContains extends TypeSafeMatcher<String> {

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/JsonHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/JsonHandlerTest.java
@@ -20,13 +20,13 @@ import com.hotels.styx.api.Clock;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.hotels.styx.api.LiveHttpRequest.get;
-import static com.hotels.styx.common.StyxFutures.await;
 import static java.lang.System.currentTimeMillis;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -106,11 +106,11 @@ public class JsonHandlerTest {
     }
 
     private String responseFor(JsonHandler<?> handler, LiveHttpRequest request) {
-        return await(
+        return Mono.from(
                 handler.handle(request, HttpInterceptorContext.create())
                         .flatMap(response -> response.aggregate(1000000))
                         .map(response -> response.bodyAs(UTF_8))
-                        .asCompletableFuture());
+        ).block();
     }
 
     private static class Convertible {

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ThreadsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ThreadsHandlerTest.java
@@ -17,20 +17,17 @@ package com.hotels.styx.admin.handlers;
 
 
 import com.hotels.styx.api.HttpResponse;
-import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.Test;
 
-import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
-import static com.hotels.styx.support.api.BlockingObservables.getFirst;
+import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.support.api.BlockingObservables.waitForResponse;
 import static com.hotels.styx.support.api.matchers.HttpHeadersMatcher.isNotCacheable;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.StringContains.containsString;
-import com.hotels.styx.api.LiveHttpRequest;
 
 public class ThreadsHandlerTest {
     final ThreadsHandler handler = new ThreadsHandler();
@@ -44,7 +41,4 @@ public class ThreadsHandlerTest {
         assertThat(response.bodyAs(UTF_8), containsString("Finalizer"));
     }
 
-    private LiveHttpResponse handle(LiveHttpRequest request) {
-        return getFirst(handler.handle(request, HttpInterceptorContext.create()));
-    }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/admin/tasks/OriginsCommandHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/tasks/OriginsCommandHandlerTest.java
@@ -32,6 +32,7 @@ import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import java.util.Set;
 
@@ -39,7 +40,6 @@ import static com.hotels.styx.api.HttpResponseStatus.BAD_REQUEST;
 import static com.hotels.styx.api.Id.id;
 import static com.hotels.styx.api.extension.Origin.newOriginBuilder;
 import static com.hotels.styx.api.extension.RemoteHost.remoteHost;
-import static com.hotels.styx.support.api.BlockingObservables.getFirst;
 import static com.hotels.styx.support.api.matchers.HttpResponseBodyMatcher.hasBody;
 import static com.hotels.styx.support.api.matchers.HttpResponseStatusMatcher.hasStatus;
 import static java.lang.String.format;
@@ -124,7 +124,7 @@ public class OriginsCommandHandlerTest {
 
     private LiveHttpResponse post(String path) {
         LiveHttpRequest request = LiveHttpRequest.post(path).build();
-        return getFirst(originsCommand.handle(request, HttpInterceptorContext.create()));
+        return Mono.from(originsCommand.handle(request, HttpInterceptorContext.create())).block();
     }
 
     static class RecordingOriginsCommandsListener implements OriginsCommandsListener {

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/BackendServicesRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/BackendServicesRouterTest.java
@@ -31,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -210,8 +211,8 @@ public class BackendServicesRouterTest {
         assertThat(proxyTo(route2, request).header(ORIGIN_ID_DEFAULT), isValue(APP_B));
     }
 
-    private LiveHttpResponse proxyTo(Optional<HttpHandler> pipeline, LiveHttpRequest request) throws ExecutionException, InterruptedException {
-        return pipeline.get().handle(request, context).asCompletableFuture().get();
+    private LiveHttpResponse proxyTo(Optional<HttpHandler> pipeline, LiveHttpRequest request) {
+        return Mono.from(pipeline.get().handle(request, context)).block();
     }
 
     @Test

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/InterceptorPipelineBuilderTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/InterceptorPipelineBuilderTest.java
@@ -22,23 +22,24 @@ import com.hotels.styx.StyxConfig;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
+import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
+import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpResponse.response;
 import static com.hotels.styx.proxy.plugin.NamedPlugin.namedPlugin;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
-import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import com.hotels.styx.api.LiveHttpRequest;
 
 public class InterceptorPipelineBuilderTest {
     private Environment environment;
@@ -72,7 +73,7 @@ public class InterceptorPipelineBuilderTest {
     @Test
     public void buildsPipelineWithInterceptors() throws Exception {
         HttpHandler pipeline = new InterceptorPipelineBuilder(environment, plugins, handler, false).build();
-        LiveHttpResponse response = pipeline.handle(get("/foo").build(), HttpInterceptorContext.create()).asCompletableFuture().get();
+        LiveHttpResponse response = Mono.from(pipeline.handle(get("/foo").build(), HttpInterceptorContext.create())).block();
 
         assertThat(response.header("plug1"), isValue("1"));
         assertThat(response.header("plug2"), isValue("1"));

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/RouteHandlerAdapterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/RouteHandlerAdapterTest.java
@@ -18,17 +18,18 @@ package com.hotels.styx.proxy;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
-import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.server.HttpInterceptorContext;
 import com.hotels.styx.server.HttpRouter;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 
+import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpResponse.response;
-import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
@@ -41,14 +42,14 @@ public class RouteHandlerAdapterTest {
     private LiveHttpResponse respOk = response(OK).build();
 
     @Test
-    public void injectsToPipelineWhenRouteFound() throws Exception {
+    public void injectsToPipelineWhenRouteFound() {
         HttpHandler pipeline = mock(HttpHandler.class);
         when(pipeline.handle(any(LiveHttpRequest.class), any(HttpInterceptor.Context.class))).thenReturn(Eventual.of(respOk));
 
         HttpRouter router = mock(HttpRouter.class);
         when(router.route(any(LiveHttpRequest.class), any(HttpInterceptor.Context.class))).thenReturn(Optional.of(pipeline));
 
-        LiveHttpResponse response = new RouteHandlerAdapter(router).handle(request, HttpInterceptorContext.create()).asCompletableFuture().get();
+        LiveHttpResponse response = Mono.from(new RouteHandlerAdapter(router).handle(request, HttpInterceptorContext.create())).block();
 
         assertThat(response.status(), is(OK));
     }

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ConfigurationContextResolverInterceptorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ConfigurationContextResolverInterceptorTest.java
@@ -24,11 +24,11 @@ import com.hotels.styx.api.configuration.Configuration;
 import com.hotels.styx.api.configuration.ConfigurationContextResolver;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
+import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpResponse.response;
-import static com.hotels.styx.api.HttpResponseStatus.OK;
-import static com.hotels.styx.common.StyxFutures.await;
 import static com.hotels.styx.support.api.matchers.HttpStatusMatcher.hasStatus;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -49,7 +49,7 @@ public class ConfigurationContextResolverInterceptorTest {
 
         Eventual<LiveHttpResponse> responseObservable = interceptor.intercept(request, chain);
 
-        assertThat(await(responseObservable.asCompletableFuture()), hasStatus(OK));
+        assertThat(Mono.from(responseObservable).block(), hasStatus(OK));
         assertThat(chain.proceedWasCalled, is(true));
         assertThat(chain.context.get("config.context", Configuration.Context.class), is(context));
     }

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/HopByHopHeadersRemovingInterceptorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/HopByHopHeadersRemovingInterceptorTest.java
@@ -16,16 +16,16 @@
 package com.hotels.styx.proxy.interceptors;
 
 import com.hotels.styx.api.HttpInterceptor.Chain;
-import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.api.LiveHttpResponse;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import static com.hotels.styx.api.HttpHeaderNames.CONNECTION;
 import static com.hotels.styx.api.LiveHttpRequest.delete;
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpRequest.post;
 import static com.hotels.styx.api.LiveHttpResponse.response;
-import static com.hotels.styx.common.StyxFutures.await;
 import static com.hotels.styx.proxy.interceptors.RequestRecordingChain.requestRecordingChain;
 import static com.hotels.styx.proxy.interceptors.ReturnResponseChain.returnsResponse;
 import static com.hotels.styx.support.matchers.IsOptional.isAbsent;
@@ -61,12 +61,11 @@ public class HopByHopHeadersRemovingInterceptorTest {
 
     @Test
     public void removesHopByHopHeadersFromResponse() throws Exception {
-        LiveHttpResponse response = await(interceptor.intercept(get("/foo").build(), returnsResponse(response()
+        LiveHttpResponse response = Mono.from(interceptor.intercept(get("/foo").build(), returnsResponse(response()
                 .header(TE, "foo")
                 .header(PROXY_AUTHENTICATE, "foo")
                 .header(PROXY_AUTHORIZATION, "bar")
-                .build())
-        ).asCompletableFuture());
+                .build()))).block();
 
         assertThat(response.header(TE), isAbsent());
         assertThat(response.header(PROXY_AUTHENTICATE), isAbsent());
@@ -118,13 +117,12 @@ public class HopByHopHeadersRemovingInterceptorTest {
 
     @Test
     public void removesConnectionHeadersFromResponse() throws Exception {
-        LiveHttpResponse response = await(interceptor.intercept(get("/foo").build(), returnsResponse(response()
+        LiveHttpResponse response = Mono.from(interceptor.intercept(get("/foo").build(), returnsResponse(response()
                 .header(CONNECTION, "Foo, Bar, Baz")
                 .header("Foo", "abc")
                 .header("Foo", "def")
                 .header("Bar", "one, two, three")
-                .build())
-        ).asCompletableFuture());
+                .build()))).block();
 
         assertThat(response.header(CONNECTION), isAbsent());
         assertThat(response.header("Foo"), isAbsent());

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/HttpMessageLoggingInterceptorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/HttpMessageLoggingInterceptorTest.java
@@ -15,23 +15,23 @@
  */
 package com.hotels.styx.proxy.interceptors;
 
+import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
-import com.hotels.styx.api.Eventual;
 import com.hotels.styx.server.HttpInterceptorContext;
 import com.hotels.styx.support.matchers.LoggingTestSupport;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import static ch.qos.logback.classic.Level.INFO;
+import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpResponse.response;
-import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.RequestCookie.requestCookie;
 import static com.hotels.styx.api.ResponseCookie.responseCookie;
-import static com.hotels.styx.common.StyxFutures.await;
 import static com.hotels.styx.support.matchers.LoggingEventMatcher.loggingEvent;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -127,6 +127,6 @@ public class HttpMessageLoggingInterceptorTest {
     }
 
     private static void consume(Eventual<LiveHttpResponse> resp) {
-        await(resp.flatMap(it -> it.aggregate(1000000)).asCompletableFuture());
+        Mono.from(resp.flatMap(it -> it.aggregate(1000000))).block();
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ViaHeaderAppendingInterceptorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ViaHeaderAppendingInterceptorTest.java
@@ -19,13 +19,14 @@ import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import static com.hotels.styx.api.HttpHeaderNames.HOST;
 import static com.hotels.styx.api.HttpHeaderNames.VIA;
+import static com.hotels.styx.api.HttpVersion.HTTP_1_0;
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpRequest.post;
 import static com.hotels.styx.api.LiveHttpResponse.response;
-import static com.hotels.styx.api.HttpVersion.HTTP_1_0;
 import static com.hotels.styx.proxy.interceptors.RequestRecordingChain.requestRecordingChain;
 import static com.hotels.styx.proxy.interceptors.ReturnResponseChain.returnsResponse;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
@@ -74,7 +75,7 @@ public class ViaHeaderAppendingInterceptorTest {
 
     @Test
     public void appendsHttp10RequestVersionInResponseViaHeader() throws Exception {
-        LiveHttpResponse response = interceptor.intercept(get("/foo").build(), ANY_RESPONSE_HANDLER).asCompletableFuture().get();
+        LiveHttpResponse response = Mono.from(interceptor.intercept(get("/foo").build(), ANY_RESPONSE_HANDLER)).block();
         assertThat(response.headers().get(VIA), isValue("1.1 styx"));
     }
 
@@ -90,10 +91,9 @@ public class ViaHeaderAppendingInterceptorTest {
 
     @Test
     public void appendsViaHeaderValueAtEndOfListInResponse() throws Exception {
-        LiveHttpResponse response = interceptor.intercept(get("/foo").build(), returnsResponse(response()
+        LiveHttpResponse response = Mono.from(interceptor.intercept(get("/foo").build(), returnsResponse(response()
                         .header(VIA, "1.0 ricky, 1.1 mertz, 1.0 lucy")
-                        .build())
-        ).asCompletableFuture().get();
+                        .build()))).block();
 
         assertThat(response.headers().get(VIA), isValue("1.0 ricky, 1.1 mertz, 1.0 lucy, 1.1 styx"));
     }

--- a/components/proxy/src/test/java/com/hotels/styx/routing/StaticPipelineBuilderTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/routing/StaticPipelineBuilderTest.java
@@ -19,10 +19,10 @@ import com.google.common.collect.ImmutableList;
 import com.hotels.styx.Environment;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.LiveHttpResponse;
-import com.hotels.styx.api.plugins.spi.Plugin;
 import com.hotels.styx.api.extension.service.BackendService;
 import com.hotels.styx.api.extension.service.spi.AbstractRegistry;
 import com.hotels.styx.api.extension.service.spi.Registry;
+import com.hotels.styx.api.plugins.spi.Plugin;
 import com.hotels.styx.proxy.BackendServiceClientFactory;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
 import com.hotels.styx.server.HttpInterceptorContext;
@@ -32,10 +32,10 @@ import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 
+import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpResponse.response;
 import static com.hotels.styx.api.extension.Origin.newOriginBuilder;
-import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.extension.service.BackendService.newBackendServiceBuilder;
 import static com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.reloaded;
 import static java.util.Arrays.asList;
@@ -63,7 +63,7 @@ public class StaticPipelineBuilderTest {
     public void buildsInterceptorPipelineForBackendServices() throws Exception {
 
         HttpHandler handler = new StaticPipelineFactory(clientFactory, environment, registry, ImmutableList.of(), false).build();
-        LiveHttpResponse response = handler.handle(get("/foo").build(), HttpInterceptorContext.create()).asCompletableFuture().get();
+        LiveHttpResponse response = Mono.from(handler.handle(get("/foo").build(), HttpInterceptorContext.create())).block();
         assertThat(response.status(), is(OK));
     }
 
@@ -76,7 +76,7 @@ public class StaticPipelineBuilderTest {
 
         HttpHandler handler = new StaticPipelineFactory(clientFactory, environment, registry, plugins, false).build();
 
-        LiveHttpResponse response = handler.handle(get("/foo").build(), HttpInterceptorContext.create()).asCompletableFuture().get();
+        LiveHttpResponse response = Mono.from(handler.handle(get("/foo").build(), HttpInterceptorContext.create())).block();
         assertThat(response.status(), is(OK));
         assertThat(response.headers("X-From-Plugin"), hasItems("B", "A"));
     }

--- a/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/BackendServiceProxySpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/BackendServiceProxySpec.scala
@@ -22,23 +22,19 @@ import com.hotels.styx.Environment
 import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.extension.Origin.newOriginBuilder
 import com.hotels.styx.api.extension.service.BackendService
-import com.hotels.styx.api.extension.service.spi.{AbstractRegistry, Registry}
-import com.hotels.styx.api.extension.service.spi.{AbstractRegistry, Registry}
-import com.hotels.styx.api.{HttpResponseStatus, LiveHttpRequest, LiveHttpResponse}
-import com.hotels.styx.client.{BackendServiceClient, OriginStatsFactory, OriginsInventory}
 import com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.reloaded
 import com.hotels.styx.api.extension.service.spi.Registry.{Changes, ReloadResult}
-import com.hotels.styx.common.StyxFutures
+import com.hotels.styx.api.extension.service.spi.{AbstractRegistry, Registry}
+import com.hotels.styx.api.{LiveHttpRequest, LiveHttpResponse}
+import com.hotels.styx.client.{BackendServiceClient, OriginStatsFactory, OriginsInventory}
 import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig
 import com.hotels.styx.proxy.BackendServiceClientFactory
 import com.hotels.styx.routing.config.RouteHandlerDefinition
 import com.hotels.styx.server.HttpInterceptorContext
-import com.hotels.styx.support.api.BlockingObservables
 import org.reactivestreams.Publisher
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import reactor.core.publisher.Mono
-import rx.Observable
 
 import scala.collection.JavaConversions._
 
@@ -69,13 +65,13 @@ class BackendServiceProxySpec extends FunSpec with Matchers with MockitoSugar {
     val handler = new BackendServiceProxy.ConfigFactory(environment, clientFactory(), services).build(List(), null, config)
     backendRegistry.reload()
 
-    val hwaResponse = StyxFutures.await(handler.handle(hwaRequest, HttpInterceptorContext.create).asCompletableFuture())
+    val hwaResponse = Mono.from(handler.handle(hwaRequest, HttpInterceptorContext.create)).block()
     hwaResponse.header("X-Backend-Service").get() should be("hwa")
 
-    val laResponse = StyxFutures.await(handler.handle(laRequest, HttpInterceptorContext.create).asCompletableFuture())
+    val laResponse = Mono.from(handler.handle(laRequest, HttpInterceptorContext.create)).block()
     laResponse.header("X-Backend-Service").get() should be("la")
 
-    val baResponse = StyxFutures.await(handler.handle(baRequest, HttpInterceptorContext.create).asCompletableFuture())
+    val baResponse = Mono.from(handler.handle(baRequest, HttpInterceptorContext.create)).block()
     baResponse.header("X-Backend-Service").get() should be("ba")
   }
 

--- a/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/ConditionRouterConfigSpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/ConditionRouterConfigSpec.scala
@@ -15,10 +15,9 @@
  */
 package com.hotels.styx.routing.handlers
 
-import com.hotels.styx.api.LiveHttpResponse.response
 import com.hotels.styx.api.HttpResponseStatus.{BAD_GATEWAY, OK}
-import com.hotels.styx.api.{HttpHandler, HttpInterceptor, LiveHttpRequest, Eventual}
-import com.hotels.styx.common.StyxFutures
+import com.hotels.styx.api.LiveHttpResponse.response
+import com.hotels.styx.api.{Eventual, HttpHandler, LiveHttpRequest}
 import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig
 import com.hotels.styx.routing.HttpHandlerAdapter
 import com.hotels.styx.routing.config.{HttpHandlerFactory, RouteHandlerConfig, RouteHandlerDefinition, RouteHandlerFactory}
@@ -27,6 +26,7 @@ import org.mockito.Matchers.{any, eq => meq}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import reactor.core.publisher.Mono
 
 import scala.collection.JavaConversions._
 
@@ -72,15 +72,14 @@ class ConditionRouterConfigSpec extends FunSpec with Matchers with MockitoSugar 
 
   it("Builds an instance with fallback handler") {
     val router = new ConditionRouter.ConfigFactory().build(List(), routeHandlerFactory, config)
-    val response = StyxFutures.await(router.handle(request, new HttpInterceptorContext(true))
-    .asCompletableFuture())
+    val response = Mono.from(router.handle(request, new HttpInterceptorContext(true))).block()
 
     response.status() should be(OK)
   }
 
   it("Builds condition router instance routes") {
     val router = new ConditionRouter.ConfigFactory().build(List(), routeHandlerFactory, config)
-    val response = StyxFutures.await(router.handle(request, new HttpInterceptorContext()).asCompletableFuture())
+    val response = Mono.from(router.handle(request, new HttpInterceptorContext())).block()
 
     response.status().code() should be(301)
   }
@@ -95,7 +94,7 @@ class ConditionRouterConfigSpec extends FunSpec with Matchers with MockitoSugar 
 
     val router = new ConditionRouter.ConfigFactory().build(List(), routeHandlerFactory, configWithReferences)
 
-    val resp = StyxFutures.await(router.handle(request, new HttpInterceptorContext()).asCompletableFuture())
+    val resp = Mono.from(router.handle(request, new HttpInterceptorContext())).block()
 
     resp.header("source").get() should be("fallback")
   }
@@ -114,7 +113,7 @@ class ConditionRouterConfigSpec extends FunSpec with Matchers with MockitoSugar 
       configWithReferences
       )
 
-    val resp = StyxFutures.await(router.handle(request, new HttpInterceptorContext(true)).asCompletableFuture())
+    val resp = Mono.from(router.handle(request, new HttpInterceptorContext(true))).block()
 
     resp.header("source").get() should be("secure")
   }
@@ -160,7 +159,7 @@ class ConditionRouterConfigSpec extends FunSpec with Matchers with MockitoSugar 
 
     val router = new ConditionRouter.ConfigFactory().build(List(), routeHandlerFactory, config)
 
-    val resp = StyxFutures.await(router.handle(request, new HttpInterceptorContext()).asCompletableFuture())
+    val resp = Mono.from(router.handle(request, new HttpInterceptorContext())).block()
 
     resp.status() should be(BAD_GATEWAY)
   }

--- a/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/ProxyToBackendSpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/ProxyToBackendSpec.scala
@@ -56,7 +56,7 @@ class ProxyToBackendSpec extends FunSpec with Matchers {
   it("builds ProxyToBackend handler") {
     val handler = new ProxyToBackend.ConfigFactory(environment, clientFactory()).build(List().asJava, null, config)
 
-    val response = StyxFutures.await(handler.handle(LiveHttpRequest.get("/foo").build(), HttpInterceptorContext.create).asCompletableFuture())
+    val response = Mono.from(handler.handle(LiveHttpRequest.get("/foo").build(), HttpInterceptorContext.create)).block()
     response.status should be (OK)
   }
 

--- a/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/StaticResponseHandlerSpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/routing/handlers/StaticResponseHandlerSpec.scala
@@ -17,11 +17,11 @@ package com.hotels.styx.routing.handlers
 
 import com.hotels.styx.api.HttpResponseStatus.CREATED
 import com.hotels.styx.api.LiveHttpRequest
-import com.hotels.styx.common.StyxFutures
 import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig
 import com.hotels.styx.routing.config.RouteHandlerDefinition
 import com.hotels.styx.server.HttpInterceptorContext
 import org.scalatest.{FunSpec, Matchers}
+import reactor.core.publisher.Mono
 
 import scala.collection.JavaConversions._
 
@@ -40,7 +40,7 @@ class StaticResponseHandlerSpec extends FunSpec with Matchers {
 
   it("builds static response handler") {
     val handler = new StaticResponseHandler.ConfigFactory().build(List(), null, config)
-    val response = StyxFutures.await(handler.handle(LiveHttpRequest.get("/foo").build(), HttpInterceptorContext.create).asCompletableFuture())
+    val response = Mono.from(handler.handle(LiveHttpRequest.get("/foo").build(), HttpInterceptorContext.create)).block()
 
     response.status should be (CREATED)
   }

--- a/components/proxy/src/test/scala/com/hotels/styx/routing/interceptors/RewriteInterceptorSpec.scala
+++ b/components/proxy/src/test/scala/com/hotels/styx/routing/interceptors/RewriteInterceptorSpec.scala
@@ -15,14 +15,14 @@
  */
 package com.hotels.styx.routing.interceptors
 
+import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.LiveHttpResponse.response
 import com.hotels.styx.api._
-import com.hotels.styx.common.StyxFutures
 import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig
 import com.hotels.styx.routing.config.RouteHandlerDefinition
-import com.hotels.styx.api.HttpResponseStatus.OK
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import reactor.core.publisher.Mono
 
 class RewriteInterceptorSpec extends FunSpec with Matchers with MockitoSugar {
 
@@ -43,7 +43,7 @@ class RewriteInterceptorSpec extends FunSpec with Matchers with MockitoSugar {
     val interceptor = new RewriteInterceptor.ConfigFactory().build(config)
     val capturingChain = new CapturingChain
 
-    val response = StyxFutures.await(interceptor.intercept(LiveHttpRequest.get("/foo").build(), capturingChain).asCompletableFuture())
+    val response = Mono.from(interceptor.intercept(LiveHttpRequest.get("/foo").build(), capturingChain)).block()
     capturingChain.request().path() should be ("/app/foo")
   }
 
@@ -60,7 +60,7 @@ class RewriteInterceptorSpec extends FunSpec with Matchers with MockitoSugar {
     val interceptor = new RewriteInterceptor.ConfigFactory().build(config)
     val capturingChain = new CapturingChain
 
-    val response = StyxFutures.await(interceptor.intercept(LiveHttpRequest.get("/foo").build(), capturingChain).asCompletableFuture())
+    val response = Mono.from(interceptor.intercept(LiveHttpRequest.get("/foo").build(), capturingChain)).block()
     capturingChain.request().path() should be ("/foo")
   }
 

--- a/components/server/src/test/java/com/hotels/styx/server/handlers/StaticFileHandlerTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/handlers/StaticFileHandlerTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -41,14 +42,13 @@ import static com.google.common.net.MediaType.OCTET_STREAM;
 import static com.google.common.net.MediaType.PDF;
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.google.common.net.MediaType.PNG;
-import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.server.handlers.MediaTypes.ICON;
 import static com.hotels.styx.server.handlers.MediaTypes.MICROSOFT_ASF_VIDEO;
 import static com.hotels.styx.server.handlers.MediaTypes.MICROSOFT_MS_VIDEO;
 import static com.hotels.styx.server.handlers.MediaTypes.WAV_AUDIO;
-import static com.hotels.styx.support.api.BlockingObservables.getFirst;
 import static com.hotels.styx.support.api.matchers.HttpStatusMatcher.hasStatus;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -181,6 +181,6 @@ public class StaticFileHandlerTest {
     }
 
     private LiveHttpResponse handle(LiveHttpRequest request) {
-        return getFirst(handler.handle(request, new HttpInterceptorContext()));
+        return Mono.from(handler.handle(request, new HttpInterceptorContext())).block();
     }
 }

--- a/components/server/src/test/java/com/hotels/styx/server/routing/routes/ProxyToBackendRouteTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/routing/routes/ProxyToBackendRouteTest.java
@@ -21,6 +21,7 @@ import com.hotels.styx.client.BackendServiceClient;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.LiveHttpRequest.get;
@@ -33,13 +34,13 @@ import static org.mockito.Mockito.when;
 
 public class ProxyToBackendRouteTest {
     @Test
-    public void proxiesUsingClient() throws Exception {
+    public void proxiesUsingClient() {
         BackendServiceClient client = mock(BackendServiceClient.class);
         when(client.sendRequest(any(LiveHttpRequest.class))).thenReturn(Flux.just(response(OK).build()));
 
         ProxyToBackendRoute proxy = ProxyToBackendRoute.proxyToBackend(client);
 
-        LiveHttpResponse response = proxy.handle(get("/foo").build(), HttpInterceptorContext.create()).asCompletableFuture().get();
+        LiveHttpResponse response = Mono.from(proxy.handle(get("/foo").build(), HttpInterceptorContext.create())).block();
         assertThat(response.status(), is(OK));
     }
 }

--- a/support/api-testsupport/src/main/java/com/hotels/styx/support/api/matchers/HttpResponseBodyMatcher.java
+++ b/support/api-testsupport/src/main/java/com/hotels/styx/support/api/matchers/HttpResponseBodyMatcher.java
@@ -20,6 +20,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -47,12 +48,12 @@ public class HttpResponseBodyMatcher<T extends LiveHttpResponse> extends TypeSaf
 
     @Override
     public boolean matchesSafely(T actual) {
-        return matcher.matches(await(actual.aggregate(0x100000).asCompletableFuture()).bodyAs(UTF_8));
+        return matcher.matches(Mono.from(actual.aggregate(0x100000)).block().bodyAs(UTF_8));
     }
 
     @Override
     protected void describeMismatchSafely(T item, Description mismatchDescription) {
-        mismatchDescription.appendText("content was '" + await(item.aggregate(0x100000).asCompletableFuture()).bodyAs(UTF_8) + "'");
+        mismatchDescription.appendText("content was '" + Mono.from(item.aggregate(0x100000)).block().bodyAs(UTF_8) + "'");
     }
 
     @Override

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/handlers/ContentDigestHandler.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/handlers/ContentDigestHandler.java
@@ -21,13 +21,13 @@ import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.common.http.handler.BaseHttpHandler;
+import reactor.core.publisher.Mono;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.HTML_UTF_8;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
-import static com.hotels.styx.common.StyxFutures.await;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
 
@@ -40,7 +40,7 @@ public class ContentDigestHandler extends BaseHttpHandler {
 
     @Override
     protected LiveHttpResponse doHandle(LiveHttpRequest request) {
-        HttpRequest fullRequest = await(request.aggregate(0x100000).asCompletableFuture());
+        HttpRequest fullRequest = Mono.from(request.aggregate(0x100000)).block();
 
         String responseBody = format("Response From %s - %s, received content digest: %s",
                 origin.hostAndPortString(),


### PR DESCRIPTION
Removes `asCompletableFuture` from Eventual. It feels quite pointless now as the `Eventual` implements a Reactive Streams `Publisher` interface.

In unit tests it is often useful to block and wait for response. Use `Mono` from Reactor-core instead:

```
HttpRequest full = Mono.from(streamingRequest.aggregate(ONE_MEGABYTE)).block();
```

Use `Mono` to convert to `CompletableFuture`:

```
Mono.from(response1.aggregate(1000)).toFuture();
```
