### PR TITLE
Adapt Version metric to a more flexible pattern 

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/Version.java
+++ b/components/proxy/src/main/java/com/hotels/styx/Version.java
@@ -88,7 +88,7 @@ public class Version {
 
     private Optional<String> extractFinalInt(String versionString) {
         Matcher m = VERSION_FORMAT.matcher(versionString);
-        if (!m.matches()){
+        if (!m.matches()) {
             return Optional.empty();
         } else {
             return Optional.of(m.group(3));
@@ -102,8 +102,6 @@ public class Version {
             return Optional.empty();
         }
     }
-
-
 
     @Override
     public String toString() {

--- a/components/proxy/src/main/java/com/hotels/styx/Version.java
+++ b/components/proxy/src/main/java/com/hotels/styx/Version.java
@@ -23,8 +23,12 @@ import org.slf4j.Logger;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Objects.toStringHelper;
+import static java.lang.Integer.parseInt;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -32,6 +36,8 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 public class Version {
     private static final Logger LOG = getLogger(Version.class);
+    private static final Pattern VERSION_FORMAT = Pattern.compile("(\\d+)\\.(\\d+)[-.](\\d+).*");
+
 
     private final String releaseTag;
 
@@ -72,6 +78,29 @@ public class Version {
         }
 
         return releaseTag.substring(firstDot + 1);
+    }
+
+    public Optional<Integer> buildNumber() {
+        String releaseVersion = releaseVersion();
+        Optional<String> buildNumberAsString = extractFinalInt(releaseVersion);
+        return buildNumberAsString.flatMap(this::parseInteger);
+    }
+
+    private Optional<String> extractFinalInt(String versionString) {
+        Matcher m = VERSION_FORMAT.matcher(versionString);
+        if (!m.matches()){
+            return Optional.empty();
+        } else {
+            return Optional.of(m.group(3));
+        }
+    }
+
+    private Optional<Integer> parseInteger(String string) {
+        try {
+            return Optional.of(parseInt(string));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
     }
 
 

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyConnectorFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyConnectorFactory.java
@@ -71,7 +71,7 @@ class ProxyConnectorFactory implements ServerConnectorFactory {
                           MetricRegistry metrics,
                           HttpErrorStatusListener errorStatusListener,
                           String unwiseCharacters,
-                          ResponseEnhancer responseEnhancer, 
+                          ResponseEnhancer responseEnhancer,
                           boolean requestTracking) {
         this.serverConfig = requireNonNull(serverConfig);
         this.metrics = requireNonNull(metrics);

--- a/components/proxy/src/test/java/com/hotels/styx/VersionTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/VersionTest.java
@@ -17,9 +17,10 @@ package com.hotels.styx;
 
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
 import static com.hotels.styx.Version.newVersion;
 import static com.hotels.styx.Version.readVersionFrom;
-import static com.hotels.styx.support.matchers.IsOptional.isPresent;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,11 +31,12 @@ public class VersionTest {
     public void readBuildInfoFromTheSpecifiedPath() {
         Version version = readVersionFrom("/version.json");
         assertThat(version.releaseTag(), containsString("STYX"));
-        assertThat(version.releaseVersion(), is("0.0-125"));
+        assertThat(version.buildNumber(), is(Optional.of(125)));
     }
 
     @Test
     public void willCreateAnEmptyBuildInfoIfFailsToRead() {
         assertThat(readVersionFrom("version.txt"), is(newVersion()));
     }
+
 }

--- a/components/proxy/src/test/java/com/hotels/styx/startup/CoreMetricsTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/startup/CoreMetricsTest.java
@@ -37,7 +37,7 @@ public class CoreMetricsTest {
 
         Gauge gauge = metrics.getGauges().get("styx.version.buildnumber");
 
-        assertThat(gauge.getValue(), is("1.2.3"));
+        assertThat(gauge.getValue(), is(3));
     }
 
     @Test


### PR DESCRIPTION
Some users want to see the version value in graphite and that server does not support non-numeric metrics. Thus, we will send the metric as a number, but supporting build numbers separated with a Hyphen instead of a dot.