### PR TITLE
Upgrade checkstyle to version 8.18

### DIFF
--- a/codequality/checkstyle_rules.xml
+++ b/codequality/checkstyle_rules.xml
@@ -3,16 +3,15 @@
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
   <property name="severity" value="warning"/>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="CHECKSTYLE\:OFF"/>
-    <property name="onCommentFormat" value="CHECKSTYLE\:ON"/>
-  </module>
   <module name="SuppressionFilter">
     <property name="file" value="${checkstyle.suppressions.file}"/>
   </module>
   <module name="TreeWalker">
     <property name="tabWidth" value="4"/>
-    <module name="FileContentsHolder"/>
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE\:OFF"/>
+      <property name="onCommentFormat" value="CHECKSTYLE\:ON"/>
+    </module>
     <module name="JavadocMethod">
       <property name="scope" value="protected"/>
       <property name="allowUndeclaredRTE" value="true"/>

--- a/components/api/src/main/java/com/hotels/styx/api/FormData.java
+++ b/components/api/src/main/java/com/hotels/styx/api/FormData.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public final class FormData {
                 .stream()
                 .filter(data -> data instanceof Attribute)
                 .map(data -> (Attribute) data)
-                .collect(toMap(Attribute::getName, (Function<Attribute, String>) (attribute) -> {
+                .collect(toMap(Attribute::getName, (Function<Attribute, String>) attribute -> {
                     try {
                         return attribute.getValue();
                     } catch (IOException e) {

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpRequest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/common/src/main/java/com/hotels/styx/api/Requests.java
+++ b/components/common/src/main/java/com/hotels/styx/api/Requests.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -70,11 +70,11 @@ public final class Requests {
     }
 
     private static Consumer<Optional<Throwable>> ifError(Consumer<Throwable> action) {
-        return (maybeCause) -> maybeCause.ifPresent(action);
+        return maybeCause -> maybeCause.ifPresent(action);
     }
 
     private static Consumer<Optional<Throwable>> ifSuccessful(Runnable action) {
-        return (maybeCause) -> {
+        return maybeCause -> {
             if (!maybeCause.isPresent()) {
                 action.run();
             }

--- a/components/common/src/main/java/com/hotels/styx/config/schema/Schema.java
+++ b/components/common/src/main/java/com/hotels/styx/config/schema/Schema.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -323,7 +323,7 @@ public class Schema {
                     .filter(field -> field.name().equals(name))
                     .map(Field::name)
                     .findFirst()
-                    .ifPresent((x) -> {
+                    .ifPresent(x -> {
                         throw new InvalidSchemaException(format("Duplicate field name '%s' in schema '%s'", name, this.name));
                     });
         }

--- a/components/common/src/main/java/com/hotels/styx/config/validator/DocumentFormat.java
+++ b/components/common/src/main/java/com/hotels/styx/config/validator/DocumentFormat.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -193,7 +193,7 @@ public class DocumentFormat {
     private static void assertNoUnknownFields(String prefix, Schema schema, List<String> fieldsPresent) {
         Set<String> knownFields = ImmutableSet.copyOf(schema.fieldNames());
 
-        fieldsPresent.forEach((name) -> {
+        fieldsPresent.forEach(name -> {
             if (!knownFields.contains(name)) {
                 throw new SchemaValidationException(format("Unexpected field: '%s'", prefix + name));
             }

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <!-- apache plugin versions and configurations, please sort alphabetically -->
     <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
-    <maven-checkstyle-plugin.version>2.16</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
@@ -1109,7 +1109,7 @@
               <dependency>
                 <groupId>com.puppycrawl.tools</groupId>
                 <artifactId>checkstyle</artifactId>
-                <version>6.9</version>
+                <version>8.18</version>
               </dependency>
             </dependencies>
             <configuration>


### PR DESCRIPTION
GitHub automated scan flagged up a potential security vulnerability in checkstyle library (https://nvd.nist.gov/vuln/detail/CVE-2019-9658).

Upgrade checkstyle to version 8.18 and maven-checkstyle plugin to 3.0.0 to rectify this issue.
