### PR TITLE
StyxHttpClient: add support for live requests

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/ConnectionPools.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/ConnectionPools.java
@@ -18,10 +18,13 @@ package com.hotels.styx.client.connectionpool;
 import com.hotels.styx.api.MetricRegistry;
 import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.extension.service.BackendService;
+import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
+import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.client.netty.connectionpool.NettyConnectionFactory;
 
 import static com.hotels.styx.api.extension.service.ConnectionPoolSettings.defaultConnectionPoolSettings;
 import static com.hotels.styx.client.HttpRequestOperationFactory.Builder.httpRequestOperationFactoryBuilder;
+import static java.lang.String.format;
 
 /**
  * Helper routines for building connection pools with default settings.
@@ -57,6 +60,18 @@ public final class ConnectionPools {
                                 .httpRequestOperationFactory(httpRequestOperationFactoryBuilder().responseTimeoutMillis(responseTimeoutMillis).build())
                                 .build()),
                 metricRegistry);
+    }
+
+    public static ConnectionPool create(String hostname, int port, ConnectionPoolSettings poolSettings) {
+        return new SimpleConnectionPoolFactory.Builder()
+                .connectionPoolSettings(poolSettings)
+                .connectionFactory(new NettyConnectionFactory.Builder().build())
+                .metricRegistry(new CodaHaleMetricRegistry())
+                .build()
+                .create(Origin.newOriginBuilder(hostname, port)
+                        .applicationId(format("%s:%d", hostname, port))
+                        .id(format("%s:%d-01", hostname, port))
+                        .build());
     }
 
     private static ConnectionPool poolForOrigin(Origin origin, MetricRegistry metricRegistry, NettyConnectionFactory connectionFactory) {


### PR DESCRIPTION
Add support for sending LiveHttpRequests.

It is now possible to:

    client.streaming().send(liveRequest)
