### PR TITLE
Update jackson-databind version

### DIFF
--- a/plugin-examples/pom.xml
+++ b/plugin-examples/pom.xml
@@ -19,7 +19,7 @@
     <!-- Styx Version -->
     <styx.version>0.9-SNAPSHOT</styx.version>
     <rxjava.version>1.1.6</rxjava.version>
-    <jackson.version>2.9.7</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <!--Testing-->
     <testng.version>6.8</testng.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <!-- General Versions -->
     <guava.version>18.0</guava.version>
     <guice.version>3.0</guice.version>
-    <jackson.version>2.9.7</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <jackson.dataformat.version>2.5.1</jackson.dataformat.version>
     <jackson.module.scala.version>2.9.7</jackson.module.scala.version>
     <metrics.version>3.2.6</metrics.version>


### PR DESCRIPTION
In response to [alerts](https://github.com/HotelsDotCom/styx/network/alerts) telling us `Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.8 or later`.