### PR TITLE
Correct javadoc for PowerOfTwoStrategy.

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategy.java
@@ -32,11 +32,8 @@ import static java.util.Objects.requireNonNull;
 
 
 /**
- * A load balancing strategy that sorts origins according to three functions:
- * <p>
- * Whether they have below or above average 5xx errors.
- * The number of busy connections.
- * Whether they having existing connections available.
+ * A load balancing strategy that selects two hosts randomly and then chooses the host (of those two) with the least ongoing connections.
+ *
  */
 public class PowerOfTwoStrategy implements LoadBalancer {
     private final ActiveOrigins activeOrigins;

--- a/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategy.java
@@ -32,7 +32,7 @@ import static java.util.Objects.requireNonNull;
 
 
 /**
- * A load balancing strategy that selects two hosts randomly and then chooses the host (of those two) with the least ongoing connections.
+ * A load balancing strategy that selects two hosts randomly and chooses the one with fewer ongoing connections.
  *
  */
 public class PowerOfTwoStrategy implements LoadBalancer {


### PR DESCRIPTION
It seems that we copied the description from the BusyResourceStrategy class (that class has also evolved from then). 

Please use 'suggestions' to properly rewrite the description.