### PR TITLE
Fix inaccurate dependency declarations.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -58,6 +58,13 @@
         <version>${project.version}</version>
       </dependency>
 
+      <!-- Netty -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-all</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 </project>

--- a/components/api/pom.xml
+++ b/components/api/pom.xml
@@ -21,26 +21,10 @@
       <artifactId>netty-all</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>io.reactivex</groupId>
-      <artifactId>rxjava</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.reactivex</groupId>
-      <artifactId>rxjava-reactive-streams</artifactId>
-    </dependency>
-
     <!-- https://mvnrepository.com/artifact/io.projectreactor/reactor-core -->
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.projectreactor</groupId>
-      <artifactId>reactor-test</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -49,18 +33,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hdrhistogram</groupId>
-      <artifactId>HdrHistogram</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-healthchecks</artifactId>
     </dependency>
 
     <dependency>
@@ -103,7 +77,15 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
 
   </dependencies>
 

--- a/components/common/pom.xml
+++ b/components/common/pom.xml
@@ -26,6 +26,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-test</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -536,11 +536,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.0.1</version>
-        </plugin>
-        <plugin>
           <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-maven-plugin</artifactId>
           <version>${kotlin.version}</version>

--- a/support/api-testsupport/pom.xml
+++ b/support/api-testsupport/pom.xml
@@ -34,6 +34,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava-reactive-streams</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <exclusions>


### PR DESCRIPTION
Some submodule dependencies were not quite correct. The API module declared unnecessary dependencies, while few other modules didn't contain all required dependencies.
