### PR TITLE
Make small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,6 @@ CONFIG_ROOT := $(STYX_HOME)/conf/env-$(STACK)
 ## Compile and create styx.zip then unzip into a directory defined by STYX_HOME
 release-styx: release-no-tests
 	unzip -oq ${STYX_BUILD_ARTIFACT} -d $(dir ${STYX_HOME})
-	mv `find $(CURRENT_DIR)/distribution/target/styx -type d -name "styx-*"` ${STYX_HOME}
 
 ## Stops running netty-based origins (i.e. the origins started by start-origins)
 stop-origins:

--- a/codequality/checkstyle_rules.xml
+++ b/codequality/checkstyle_rules.xml
@@ -68,7 +68,6 @@
     </module>
     <module name="MethodLength">
       <property name="max" value="40"/>
-      <property name="id" value="MethodLength_Warning"/>
     </module>
     <module name="MethodLength">
       <property name="max" value="50"/>
@@ -76,21 +75,17 @@
     <module name="MethodLength">
       <property name="severity" value="error"/>
       <property name="max" value="70"/>
-      <property name="id" value="MethodLength_Error"/>
     </module>
     <module name="ParameterNumber">
       <property name="max" value="4"/>
-      <property name="id" value="ParameterNumber_Warning"/>
     </module>
     <module name="ParameterNumber">
       <property name="severity" value="error"/>
       <property name="max" value="7"/>
-      <property name="id" value="ParameterNumber_Error"/>
     </module>
     <module name="ParameterNumber">
       <property name="severity" value="error"/>
       <property name="max" value="7"/>
-      <property name="id" value="ParameterNumber_Severe_Error"/>
     </module>
     <module name="EmptyForIteratorPad">
       <property name="severity" value="error"/>
@@ -179,7 +174,6 @@
     <module name="CyclomaticComplexity">
       <property name="severity" value="error"/>
       <property name="max" value="15"/>
-      <property name="id" value="CyclomaticComplexity_Error"/>
     </module>
     <module name="BooleanExpressionComplexity">
       <property name="max" value="5"/>
@@ -188,7 +182,6 @@
     <module name="ClassFanOutComplexity">
       <property name="severity" value="error"/>
       <property name="max" value="75"/>
-      <property name="id" value="ClassFanOutComplexity_Error"/>
     </module>
     <module name="NPathComplexity">
       <property name="max" value="100"/>
@@ -196,7 +189,6 @@
     <module name="NPathComplexity">
       <property name="severity" value="error"/>
       <property name="max" value="200"/>
-      <property name="id" value="NPathComplexity_Error"/>
     </module>
     <module name="FallThrough"/>
     <module name="DeclarationOrder">
@@ -228,10 +220,6 @@
     <module name="UnnecessaryParentheses">
       <property name="severity" value="error"/>
     </module>
-    <!--<module name="Indentation">-->
-    <!--<property name="severity" value="error" />-->
-    <!--<property name="caseIndent" value="4" />-->
-    <!--</module>-->
     <module name="ExplicitInitialization">
       <property name="severity" value="error"/>
     </module>
@@ -292,7 +280,6 @@
     <module name="AnonInnerLength">
       <property name="severity" value="error"/>
       <property name="max" value="100"/>
-      <property name="id" value="AnonInnerLength_Error"/>
     </module>
     <module name="AnnotationUseStyle">
       <property name="severity" value="error"/>
@@ -304,7 +291,6 @@
     <module name="ClassDataAbstractionCoupling"/>
     <module name="ClassDataAbstractionCoupling">
       <property name="max" value="15"/>
-      <property name="id" value="ClassDataAbstractionCoupling_Error"/>
     </module>
     <module name="InnerTypeLast">
       <property name="severity" value="error"/>
@@ -321,17 +307,14 @@
     <module name="MethodCount">
       <property name="severity" value="error"/>
       <property name="maxTotal" value="50"/>
-      <property name="id" value="MethodCountTotal_Error"/>
     </module>
     <module name="MethodCount">
       <property name="severity" value="error"/>
       <property name="maxProtected" value="20"/>
-      <property name="id" value="MethodCountProtected_Error"/>
     </module>
     <module name="MethodCount">
       <property name="severity" value="error"/>
       <property name="maxPackage" value="20"/>
-      <property name="id" value="MethodCountPrivate_Error"/>
     </module>
     <module name="OneStatementPerLine">
       <property name="severity" value="error"/>
