### PR TITLE
Improve Styx Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,6 @@ distribution/target/styx-1.0-SNAPSHOT-linux-x86_64.zip:
 docker-image: distribution/target/styx-1.0-SNAPSHOT-linux-x86_64.zip
 	rm -rf ${DOCKER_CONTEXT}
 	mkdir -p ${DOCKER_CONTEXT}
-	cp ${STYX_BUILD_ARTIFACT} ${DOCKER_CONTEXT}
+	cp ${STYX_BUILD_ARTIFACT} ${DOCKER_CONTEXT}/styx.zip
 	cp docker/* ${DOCKER_CONTEXT}
-	docker build -t styxcore:latest -f docker/Dockerfile ${DOCKER_CONTEXT}/.
+	docker build -t styxcore:latest --build-arg STYX_IMAGE=styx.zip -f docker/Dockerfile ${DOCKER_CONTEXT}/.

--- a/distribution/assembly/artifact.xml
+++ b/distribution/assembly/artifact.xml
@@ -10,7 +10,7 @@
     <format>tar.gz</format>
   </formats>
 
-  <baseDirectory>styx-${project.version}</baseDirectory>
+  <baseDirectory>styx</baseDirectory>
 
   <!-- Include NOTICE and version txt -->
   <files>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,10 @@
 FROM openjdk:11-jre-slim
 
+ARG STYX_VERSION=""
+ARG STYX_IMAGE=https://github.com/HotelsDotCom/styx/releases/download/${STYX_VERSION}/${STYX_VERSION}-linux-x86_64.zip
+
 ENV APP_HOME=/styx
-ENV BASENAME=styx-1.0.0.beta3
+
 ENV STYX_CONFIG=/styx/default-config/default.yml
 ENV STYX_LOG_CONFIG=/styx/styx/conf/logback.xml
 ENV STYX_ENV_FILE=/styx/default-config/styx-env.sh
@@ -9,13 +12,12 @@ ENV STYX_LOG_OUTPUT=/styx/logs/
 
 WORKDIR ${APP_HOME}
 
-ADD https://github.com/HotelsDotCom/styx/releases/download/${BASENAME}/${BASENAME}-linux-x86_64.zip ${APP_HOME}/styx.zip
+ADD ${STYX_IMAGE} ${APP_HOME}/styx.zip
 ADD default-docker.yml /styx/default-config/default.yml
 ADD styx-env.sh /styx/default-config/styx-env.sh
 ADD origins.yml /styx/default-config/origins.yml
 
 RUN unzip styx.zip \
-    && mv ${BASENAME} styx \
     && rm styx.zip
 
 EXPOSE 8080 8443 9000

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,7 @@ To build Styx Docker image, run `make docker-image` from the Styx project root:
 
 To run the resulting Styx Docker image:
 
-    $ docker container run -d --name myStyx -p 8000:8080 -p 9000:9000 -p 8443:8443styxcore:latest
+    $ docker container run -d --name myStyx -p 8000:8080 -p 9000:9000 -p 8443:8443 styxcore:latest
 
 ## Configuration
 
@@ -31,7 +31,8 @@ Ensure the the Styx configuration reads the origins from `/styx/config/` directo
 
 Finally, start the Styx Docker image using `/styx/config/styxconf.yml` as a configuration file:        
 
-    docker container run -d --name myStyx \
-        -p 8080:8080 -p 9000:9000 -p 8443:8443
+    docker container run -d  \
+        -p 8080:8080 -p 9000:9000 -p 8443:8443 \
         -v $(pwd)/myConfig:/styx/config \
+        -v $(pwd)/styxLogs:/styx/logs \
         styxcore:latest /styx/config/styxconf.yml

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,7 @@ To build Styx Docker image, run `make docker-image` from the Styx project root:
 
 To run the resulting Styx Docker image:
 
-    $ docker container run -d --name myStyx -p 8000:8080 -p 9000:9000 -p 8443:8443 styxcore:latest
+    $ docker container run -d --name myStyx --rm -p 8000:8080 -p 9000:9000 -p 8443:8443 styxcore:latest
 
 ## Configuration
 
@@ -31,7 +31,7 @@ Ensure the the Styx configuration reads the origins from `/styx/config/` directo
 
 Finally, start the Styx Docker image using `/styx/config/styxconf.yml` as a configuration file:        
 
-    docker container run -d  \
+    docker container run -d --name myStyx --rm \
         -p 8080:8080 -p 9000:9000 -p 8443:8443 \
         -v $(pwd)/myConfig:/styx/config \
         -v $(pwd)/styxLogs:/styx/logs \

--- a/docker/origins.yml
+++ b/docker/origins.yml
@@ -2,6 +2,9 @@
 ---
 - id: "app"
   path: "/"
+  healthCheck:
+    uri: "/"
+    intervalMillis: 5000
   connectionPool:
     maxConnectionsPerHost: 45
     maxPendingConnectionsPerHost: 15


### PR DESCRIPTION
Generify Dockerfile so that it can be used for building both development images and official Styx release images.

**This change also removes the release version number from Styx assembly base directory.**
That is the top-level directory in a Styx release zip file. The version number in the base directory is pointless because it is in the release zip file anyway, and it unnecessarily complicates the Dockerfile and possibly other release scripts.
