### PR TITLE
Improve log message on plugin load fail/Decouple failure handling from task execution

### DIFF
--- a/components/common/src/main/java/com/hotels/styx/common/FailureHandlingStrategy.java
+++ b/components/common/src/main/java/com/hotels/styx/common/FailureHandlingStrategy.java
@@ -38,13 +38,13 @@ import static java.util.Objects.requireNonNull;
  * @param <T> input type
  * @param <R> output type
  */
-public class FailureHandlingTaskProcessor<T, R> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FailureHandlingTaskProcessor.class);
+public class FailureHandlingStrategy<T, R> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailureHandlingStrategy.class);
 
     private final BiConsumer<T, Exception> onEachFailure;
     private final Consumer<Map<T, Exception>> failuresPostProcessing;
 
-    private FailureHandlingTaskProcessor(Builder<T, R> builder) {
+    private FailureHandlingStrategy(Builder<T, R> builder) {
         this.onEachFailure = builder.onEachFailure;
         this.failuresPostProcessing = builder.failuresPostProcessing;
     }
@@ -77,7 +77,7 @@ public class FailureHandlingTaskProcessor<T, R> {
     }
 
     /**
-     * Builds {@link FailureHandlingTaskProcessor}.
+     * Builds {@link FailureHandlingStrategy}.
      *
      * @param <T> input type
      * @param <R> output type
@@ -115,12 +115,12 @@ public class FailureHandlingTaskProcessor<T, R> {
         }
 
         /**
-         * Build an instance of {@link FailureHandlingTaskProcessor} using the configuration provided.
+         * Build an instance of {@link FailureHandlingStrategy} using the configuration provided.
          *
          * @return a new instance
          */
-        public FailureHandlingTaskProcessor<T, R> build() {
-            return new FailureHandlingTaskProcessor<>(this);
+        public FailureHandlingStrategy<T, R> build() {
+            return new FailureHandlingStrategy<>(this);
         }
     }
 

--- a/components/common/src/main/java/com/hotels/styx/common/FailureHandlingTaskProcessor.java
+++ b/components/common/src/main/java/com/hotels/styx/common/FailureHandlingTaskProcessor.java
@@ -1,0 +1,144 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Allows various types of failure handling to be applied to a task running over a list of inputs.
+ *
+ * It can be as strict or lenient as desired - from failing the whole run immediately as soon as a single iteration fails,
+ * to just logging failures and returning successful results.
+ *
+ * The behaviour is configured by injecting lambdas when an instance of this class is built using the {@link Builder}.
+ *
+ * @param <T> input type
+ * @param <R> output type
+ */
+public class FailureHandlingTaskProcessor<T, R> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FailureHandlingTaskProcessor.class);
+
+    private final BiConsumer<T, Exception> onEachFailure;
+    private final Consumer<Map<T, Exception>> failuresPostProcessing;
+
+    private FailureHandlingTaskProcessor(Builder<T, R> builder) {
+        this.onEachFailure = builder.onEachFailure;
+        this.failuresPostProcessing = builder.failuresPostProcessing;
+    }
+
+    /**
+     * Execute the task on a list of inputs, using the configured failure handling.
+     *
+     * @param inputs a list of inputs
+     * @param task a task to execute
+     * @return a list of outputsl
+     */
+    public List<R> process(List<T> inputs, Task<T, R> task) {
+        List<R> successes = new ArrayList<>();
+        Map<T, Exception> failures = new LinkedHashMap<>();
+
+        inputs.forEach(input -> {
+            try {
+                successes.add(task.execute(input));
+            } catch (Exception t) {
+                onEachFailure.accept(input, t);
+                failures.put(input, t);
+            }
+        });
+
+        if (!failures.isEmpty()) {
+            failuresPostProcessing.accept(failures);
+        }
+
+        return successes;
+    }
+
+    /**
+     * Builds {@link FailureHandlingTaskProcessor}.
+     *
+     * @param <T> input type
+     * @param <R> output type
+     */
+    public static final class Builder<T, R> {
+        // Logs by default so that failures do not become invisible.
+        private BiConsumer<T, Exception> onEachFailure = (input, err) -> LOGGER.error("Failed on input " + input, err);
+        private Consumer<Map<T, Exception>> failuresPostProcessing = failures -> LOGGER.error("Failures: " + failures);
+
+        /**
+         * An action to take immediately after a failure. This can be used to fail fast by rethrowing the error,
+         * or to log the failure as soon as it happens without waiting.
+         *
+         * @param onEachFailure an action to take
+         * @return this builder
+         */
+        public Builder<T, R> doImmediatelyOnEachFailure(BiConsumer<T, Exception> onEachFailure) {
+            this.onEachFailure = requireNonNull(onEachFailure);
+            return this;
+        }
+
+        /**
+         * An action to take after processing all list items, if there were failures.
+         * This will only execute if the individual failures were did not rethrow their exceptions.
+         *
+         * This action may be used to throw an exception, otherwise the {@link #process(List, Task)} method
+         * will return whatever successful results it had (or an empty list if none).
+         *
+         * @param failuresPostProcessing an action to take
+         * @return this builder
+         */
+        public Builder<T, R> doOnFailuresAfterAllProcessing(Consumer<Map<T, Exception>> failuresPostProcessing) {
+            this.failuresPostProcessing = requireNonNull(failuresPostProcessing);
+            return this;
+        }
+
+        /**
+         * Build an instance of {@link FailureHandlingTaskProcessor} using the configuration provided.
+         *
+         * @return a new instance
+         */
+        public FailureHandlingTaskProcessor<T, R> build() {
+            return new FailureHandlingTaskProcessor<>(this);
+        }
+    }
+
+    /**
+     * A task to execute. Similar to {@link java.util.function.Function}, except it is allowed to throw any type of
+     * {@link Exception}.
+     *
+     * @param <T> input type
+     * @param <R> output type
+     */
+    public interface Task<T, R> {
+        /**
+         * Execute task.
+         *
+         * @param input input
+         * @return output
+         * @throws Exception if there is a failure
+         */
+        R execute(T input) throws Exception;
+    }
+}

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/PluginStartupException.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/PluginStartupException.java
@@ -1,0 +1,36 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.proxy.plugin;
+
+/**
+ * An exception thrown when plugins fail to start.
+ */
+public class PluginStartupException extends RuntimeException {
+    public PluginStartupException() {
+    }
+
+    public PluginStartupException(String message) {
+        super(message);
+    }
+
+    public PluginStartupException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PluginStartupException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/PluginSuppliers.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/PluginSuppliers.java
@@ -19,7 +19,7 @@ import com.hotels.styx.api.Environment;
 import com.hotels.styx.api.configuration.Configuration;
 import com.hotels.styx.api.plugins.spi.Plugin;
 import com.hotels.styx.api.plugins.spi.PluginFactory;
-import com.hotels.styx.common.FailureHandlingTaskProcessor;
+import com.hotels.styx.common.FailureHandlingStrategy;
 import com.hotels.styx.common.Pair;
 import com.hotels.styx.spi.config.SpiExtension;
 import org.slf4j.Logger;
@@ -46,8 +46,8 @@ public class PluginSuppliers {
     private final PluginFactoryLoader pluginFactoryLoader;
     private final Environment environment;
 
-    private final FailureHandlingTaskProcessor<Pair<String, SpiExtension>, NamedPlugin> processor =
-            new FailureHandlingTaskProcessor.Builder<Pair<String, SpiExtension>, NamedPlugin>()
+    private final FailureHandlingStrategy<Pair<String, SpiExtension>, NamedPlugin> processor =
+            new FailureHandlingStrategy.Builder<Pair<String, SpiExtension>, NamedPlugin>()
                     .doImmediatelyOnEachFailure((plugin, err) ->
                             LOG.error(perFailureErrorMessage(plugin), err))
                     .doOnFailuresAfterAllProcessing(failures -> {

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/PluginSuppliers.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/PluginSuppliers.java
@@ -46,14 +46,13 @@ public class PluginSuppliers {
     private final PluginFactoryLoader pluginFactoryLoader;
     private final Environment environment;
 
-    private final FailureHandlingStrategy<Pair<String, SpiExtension>, NamedPlugin> processor =
+    private final FailureHandlingStrategy<Pair<String, SpiExtension>, NamedPlugin> failureHandlingStrategy =
             new FailureHandlingStrategy.Builder<Pair<String, SpiExtension>, NamedPlugin>()
                     .doImmediatelyOnEachFailure((plugin, err) ->
                             LOG.error(perFailureErrorMessage(plugin), err))
                     .doOnFailuresAfterAllProcessing(failures -> {
                         throw new PluginStartupException(afterFailuresErrorMessage(failures));
-                    })
-                    .build();
+                    }).build();
 
     public PluginSuppliers(Environment environment) {
         this(environment, new FileSystemPluginFactoryLoader());
@@ -76,7 +75,7 @@ public class PluginSuppliers {
     }
 
     private Iterable<NamedPlugin> activePlugins(PluginsMetadata pluginsMetadata) {
-        return processor.process(pluginsMetadata.activePlugins(), this::loadPlugin);
+        return failureHandlingStrategy.process(pluginsMetadata.activePlugins(), this::loadPlugin);
     }
 
     private NamedPlugin loadPlugin(Pair<String, SpiExtension> pair) {

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/plugin/PluginSuppliersTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/plugin/PluginSuppliersTest.java
@@ -180,7 +180,7 @@ public class PluginSuppliersTest {
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp =
-            "1 plugin could not be loaded: \\[myPlugin\\]. Causes:\\[myPlugin: java.lang.RuntimeException: plugin factory error\\]")
+            "1 plugin could not be loaded: failedPlugins=\\[myPlugin\\]; failureCauses=\\[myPlugin: java.lang.RuntimeException: plugin factory error\\]")
     public void throwsExceptionIfFactoryFailsToLoadPlugin() {
         String yaml = "" +
                 "plugins:\n" +
@@ -197,7 +197,7 @@ public class PluginSuppliersTest {
     }
 
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp =
-            "3 plugins could not be loaded: \\[myPlugin1, myPlugin2, myPlugin3\\]. Causes:\\[" +
+            "3 plugins could not be loaded: failedPlugins=\\[myPlugin1, myPlugin2, myPlugin3\\]; failureCauses=\\[" +
                     "myPlugin1: java.lang.RuntimeException: plugin factory error, " +
                     "myPlugin2: java.lang.RuntimeException: plugin factory error, " +
                     "myPlugin3: java.lang.RuntimeException: plugin factory error\\]")
@@ -226,7 +226,7 @@ public class PluginSuppliersTest {
 
             pluginSuppliers.fromConfigurations();
         } catch (RuntimeException e) {
-            assertThat(log.log(), hasItem(loggingEvent(ERROR, "Could not load plugin myPlugin1.*", RuntimeException.class, "plugin factory error")));
+            assertThat(log.log(), hasItem(loggingEvent(ERROR, "Could not load plugin: pluginName=myPlugin1; factoryClass=.*", RuntimeException.class, "plugin factory error")));
             throw e;
         } finally {
             log.stop();

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/plugin/PluginSuppliersTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/plugin/PluginSuppliersTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@ package com.hotels.styx.proxy.plugin;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hotels.styx.api.Environment;
-import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.MetricRegistry;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.api.plugins.spi.Plugin;
 import com.hotels.styx.api.plugins.spi.PluginFactory;
-import com.hotels.styx.api.Eventual;
 import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig;
 import com.hotels.styx.support.api.SimpleEnvironment;
 import com.hotels.styx.support.matchers.LoggingTestSupport;
@@ -179,7 +179,8 @@ public class PluginSuppliersTest {
         pluginSuppliers.fromConfigurations();
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "1 plugins could not be loaded")
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp =
+            "1 plugin could not be loaded: \\[myPlugin\\]. Causes:\\[myPlugin: java.lang.RuntimeException: plugin factory error\\]")
     public void throwsExceptionIfFactoryFailsToLoadPlugin() {
         String yaml = "" +
                 "plugins:\n" +
@@ -195,7 +196,11 @@ public class PluginSuppliersTest {
         pluginSuppliers.fromConfigurations();
     }
 
-    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "3 plugins could not be loaded")
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp =
+            "3 plugins could not be loaded: \\[myPlugin1, myPlugin2, myPlugin3\\]. Causes:\\[" +
+                    "myPlugin1: java.lang.RuntimeException: plugin factory error, " +
+                    "myPlugin2: java.lang.RuntimeException: plugin factory error, " +
+                    "myPlugin3: java.lang.RuntimeException: plugin factory error\\]")
     public void attemptsToLoadAllPluginsEvenIfSomeFail() {
         LoggingTestSupport log = new LoggingTestSupport(PluginSuppliers.class);
 


### PR DESCRIPTION
This PR introduces a common class called `FailureHandlingStrategy` that can be used to decouple failure-handling logic from the logic of processing items in a list.

Demonstrating this decoupling are the changes in `PluginSuppliers`, which also fixes #372.

