### PR TITLE
A docker container network with Toxi-Proxy

### DIFF
--- a/system-tests/docker-toxiproxy/apache-config/info.txt
+++ b/system-tests/docker-toxiproxy/apache-config/info.txt
@@ -1,0 +1,4 @@
+Hello, world!
+
+This directory is mounted into Apache/httpd container. Any files added
+into this directory are visible to Apache and served as static files.

--- a/system-tests/docker-toxiproxy/docker-compose.yml
+++ b/system-tests/docker-toxiproxy/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3'
+services:
+
+  httpd-01:
+    image: httpd:2.4
+    ports:
+      - "8081:80"
+    volumes:
+      - ./apache-config:/usr/local/apache2/htdocs/
+
+  toxiproxy:
+    image: shopify/toxiproxy:latest
+    depends_on:
+      - httpd-01
+    ports:
+      - "8474:8474"
+    volumes:
+      - ./toxiproxy/:/config
+    entrypoint:
+      - /go/bin/toxiproxy
+      - "-host=0.0.0.0"
+      - "-config=/config/config.json"
+
+  styx:
+    image: styxcore:latest
+    depends_on:
+      - httpd-01
+      - toxiproxy
+    ports:
+      - "9000:9000"
+      - "8080:8080"
+      - "8443:8443"
+    volumes:
+      - ./styx-config:/styx/config
+    links:
+      - httpd-01
+      - toxiproxy
+    entrypoint:
+      - styx/bin/startup
+      - /styx/config/styxconf.yml

--- a/system-tests/docker-toxiproxy/styx-config/origins.yml
+++ b/system-tests/docker-toxiproxy/styx-config/origins.yml
@@ -1,0 +1,12 @@
+# See origins/origins-default.yaml for explanation of config format
+---
+- id: "httpd"
+  path: "/"
+  connectionPool:
+    maxConnectionsPerHost: 45
+    maxPendingConnectionsPerHost: 15
+    connectTimeoutMillis: 1000
+    pendingConnectionTimeoutMillis: 8000
+  responseTimeoutMillis: 60000
+  origins:
+    - { id: "httpd-01", host: "toxiproxy:80" }

--- a/system-tests/docker-toxiproxy/styx-config/styxconf.yml
+++ b/system-tests/docker-toxiproxy/styx-config/styxconf.yml
@@ -1,0 +1,8 @@
+---
+include: /styx/default-config/default.yml
+
+services:
+  factories:
+    backendServiceRegistry:
+      config:
+        originsFile: "/styx/config/origins.yml"

--- a/system-tests/docker-toxiproxy/toxiproxy/config.json
+++ b/system-tests/docker-toxiproxy/toxiproxy/config.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "httpd-01",
+    "listen": "0.0.0.0:80",
+    "upstream": "httpd-01:80"
+  }
+]


### PR DESCRIPTION
This PR adds Docker container network for integration testing with Toxi-Proxy.

The container network has a Styx as a proxy and an Apache as a static file server. A toxi-proxy is deployed to intercept all traffic between the two. The toxics can be configured in toxi-proxy configuration file, or in runtime using the toxi-proxy HTTP API etc.

The following ports are exposed to the host machine:
* styx proxy 8080 (http), 8443 (https), 9000 (admin interface)
* toxi-proxy API server: 8474

Styx configuration server configuration is mounted from host, from `styx-config/styxconf.yml` file, and the origin file is in `styx-config/origins.yml`. By default, the styx configuration is set to monitor the origins file. Therefore the origins can be re-configured while the styx is running.

