### PR TITLE
Remove deprecated `request-logging.enabled` option.

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxPipelineFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxPipelineFactory.java
@@ -85,7 +85,6 @@ public final class StyxPipelineFactory implements PipelineFactory {
         ImmutableList.Builder<HttpInterceptor> builder = ImmutableList.builder();
 
         boolean loggingEnabled = config.get("request-logging.inbound.enabled", Boolean.class)
-                .map(isEnabled -> isEnabled || config.get("request-logging.enabled", Boolean.class).orElse(false))
                 .orElse(false);
 
         boolean longFormatEnabled = config.get("request-logging.inbound.longFormat", Boolean.class)

--- a/docs/user-guide/configure-overview.md
+++ b/docs/user-guide/configure-overview.md
@@ -106,9 +106,9 @@ using environment variables with the same name as the property.
         enabled: true
         
     request-logging:
-      # Enabled logging of requests and responses (with requestId to match them up)
-      # Logs are produced on server and client side, so there is an information on 
-      # how the server-side (inbound) and client-side (outbound) request/response look like.
+      # Enable logging of requests and responses (with requestId to match them up).
+      # Logs are produced on server and origin side, so there is an information on 
+      # how the server-side (inbound) and origin-side (outbound) request/response look like.
       # In long format log entry contains additionally headers and cookies. 
       inbound:
         enabled: true
@@ -187,8 +187,9 @@ Without the comments, it looks like this:
         enabled: true
 
     request-logging:
-      enabled: true
-
+      inbound:
+        enabled: true
+        
     styxHeaders:
       styxInfo:
         name: "X-Styx-Info"

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/CipherSuitesSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/CipherSuitesSpec.scala
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client
 
-import java.nio.charset.StandardCharsets
 import java.nio.charset.StandardCharsets.UTF_8
 
 import com.github.tomakehurst.wiremock.client.WireMock._
@@ -47,8 +46,6 @@ class CipherSuitesSpec extends FunSpec
       |  connectors:
       |    http:
       |      port: 0
-      |request-logging:
-      |  enabled: true
     """.stripMargin,
     logbackXmlLocation = logback)
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/HealthCheckSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/HealthCheckSpec.scala
@@ -72,8 +72,6 @@ class HealthCheckSpec extends FunSpec
       |  connectors:
       |    http:
       |      port: 0
-      |request-logging:
-      |  enabled: true
     """.stripMargin,
     logbackXmlLocation = logback)
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/TlsVersionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/TlsVersionSpec.scala
@@ -76,8 +76,6 @@ class TlsVersionSpec extends FunSpec
       |  connectors:
       |    http:
       |      port: 0
-      |request-logging:
-      |  enabled: true
     """.stripMargin,
     logbackXmlLocation = logback)
 


### PR DESCRIPTION
The `request-logging.enabled` is unnecessary relic from the past. 

The correct way to enable minimal request logging in styx is:

```
request-logging:
  inbound:
    enabled: true
```

This pull request updates the documentation, and removes any code referring to the `request-logging.enabled`.
