### PR TITLE
Fix intermittently failing test.

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/CurrentRequestsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/CurrentRequestsHandler.java
@@ -67,21 +67,21 @@ public class CurrentRequestsHandler extends BaseHttpHandler {
 
         tracker.currentRequests().forEach(req -> {
             sb.append("[\n");
-            sb.append(req.getRequest().replaceAll(",", "\n"));
+            sb.append(req.request().replaceAll(",", "\n"));
             sb.append("\n\n");
             sb.append("running for: ");
-            sb.append(currentTimeMillis() - req.getStartingTimeMillies());
+            sb.append(currentTimeMillis() - req.startingTimeMillies());
             sb.append("ms\n");
             if (req.isRequestSent()) {
                 sb.append("\nRequest state: Waiting response from origin.\n");
             } else {
                 sb.append("\nRequest state: Plugins pipeline.\n");
-                sb.append("\n\n   ...   Thread Info: ...\n");
+                sb.append("\n\nThread Info:\n");
                 if (withStackTrace) {
-                    sb.append(getThreadInfo(req.getCurrentThread().getId()));
+                    sb.append(getThreadInfo(req.currentThread().getId()));
                 } else {
                     sb.append("Name: ");
-                    sb.append(req.getCurrentThread().getName());
+                    sb.append(req.currentThread().getName());
                     sb.append("\n");
                 }
             }

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
@@ -32,7 +32,7 @@ import static org.testng.AssertJUnit.assertFalse;
 
 public class CurrentRequestsHandlerTest {
 
-    private final int MAX_CONTENT_SIZE;
+    private static final int MAX_CONTENT_SIZE = 10_000;
     LiveHttpRequest req1 = get("/requestId1").build();
 
     CurrentRequestTracker tracker = new CurrentRequestTracker();

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
@@ -15,28 +15,32 @@
  */
 package com.hotels.styx.admin.handlers;
 
-import static com.hotels.styx.api.LiveHttpRequest.get;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
+import com.hotels.styx.api.HttpResponse;
+import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.server.track.CurrentRequestTracker;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
 
-import com.hotels.styx.api.Buffer;
-import com.hotels.styx.api.LiveHttpRequest;
-import com.hotels.styx.api.LiveHttpResponse;
-import com.hotels.styx.server.track.CurrentRequestTracker;
-
-import reactor.core.publisher.Flux;
-
+import static com.hotels.styx.api.LiveHttpRequest.get;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
 
 public class CurrentRequestsHandlerTest {
 
+    private final int MAX_CONTENT_SIZE;
     LiveHttpRequest req1 = get("/requestId1").build();
 
     CurrentRequestTracker tracker = new CurrentRequestTracker();
     private CurrentRequestsHandler handler;
+
+    public CurrentRequestsHandlerTest() {
+        MAX_CONTENT_SIZE = 10000;
+    }
 
     @BeforeMethod
     public void setUp() {
@@ -48,8 +52,8 @@ public class CurrentRequestsHandlerTest {
     public void testStackTrace() {
         Thread.currentThread().setName("Test-Thread");
         tracker.trackRequest(req1);
-        LiveHttpResponse response = handler.doHandle(req1);
-        assertThat(Flux.from(response.body()).map(this::decodeUtf8String).blockFirst().contains("Test-Thread"), is(true));
+        HttpResponse response = Mono.from(handler.doHandle(req1).aggregate(MAX_CONTENT_SIZE)).block();
+        assertThat(response.bodyAs(UTF_8).contains("Test-Thread"), is(true));
     }
 
     @Test
@@ -57,27 +61,28 @@ public class CurrentRequestsHandlerTest {
         Thread.currentThread().setName("Test-Thread-1");
         tracker.trackRequest(req1);
         tracker.markRequestAsSent(req1);
-        LiveHttpResponse response = handler.doHandle(req1);
-        assertThat(Flux.from(response.body()).map(this::decodeUtf8String).blockFirst().contains("Request state: Waiting response from origin."), is(true));
+        HttpResponse response = Mono.from(handler.doHandle(req1).aggregate(MAX_CONTENT_SIZE)).block();
+        assertThat(response.bodyAs(UTF_8).contains("Request state: Waiting response from origin."), is(true));
     }
 
     @Test
     public void testWithStackTrace() {
         Thread.currentThread().setName("Test-Thread");
         tracker.trackRequest(req1);
-        LiveHttpResponse response = handler.doHandle(get("/req?withStackTrace=true").build());
-        assertThat(Flux.from(response.body()).map(this::decodeUtf8String).blockFirst().contains("id=" + Thread.currentThread().getId()), is(true));
+        HttpResponse response = Mono.from(handler.doHandle(get("/req?withStackTrace=true").build()).aggregate(MAX_CONTENT_SIZE)).block();
+
+        assertTrue(response.bodyAs(UTF_8).contains("Thread Info:"));
+        assertTrue(response.bodyAs(UTF_8).contains("id=" + Thread.currentThread().getId()));
     }
 
     @Test
     public void testWithoutStackTrace() {
-        Thread.currentThread().setName("Test-Thread");
         tracker.trackRequest(req1);
-        LiveHttpResponse response = handler.doHandle(req1);
-        assertThat(Flux.from(response.body()).map(this::decodeUtf8String).blockFirst().contains("id=" + Thread.currentThread().getId()), is(false));
-    }
+        HttpResponse response = Mono.from(handler.doHandle(req1).aggregate(100000)).block();
 
-    private String decodeUtf8String(Buffer buffer) {
-        return new String(buffer.content(), UTF_8);
+        String body = response.bodyAs(UTF_8);
+
+        assertFalse(format("This is received response body: ```%s```", body),
+                body.contains(format("id=%d state", Thread.currentThread().getId())));
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
@@ -38,10 +38,6 @@ public class CurrentRequestsHandlerTest {
     private CurrentRequestTracker tracker = new CurrentRequestTracker();
     private CurrentRequestsHandler handler;
 
-    public CurrentRequestsHandlerTest() {
-        MAX_CONTENT_SIZE = 10000;
-    }
-
     @BeforeMethod
     public void setUp() {
         tracker = new CurrentRequestTracker();

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
@@ -72,7 +72,7 @@ public class CurrentRequestsHandlerTest {
         HttpResponse response = Mono.from(handler.doHandle(get("/req?withStackTrace=true").build()).aggregate(MAX_CONTENT_SIZE)).block();
 
         assertTrue(response.bodyAs(UTF_8).contains("Thread Info:"));
-        assertTrue(response.bodyAs(UTF_8).contains("id=" + Thread.currentThread().getId()));
+        assertTrue(response.bodyAs(UTF_8).contains("id=" + Thread.currentThread().getId() + " state"));
     }
 
     @Test

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
@@ -35,7 +35,7 @@ public class CurrentRequestsHandlerTest {
     private static final int MAX_CONTENT_SIZE = 10_000;
     LiveHttpRequest req1 = get("/requestId1").build();
 
-    CurrentRequestTracker tracker = new CurrentRequestTracker();
+    private CurrentRequestTracker tracker = new CurrentRequestTracker();
     private CurrentRequestsHandler handler;
 
     public CurrentRequestsHandlerTest() {

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/CurrentRequestsHandlerTest.java
@@ -33,7 +33,7 @@ import static org.testng.AssertJUnit.assertFalse;
 public class CurrentRequestsHandlerTest {
 
     private static final int MAX_CONTENT_SIZE = 10_000;
-    LiveHttpRequest req1 = get("/requestId1").build();
+    private LiveHttpRequest req1 = get("/requestId1").build();
 
     private CurrentRequestTracker tracker = new CurrentRequestTracker();
     private CurrentRequestsHandler handler;

--- a/components/server/src/main/java/com/hotels/styx/server/track/CurrentRequest.java
+++ b/components/server/src/main/java/com/hotels/styx/server/track/CurrentRequest.java
@@ -39,19 +39,19 @@ public class CurrentRequest {
         this.stateSupplier = stateSupplier;
     }
 
-    public Thread getCurrentThread() {
+    public Thread currentThread() {
         return currentThread;
     }
 
-    public String getRequest() {
+    public String request() {
         return request;
     }
 
-    public long getStartingTimeMillies() {
+    public long startingTimeMillies() {
         return startingTimeMillies;
     }
 
-    public String getState() {
+    public String state() {
         return stateSupplier.get();
     }
 

--- a/components/server/src/test/java/com/hotels/styx/server/track/CurrentRequestTrackerTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/track/CurrentRequestTrackerTest.java
@@ -39,17 +39,17 @@ public class CurrentRequestTrackerTest {
     @Test
     public void testTrackRequest() {
         tracker.trackRequest(req1);
-        assertThat(tracker.currentRequests().iterator().next().getRequest(), is(req1.toString()));
+        assertThat(tracker.currentRequests().iterator().next().request(), is(req1.toString()));
     }
 
     @Test
     public void testChangeWorkingThread() {
         Thread.currentThread().setName("thread-1");
         tracker.trackRequest(req1);
-        assertThat("thread-1", is(tracker.currentRequests().iterator().next().getCurrentThread().getName()));
+        assertThat("thread-1", is(tracker.currentRequests().iterator().next().currentThread().getName()));
         Thread.currentThread().setName("thread-2");
         tracker.trackRequest(req1);
-        assertThat("thread-2", is(tracker.currentRequests().iterator().next().getCurrentThread().getName()));
+        assertThat("thread-2", is(tracker.currentRequests().iterator().next().currentThread().getName()));
     }
 
     @Test
@@ -60,14 +60,14 @@ public class CurrentRequestTrackerTest {
         tracker.trackRequest(req1);
         tracker.trackRequest(req1);
         assertThat(tracker.currentRequests().size(), is(1));
-        assertThat(tracker.currentRequests().iterator().next().getRequest(), is(req1.toString()));
+        assertThat(tracker.currentRequests().iterator().next().request(), is(req1.toString()));
     }
 
     @Test
     public void testEndTrack() {
         tracker.trackRequest(req1);
         assertThat(tracker.currentRequests().size(), is(1));
-        assertThat(tracker.currentRequests().iterator().next().getRequest(), is(req1.toString()));
+        assertThat(tracker.currentRequests().iterator().next().request(), is(req1.toString()));
         tracker.endTrack(req1);
         assertThat(tracker.currentRequests().size(), is(0));
     }
@@ -86,6 +86,6 @@ public class CurrentRequestTrackerTest {
         tracker.trackRequest(req1);
         tracker.trackRequest(req2);
         tracker.endTrack(req1);
-        assertThat(tracker.currentRequests().iterator().next().getRequest(), is(req2.toString()));
+        assertThat(tracker.currentRequests().iterator().next().request(), is(req2.toString()));
     }
 }


### PR DESCRIPTION
Fixes an intermittently failing test. 

The `testWithoutStackTrace` test searches for a thread ID from the response output and asserts it is absent. The search string is constructed as `"id=" + Thread.currentThread.getId()`, but sometimes it matches with the *request id* (but not the thread ID) therefore failing the test.

Fixed by altering the search pattern such that it no longer accidentally match with response ID.
