### PR TITLE
Fix URL parsing issue (#391)

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/Url.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Url.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public final class Url implements Comparable<Url> {
      * @return scheme
      */
     public String scheme() {
-        return this.scheme;
+        return this.scheme != null ? this.scheme : "";
     }
 
     /**
@@ -121,7 +121,7 @@ public final class Url implements Comparable<Url> {
      * @return true if the URL is absolute.
      */
     public boolean isAbsolute() {
-        return path.startsWith("/");
+        return Objects.nonNull(scheme) && !scheme.isEmpty();
     }
 
     /**
@@ -131,7 +131,7 @@ public final class Url implements Comparable<Url> {
      * @see {@link #isAbsolute()}
      */
     public boolean isRelative() {
-        return !isAbsolute();
+        return scheme == null || scheme.isEmpty();
     }
 
     /**
@@ -455,7 +455,7 @@ public final class Url implements Comparable<Url> {
                     .fragment(uri.getFragment());
         }
 
-        Builder rawQuery(String rawQuery) {
+        public Builder rawQuery(String rawQuery) {
             this.queryBuilder = rawQuery == null ? null : new UrlQuery.Builder(rawQuery);
             return this;
         }

--- a/components/api/src/test/java/com/hotels/styx/api/UrlTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/UrlTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -192,13 +192,13 @@ public class UrlTest {
     public void identifiesCorrectlyIfUrlIsFullyQualified() throws Exception {
         Url fqUrl = url("http://example.com").build();
         assertThat(fqUrl.isFullyQualified(), is(true));
-        assertThat(fqUrl.isAbsolute(), is(false));
-        assertThat(fqUrl.isRelative(), is(true));
+        assertThat(fqUrl.isAbsolute(), is(true));
+        assertThat(fqUrl.isRelative(), is(false));
 
         Url nonFqUrl = url("/somepath").build();
         assertThat(nonFqUrl.isFullyQualified(), is(false));
-        assertThat(nonFqUrl.isAbsolute(), is(true));
-        assertThat(nonFqUrl.isRelative(), is(false));
+        assertThat(nonFqUrl.isAbsolute(), is(false));
+        assertThat(nonFqUrl.isRelative(), is(true));
     }
 
     @Test

--- a/components/server/src/main/java/com/hotels/styx/server/netty/codec/UrlDecoder.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/codec/UrlDecoder.java
@@ -1,0 +1,44 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.server.netty.codec;
+
+import com.hotels.styx.api.Url;
+import io.netty.handler.codec.http.HttpRequest;
+
+import java.net.URI;
+
+import static com.hotels.styx.api.HttpHeaderNames.HOST;
+import static com.hotels.styx.api.Url.Builder.url;
+
+final class UrlDecoder {
+    private UrlDecoder() {
+    }
+
+    static Url decodeUrl(UnwiseCharsEncoder unwiseCharEncoder, HttpRequest request) {
+        String host = request.headers().get(HOST);
+
+        if (request.uri().startsWith("/") && host != null) {
+            URI uri = URI.create("http://" + host + unwiseCharEncoder.encode(request.uri()));
+            return new Url.Builder()
+                    .path(uri.getRawPath())
+                    .rawQuery(uri.getRawQuery())
+                    .fragment(uri.getFragment())
+                    .build();
+        } else {
+            return url(unwiseCharEncoder.encode(request.uri())).build();
+        }
+    }
+}

--- a/components/server/src/test/java/com/hotels/styx/server/netty/codec/NettyToStyxRequestDecoderTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/codec/NettyToStyxRequestDecoderTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2018 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -47,7 +47,6 @@ import rx.observers.TestSubscriber;
 
 import java.net.URI;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.base.Charsets.US_ASCII;
 import static com.google.common.base.Charsets.UTF_8;
@@ -70,7 +69,9 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static io.netty.handler.codec.http.LastHttpContent.EMPTY_LAST_CONTENT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.testng.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static rx.RxReactiveStreams.toObservable;
 
 public class NettyToStyxRequestDecoderTest {
@@ -220,24 +221,18 @@ public class NettyToStyxRequestDecoderTest {
     }
 
     @Test
-    public void callsTheEscaperForUnwiseChars() throws Exception {
-        AtomicBoolean encoderCalled = new AtomicBoolean();
-        UnwiseCharsEncoder encoder = x -> {
-            encoderCalled.set(true);
-            return x;
-        };
-
+    public void callsTheEscaperForUnwiseChars() {
+        UnwiseCharsEncoder encoder = mock(UnwiseCharsEncoder.class);
         NettyToStyxRequestDecoder decoder = new NettyToStyxRequestDecoder.Builder()
                 .uniqueIdSupplier(uniqueIdSupplier)
                 .unwiseCharEncoder(encoder)
                 .build();
 
         HttpRequest request = newHttpRequest("/foo");
+        when(encoder.encode("/foo")).thenReturn("/foo");
         request.headers().add(HOST, "example.com");
-
         handle(request, decoder);
-
-        assertTrue(encoderCalled.get());
+        verify(encoder).encode("/foo");
     }
 
     @Test(expectedExceptions = BadRequestException.class)

--- a/components/server/src/test/java/com/hotels/styx/server/netty/codec/UrlDecoderTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/codec/UrlDecoderTest.java
@@ -1,0 +1,100 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.server.netty.codec;
+
+import com.hotels.styx.api.Url;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.HOST;
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class UrlDecoderTest {
+    @Test
+    public void decodesOriginForm() {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/foo");
+        request.headers().add(HOST, "example.com");
+
+        Url url = UrlDecoder.decodeUrl(x -> x, request);
+
+        assertThat(url.authority(), is(Optional.empty()));
+        assertThat(url.path(), is("/foo"));
+        assertThat(url.encodedUri(), is("/foo"));
+        assertThat(url.isAbsolute(), is(false));
+        assertThat(url.isRelative(), is(true));
+        assertThat(url.host(), is(Optional.empty()));
+        assertThat(url.query(), is(Optional.empty()));
+        assertThat(url.scheme(), is(""));
+    }
+
+    @Test
+    public void decodesOriginFormWithLowercaseHostHeader() {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/foo");
+        request.headers().add("host", "example.com");
+
+        Url url = UrlDecoder.decodeUrl(x -> x, request);
+
+        assertThat(url.authority(), is(Optional.empty()));
+        assertThat(url.path(), is("/foo"));
+        assertThat(url.encodedUri(), is("/foo"));
+        assertThat(url.isAbsolute(), is(false));
+        assertThat(url.isRelative(), is(true));
+        assertThat(url.host(), is(Optional.empty()));
+        assertThat(url.query(), is(Optional.empty()));
+        assertThat(url.scheme(), is(""));
+    }
+
+    @Test
+    public void decodesOriginFormWithUppercaseHostHeader() {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/foo");
+        request.headers().add("host", "example.com");
+
+        Url url = UrlDecoder.decodeUrl(x -> x, request);
+
+        assertThat(url.authority(), is(Optional.empty()));
+        assertThat(url.path(), is("/foo"));
+        assertThat(url.encodedUri(), is("/foo"));
+        assertThat(url.isAbsolute(), is(false));
+        assertThat(url.isRelative(), is(true));
+        assertThat(url.host(), is(Optional.empty()));
+        assertThat(url.query(), is(Optional.empty()));
+        assertThat(url.scheme(), is(""));
+    }
+
+
+    @Test
+    public void decodesAbsoluteForm() {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "http://example.com/foo");
+
+        Url url = UrlDecoder.decodeUrl(x -> x, request);
+
+        assertThat(url.authority().isPresent(), is(true));
+        assertThat(url.path(), is("/foo"));
+        assertThat(url.encodedUri(), is("http://example.com/foo"));
+        assertThat(url.isAbsolute(), is(true));
+        assertThat(url.isRelative(), is(false));
+        assertThat(url.host(), is(Optional.of("example.com")));
+        assertThat(url.query(), is(Optional.empty()));
+        assertThat(url.scheme(), is("http"));
+    }
+
+
+}

--- a/components/server/src/test/java/com/hotels/styx/server/netty/codec/UrlDecoderTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/codec/UrlDecoderTest.java
@@ -45,8 +45,9 @@ public class UrlDecoderTest {
         assertThat(url.scheme(), is(""));
     }
 
+    // From GitHub issue #391.
     @Test
-    public void decodesOriginFormIssue391() {
+    public void exposesPathComponentsWithDoubleSlashSeparators() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "//www.abc.com//abc123Z");
         request.headers().add(HOST, "example.com");
 
@@ -62,27 +63,11 @@ public class UrlDecoderTest {
         assertThat(url.scheme(), is(""));
     }
 
-    @Test
-    public void decodesOriginFormWithLowercaseHostHeader() {
-        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/foo");
-        request.headers().add("host", "example.com");
-
-        Url url = UrlDecoder.decodeUrl(x -> x, request);
-
-        assertThat(url.authority(), is(Optional.empty()));
-        assertThat(url.path(), is("/foo"));
-        assertThat(url.encodedUri(), is("/foo"));
-        assertThat(url.isAbsolute(), is(false));
-        assertThat(url.isRelative(), is(true));
-        assertThat(url.host(), is(Optional.empty()));
-        assertThat(url.query(), is(Optional.empty()));
-        assertThat(url.scheme(), is(""));
-    }
-
+    // Demonstrates that Host header handling is case insensitive.
     @Test
     public void decodesOriginFormWithUppercaseHostHeader() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/foo");
-        request.headers().add("host", "example.com");
+        request.headers().add("HOST", "example.com");
 
         Url url = UrlDecoder.decodeUrl(x -> x, request);
 

--- a/components/server/src/test/java/com/hotels/styx/server/netty/codec/UrlDecoderTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/codec/UrlDecoderTest.java
@@ -46,6 +46,23 @@ public class UrlDecoderTest {
     }
 
     @Test
+    public void decodesOriginFormIssue391() {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "//www.abc.com//abc123Z");
+        request.headers().add(HOST, "example.com");
+
+        Url url = UrlDecoder.decodeUrl(x -> x, request);
+
+        assertThat(url.authority(), is(Optional.empty()));
+        assertThat(url.path(), is("//www.abc.com//abc123Z"));
+        assertThat(url.encodedUri(), is("//www.abc.com//abc123Z"));
+        assertThat(url.isAbsolute(), is(false));
+        assertThat(url.isRelative(), is(true));
+        assertThat(url.host(), is(Optional.empty()));
+        assertThat(url.query(), is(Optional.empty()));
+        assertThat(url.scheme(), is(""));
+    }
+
+    @Test
     public void decodesOriginFormWithLowercaseHostHeader() {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/foo");
         request.headers().add("host", "example.com");


### PR DESCRIPTION
Fixes issue #391.

The sample URI from #391 is incorrectly exposed to the interceptor chain: 

* Sample URI: `https://test.homeaway.co.uk//www.homeaway.co.uk/p6873759`
* The [origin-form](https://tools.ietf.org/html/rfc7230#section-5.3.1) of the request is: `//www.homeaway.co.uk/p6873759`
* The path component exposed to the plugins is: `/p6873759`
* The request is proxied correctly.

Root cause: Styx calls Java `URI.create` which fails to parse the URI in its origin form. The problem disappears when we temporarily convert the URI to its [absolute-form](https://tools.ietf.org/html/rfc7230#section-5.3.2)  before calling `URI.create`.
