### PR TITLE
An API for setting a custom HTTP response status and phrase.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponseStatus.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponseStatus.java
@@ -120,11 +120,7 @@ public final class HttpResponseStatus {
      * @return a HttpResponseStatus instance.
      */
     public static HttpResponseStatus statusWithCode(int code) {
-        if (code < 0 || code >= STATUSES.length || STATUSES[code] == null) {
-            return new HttpResponseStatus(code, "Unknown status");
-        }
-
-        return STATUSES[code];
+        return statusWithCode(code, "Unknown status");
     }
 
     /**

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponseStatus.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponseStatus.java
@@ -109,9 +109,41 @@ public final class HttpResponseStatus {
         }
     }
 
+    /**
+     * Returns a {@link HttpResponseStatus} object corresponding to numeric status code.
+     *
+     * If {@code code} is not a standard HTTP response code, a new {@link HttpResponseStatus}
+     * is created with an "Unknown status" reason phrase.
+     *
+     * @param code
+     *
+     * @return a HttpResponseStatus instance.
+     */
     public static HttpResponseStatus statusWithCode(int code) {
         if (code < 0 || code >= STATUSES.length || STATUSES[code] == null) {
             return new HttpResponseStatus(code, "Unknown status");
+        }
+
+        return STATUSES[code];
+    }
+
+    /**
+     * Returns a custom {@link HttpResponseStatus} object with a user specified reason phrase.
+     *
+     * If a {@code code} is a standard HTTP response code, a {@link HttpResponseStatus} is
+     * returned with a standard reason phrase. In this case the user provided {@code ReasonPhrase}
+     * is ignored.
+     *
+     * If a {@code code} is unrecognised, a custom {@link HttpResponseStatus} is returned with
+     * the user provided {@code ReasonPhrase}.
+     *
+     * @param code
+     *
+     * @return a HttpResponseStatus instance.
+     */
+    public static HttpResponseStatus statusWithCode(int code, String reasonPhrase) {
+        if (code < 0 || code >= STATUSES.length || STATUSES[code] == null) {
+            return new HttpResponseStatus(code, reasonPhrase);
         }
 
         return STATUSES[code];


### PR DESCRIPTION
Provides a way for setting a custom HTTP response status phrase.

This is useful for logging purposes. That is, the reason phrase will then show up when the message is logged.
