### PR TITLE
Service cleanup

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -199,13 +199,7 @@ public final class StyxServer extends AbstractService {
     protected void doStart() {
         printBanner();
         this.serviceManager.addListener(new ServerStartListener(this));
-        this.serviceManager.startAsync().awaitHealthy();
-
-        if (stopwatch == null) {
-            LOG.info("Started Styx server");
-        } else {
-            LOG.info("Started Styx server in {} ms", stopwatch.elapsed(MILLISECONDS));
-        }
+        this.serviceManager.startAsync();
     }
 
     private void printBanner() {
@@ -255,7 +249,7 @@ public final class StyxServer extends AbstractService {
                 .build();
     }
 
-    private static class ServerStartListener extends ServiceManager.Listener {
+    private class ServerStartListener extends ServiceManager.Listener {
         private final StyxServer styxServer;
 
         ServerStartListener(StyxServer styxServer) {
@@ -265,6 +259,12 @@ public final class StyxServer extends AbstractService {
         @Override
         public void healthy() {
             styxServer.notifyStarted();
+
+            if (stopwatch == null) {
+                LOG.info("Started Styx server");
+            } else {
+                LOG.info("Started Styx server in {} ms", stopwatch.elapsed(MILLISECONDS));
+            }
         }
 
         @Override

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -94,9 +94,16 @@ public class AdminServerBuilder {
     public HttpServer build() {
         LOG.info("event bus that will be used is {}", environment.eventBus());
         StyxConfig styxConfig = environment.configuration();
-
-        Optional<Duration> metricsCacheExpiration = styxConfig.adminServerConfig().metricsCacheExpiration();
         AdminServerConfig adminServerConfig = styxConfig.adminServerConfig();
+
+        return new NettyServerBuilderSpec("Admin", environment.serverEnvironment(), new WebServerConnectorFactory())
+                .toNettyServerBuilder(adminServerConfig)
+                .handlerFactory(() -> createHttpRouter(styxConfig))
+                .build();
+    }
+
+    private StandardHttpRouter createHttpRouter(StyxConfig styxConfig) {
+        Optional<Duration> metricsCacheExpiration = styxConfig.adminServerConfig().metricsCacheExpiration();
 
         StandardHttpRouter httpRouter = new StandardHttpRouter();
         httpRouter.add("/", new IndexHandler(indexLinkPaths()));
@@ -135,12 +142,7 @@ public class AdminServerBuilder {
                 });
 
         httpRouter.add("/admin/plugins", new PluginListHandler(environment.configStore()));
-
-        return new NettyServerBuilderSpec("Admin", environment.serverEnvironment(), new WebServerConnectorFactory())
-                .toNettyServerBuilder(adminServerConfig)
-                // TODO extract rather than create httpRouter upfront
-                .handlerFactory(() -> httpRouter)
-                .build();
+        return httpRouter;
     }
 
     private JsonHandler<DashboardData> dashboardDataHandler(StyxConfig styxConfig) {

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -98,11 +98,11 @@ public class AdminServerBuilder {
 
         return new NettyServerBuilderSpec("Admin", environment.serverEnvironment(), new WebServerConnectorFactory())
                 .toNettyServerBuilder(adminServerConfig)
-                .handlerFactory(() -> createHttpRouter(styxConfig))
+                .handlerFactory(() -> adminEndpoints(styxConfig))
                 .build();
     }
 
-    private StandardHttpRouter createHttpRouter(StyxConfig styxConfig) {
+    private StandardHttpRouter adminEndpoints(StyxConfig styxConfig) {
         Optional<Duration> metricsCacheExpiration = styxConfig.adminServerConfig().metricsCacheExpiration();
 
         StandardHttpRouter httpRouter = new StandardHttpRouter();

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -138,7 +138,8 @@ public class AdminServerBuilder {
 
         return new NettyServerBuilderSpec("Admin", environment.serverEnvironment(), new WebServerConnectorFactory())
                 .toNettyServerBuilder(adminServerConfig)
-                .httpHandler(httpRouter)
+                // TODO extract rather than create httpRouter upfront
+                .handlerFactory(() -> httpRouter)
                 .build();
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyServerBuilder.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.server.HttpServer;
 import com.hotels.styx.server.netty.NettyServerBuilderSpec;
 
+import java.util.function.Supplier;
+
 import static com.hotels.styx.proxy.encoders.ConfigurableUnwiseCharsEncoder.ENCODE_UNWISECHARS;
 import static java.util.Objects.requireNonNull;
 
@@ -33,7 +35,7 @@ public final class ProxyServerBuilder {
     private final ResponseInfoFormat responseInfoFormat;
     private final CharSequence styxInfoHeaderName;
 
-    private HttpHandler httpHandler;
+    private Supplier<HttpHandler> handlerFactory;
     private Runnable onStartupAction = () -> {
     };
 
@@ -51,7 +53,7 @@ public final class ProxyServerBuilder {
         return new NettyServerBuilderSpec("Proxy", environment.serverEnvironment(),
                 new ProxyConnectorFactory(proxyConfig, environment.metricRegistry(), environment.errorListener(), unwiseCharacters, this::addInfoHeader, requestTracking))
                 .toNettyServerBuilder(proxyConfig)
-                .httpHandler(httpHandler)
+                .handlerFactory(handlerFactory)
                 // register health check
                 .doOnStartUp(onStartupAction)
                 .build();
@@ -61,8 +63,8 @@ public final class ProxyServerBuilder {
         return responseBuilder.header(styxInfoHeaderName, responseInfoFormat.format(request));
     }
 
-    public ProxyServerBuilder httpHandler(HttpHandler httpHandler) {
-        this.httpHandler = httpHandler;
+    public ProxyServerBuilder handlerFactory(Supplier<HttpHandler> handlerFactory) {
+        this.handlerFactory = handlerFactory;
         return this;
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/startup/ProxyServerSetUp.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/ProxyServerSetUp.java
@@ -43,6 +43,7 @@ public final class ProxyServerSetUp {
         HttpHandler pipeline = pipelineFactory.create(config);
 
         HttpServer proxyServer = new ProxyServerBuilder(config.environment())
+                // TODO create pipeline at startup instead of here
                 .httpHandler(pipeline)
                 .onStartup(() -> initialisePlugins(config.plugins()))
                 .build();

--- a/components/proxy/src/main/java/com/hotels/styx/startup/ProxyServerSetUp.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/ProxyServerSetUp.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.startup;
 
 import com.google.common.util.concurrent.Service;
-import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.proxy.ProxyServerBuilder;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
 import com.hotels.styx.server.HttpServer;
@@ -40,11 +39,8 @@ public final class ProxyServerSetUp {
     }
 
     public HttpServer createProxyServer(StyxServerComponents config) {
-        HttpHandler pipeline = pipelineFactory.create(config);
-
         HttpServer proxyServer = new ProxyServerBuilder(config.environment())
-                // TODO create pipeline at startup instead of here
-                .httpHandler(pipeline)
+                .handlerFactory(() -> pipelineFactory.create(config))
                 .onStartup(() -> initialisePlugins(config.plugins()))
                 .build();
 

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/StyxProxyTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/StyxProxyTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class StyxProxyTest extends SSLSetup {
 
         HttpServer server = NettyServerBuilder.newBuilder()
                 .setHttpConnector(connector(0))
-                .httpHandler(new HttpInterceptorPipeline(ImmutableList.of(echoInterceptor), new StandardHttpRouter(), false))
+                .handlerFactory(() -> new HttpInterceptorPipeline(ImmutableList.of(echoInterceptor), new StandardHttpRouter(), false))
                 .build();
         server.startAsync().awaitRunning();
         assertThat("Server should be running", server.isRunning());

--- a/components/server/src/main/java/com/hotels/styx/server/HttpServers.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpServers.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -28,13 +28,12 @@ public class HttpServers {
      *
      * @param port
      * @return {@link com.hotels.styx.server.HttpServer} object
-     * @see com.hotels.styx.server.netty.NettyServer
      */
     public static HttpServer createHttpServer(int port, HttpHandler handler) {
         return NettyServerBuilder.newBuilder()
                 .name("NettyServer")
                 .setHttpConnector(new WebServerConnectorFactory().create(new HttpConnectorConfig(port)))
-                .httpHandler(new StandardHttpRouter().add("/", handler))
+                .handlerFactory(() -> new StandardHttpRouter().add("/", handler))
                 .build();
     }
 
@@ -46,13 +45,12 @@ public class HttpServers {
      * @param handler - Request handler.
      *
      * @return {@link com.hotels.styx.server.HttpServer} object
-     * @see com.hotels.styx.server.netty.NettyServer
      */
     public static HttpServer createHttpServer(String name, HttpConnectorConfig httpConnectorConfig, HttpHandler handler) {
         return NettyServerBuilder.newBuilder()
                 .name(name)
                 .setHttpConnector(new WebServerConnectorFactory().create(httpConnectorConfig))
-                .httpHandler(handler)
+                .handlerFactory(() -> handler)
                 .build();
     }
 
@@ -64,13 +62,12 @@ public class HttpServers {
      * @param handler - Request handler.
      *
      * @return {@link com.hotels.styx.server.HttpServer} object
-     * @see com.hotels.styx.server.netty.NettyServer
      */
     public static HttpServer createHttpsServer(String name, HttpsConnectorConfig httpsConnectorConfig, HttpHandler handler) {
         return NettyServerBuilder.newBuilder()
                 .name(name)
                 .setHttpsConnector(new WebServerConnectorFactory().create(httpsConnectorConfig))
-                .httpHandler(handler)
+                .handlerFactory(() -> handler)
                 .build();
     }
 

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
@@ -38,6 +38,7 @@ import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -66,17 +67,18 @@ final class NettyServer extends AbstractService implements HttpServer {
     private final Optional<ServerConnector> httpsConnector;
 
     private final Iterable<Runnable> startupActions;
-    private final HttpHandler httpHandler;
+    private final Supplier<HttpHandler> handlerFactory;
     private final ServerSocketBinder httpServerSocketBinder;
     private final ServerSocketBinder httpsServerSocketBinder;
 
-    private Callable<?> stopper;
+    private volatile Callable<?> stopper;
+    private volatile HttpHandler httpHandler;
 
     NettyServer(NettyServerBuilder nettyServerBuilder) {
         this.host = nettyServerBuilder.host();
         this.channelGroup = requireNonNull(nettyServerBuilder.channelGroup());
         this.serverEventLoopFactory = requireNonNull(nettyServerBuilder.serverEventLoopFactory(), "serverEventLoopFactory cannot be null");
-        this.httpHandler = requireNonNull(nettyServerBuilder.httpHandler());
+        this.handlerFactory = requireNonNull(nettyServerBuilder.handlerFactory());
 
         this.httpConnector = nettyServerBuilder.httpConnector();
         this.httpsConnector = nettyServerBuilder.httpsConnector();
@@ -117,6 +119,8 @@ final class NettyServer extends AbstractService implements HttpServer {
                 return;
             }
         }
+
+        httpHandler = NettyServer.this.handlerFactory.get();
 
         ServiceManager serviceManager = new ServiceManager(
                 Stream.of(httpServerSocketBinder, httpsServerSocketBinder)
@@ -250,7 +254,7 @@ final class NettyServer extends AbstractService implements HttpServer {
             }
 
             @Override
-            public Void call() throws Exception {
+            public Void call() {
                 channelGroup.close().awaitUninterruptibly();
                 shutdownEventExecutorGroup(bossGroup);
                 shutdownEventExecutorGroup(workerGroup);

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -125,12 +125,13 @@ final class NettyServer extends AbstractService implements HttpServer {
         );
 
         serviceManager.addListener(new ServerListener(this));
-        serviceManager.startAsync().awaitHealthy();
 
         this.stopper = () -> {
-            serviceManager.stopAsync().awaitStopped();
+            serviceManager.stopAsync();
             return null;
         };
+
+        serviceManager.startAsync();
     }
 
     @Override

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerBuilder.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerBuilder.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Objects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -49,7 +50,7 @@ public final class NettyServerBuilder {
     private Optional<ServerConnector> httpConnector = Optional.empty();
     private Optional<ServerConnector> httpsConnector = Optional.empty();
     private final List<Runnable> startupActions = newCopyOnWriteArrayList();
-    private HttpHandler httpHandler = (request, context) -> Eventual.of(LiveHttpResponse.response(NOT_FOUND).build());
+    private Supplier<HttpHandler> handlerFactory = () -> (request, context) -> Eventual.of(LiveHttpResponse.response(NOT_FOUND).build());
 
     public static NettyServerBuilder newBuilder() {
         return new NettyServerBuilder();
@@ -91,13 +92,13 @@ public final class NettyServerBuilder {
         return this.channelGroup;
     }
 
-    public NettyServerBuilder httpHandler(HttpHandler httpHandler) {
-        this.httpHandler = httpHandler;
+    public NettyServerBuilder handlerFactory(Supplier<HttpHandler> handlerFactory) {
+        this.handlerFactory = handlerFactory;
         return this;
     }
 
-    HttpHandler httpHandler() {
-        return this.httpHandler;
+    Supplier<HttpHandler> handlerFactory() {
+        return this.handlerFactory;
     }
 
     public NettyServerBuilder setHttpConnector(ServerConnector connector) {

--- a/support/origins-starter-app/src/main/java/com/hotels/styx/support/origins/StyxOriginsStarterApp.java
+++ b/support/origins-starter-app/src/main/java/com/hotels/styx/support/origins/StyxOriginsStarterApp.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public class StyxOriginsStarterApp {
                 .name(origin.hostAndPortString())
                 .setServerEventLoopFactory(serverEventLoopFactory)
                 .setHttpConnector(new WebServerConnectorFactory().create(new HttpConnectorConfig(origin.port())))
-                .httpHandler(new StandardHttpRouter().add("/*", new AppHandler(origin)))
+                .handlerFactory(() -> new StandardHttpRouter().add("/*", new AppHandler(origin)))
                 .build();
     }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/MockServer.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/MockServer.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ class MockServer(id: String, val port: Int) extends AbstractIdleService with Htt
   val server = NettyServerBuilder.newBuilder()
       .name("MockServer")
       .setHttpConnector(new WebServerConnectorFactory().create(new HttpConnectorConfig(port)))
-      .httpHandler(router)
+      .handlerFactory(() => router)
     .build()
 
   def takeRequest(): LiveHttpRequest = {


### PR DESCRIPTION
This was branched from #389 so please review/merge that one first, or you will see the changes from both branches at once.

This PR fixes two types of problems with our `NettyServer` and `StyxServer` classes, with respect to behaving as services:

1. Previously, the `NettyServer` instances (proxy and admin) are doing some of the start-up before the service is actually `STARTING` (i.e. construction time or before). We move it to the correct location.
2. Some of the start/stop methods are blocking on child services when they are supposed to provide async functionality.