@@ -354,39 +337,33 @@
     <property name="severity" value="error"/>
     <property name="format" value="\s+$"/>
     <property name="message" value="Line has trailing spaces"/>
-    <property name="id" value="TrailingSpaces_Error"/>
   </module>
   <module name="RegexpSingleline">
     <property name="severity" value="error"/>
     <property name="format"
               value="\.exit\(|\.halt\(|\.traceMethodCalls\(|\.traceInstructions\(|\.runFinalization\(|\.gc\("/>
     <property name="message" value="Suspicious invocation of dangerous JVM level operation"/>
-    <property name="id" value="DangerousJVMOperation_Error"/>
   </module>
   <module name="RegexpSingleline">
     <property name="severity" value="error"/>
     <property name="format" value="long serialVersionUID"/>
     <property name="message" value="Do not declare a serialVersionUID"/>
-    <property name="id" value="SerialVersionUIDDeclared_Error"/>
   </module>
   <module name="RegexpSingleline">
     <property name="severity" value="error"/>
     <property name="format"
               value="\.printStackTrace\(\)|System\.out|System\.err|org\.apache\.commons\.logging\.Log|java\.util\.logging"/>
     <property name="message" value="use SLF4J for logging"/>
-    <property name="id" value="InvalidLoggingMethod_Error"/>
   </module>
   <module name="RegexpSingleline">
     <property name="severity" value="error"/>
     <property name="format"
               value="org.springframework.web.util.JavaScriptUtils|org.springframework.web.util.HtmlUtils|org.apache.commons.lang.StringEscapeUtils|org.\apache.\commons.\codec|org\.owasp\.esapi"/>
     <property name="message" value="use EncodingSupport for encoding"/>
-    <property name="id" value="BannedEncodingLibraryReference_Error"/>
   </module>
   <module name="RegexpSingleline">
     <property name="severity" value="error"/>
     <property name="format" value="null !=|null =="/>
     <property name="message" value="Check for null in reverse order"/>
-    <property name="id" value="ReverseOrderNullCheck_Error"/>
   </module>
 </module>

--- a/codequality/checkstyle_suppressions.xml
+++ b/codequality/checkstyle_suppressions.xml
@@ -37,7 +37,7 @@
 
   <suppress checks="ParameterNumber" files=".*StartupConfig.java|.*ProxyServiceSupplier.java"/>
 
-  <suppress checks="RegexpSingleline" id="InvalidLoggingMethod_Error" files="LOGBackConfigurer.java"/>
+  <suppress checks="RegexpSingleline" files="LOGBackConfigurer.java"/>
 
   <suppress checks="VisibilityModifier" files=".*.java"/>
 

--- a/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategy.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/distribution/conf/default.yml
+++ b/distribution/conf/default.yml
@@ -88,6 +88,8 @@ url:
 
 #originRestrictionCookie: yourCookieNameHere
 
+### Uncomment the config below to test out Styx's plugin feature:
+#
 #plugins:
 #  active: demo
 #  all:

--- a/distribution/conf/default.yml
+++ b/distribution/conf/default.yml
@@ -88,15 +88,14 @@ url:
 
 #originRestrictionCookie: yourCookieNameHere
 
-# TODO comment out before raising PR
-plugins:
-  active: demo
-  all:
-    demo:
-      factory:
-        class: "com.hotels.styx.startup.extensions.DemoPlugin$Factory"
-        classPath: "${STYX_HOME:}"
-      config:
-        adminText: "this is the admin page"
-        responseHeaderValue: "this is the response header value"
+#plugins:
+#  active: demo
+#  all:
+#    demo:
+#      factory:
+#        class: "com.hotels.styx.startup.extensions.DemoPlugin$Factory"
+#        classPath: "${STYX_HOME:}"
+#      config:
+#        adminText: "this is the admin page"
+#        responseHeaderValue: "this is the response header value"
 

--- a/docker/styx-env.sh
+++ b/docker/styx-env.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+#
+# Copyright (C) 2013-2019 Expedia Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 
 # Styx JVM startup parameters
 #


### PR DESCRIPTION
* `Makefile`: `make start` was failing, this fixes that
* `checkstyle_rules.xml`: the `id` elements were totally unnecessary and now violate the expected format of the file
* `checkstyle_suppressions.xml`: suppression was not being used, fixed
* `default.yaml`: something left in from a previous commit, should be commented

There are also some changes that got automatically done to the copyright notices.