### PR TITLE
Don't deploy unnecessary modules

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -48,12 +48,6 @@
       </dependency>
       <dependency>
         <groupId>com.hotels.styx</groupId>
-        <artifactId>styx-testsupport</artifactId>
-        <version>${project.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.hotels.styx</groupId>
         <artifactId>styx-api-testsupport</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>

--- a/components/common/pom.xml
+++ b/components/common/pom.xml
@@ -43,11 +43,15 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.hotels.styx</groupId>
       <artifactId>styx-testsupport</artifactId>
+      <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>

--- a/support/api-testsupport/pom.xml
+++ b/support/api-testsupport/pom.xml
@@ -51,4 +51,17 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/support/api-testsupport/pom.xml
+++ b/support/api-testsupport/pom.xml
@@ -58,7 +58,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>
-          <skip>true</skip>
+          <skip>false</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/support/origins-starter-app/pom.xml
+++ b/support/origins-starter-app/pom.xml
@@ -79,6 +79,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/support/testsupport/pom.xml
+++ b/support/testsupport/pom.xml
@@ -66,4 +66,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
Don't deploy JARs for `api-testsupport`, `origins-starter-app` or `testsupport` modules. 
