### PR TITLE
Deprecate Scala e2e suite

### DIFF
--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -140,16 +140,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.kotlintest</groupId>
-      <artifactId>kotlintest-runner-junit5</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.mockk</groupId>
       <artifactId>mockk</artifactId>
     </dependency>
@@ -176,6 +166,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <skipTests>${surefire.skip.tests}</skipTests>
           <argLine>
@@ -190,6 +181,18 @@
           <forkCount>1</forkCount>
           <reuseForks>true</reuseForks>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>1.3.2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-testng</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -144,6 +144,12 @@
       <artifactId>mockk</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.kotlintest</groupId>
+      <artifactId>kotlintest-runner-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -163,6 +169,11 @@
     </testResources>
 
     <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StaticResponseHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StaticResponseHandler.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
 
     <!--Kotlin -->
     <kotlin.version>1.3.21</kotlin.version>
+    <kotlintest.version>3.3.2</kotlintest.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 
     <java-uuid-generator.version>3.1.5</java-uuid-generator.version>
@@ -540,7 +541,7 @@
       <dependency>
         <groupId>io.kotlintest</groupId>
         <artifactId>kotlintest-runner-junit5</artifactId>
-        <version>3.3.0</version>
+        <version>${kotlintest.version}</version>
         <scope>test</scope>
       </dependency>
 
@@ -690,35 +691,6 @@
             </execution>
           </executions>
         </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>${maven-surefire-plugin.version}</version>
-          <configuration>
-            <skipTests>${surefire.skip.tests}</skipTests>
-            <argLine>
-              -Xmx300m
-              -XX:+HeapDumpOnOutOfMemoryError
-              -XX:HeapDumpPath=${project.build.directory}/surefire-reports
-            </argLine>
-            <forkCount>1</forkCount>
-            <reuseForks>true</reuseForks>
-          </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.junit.platform</groupId>
-              <artifactId>junit-platform-surefire-provider</artifactId>
-              <version>1.3.2</version>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.maven.surefire</groupId>
-              <artifactId>surefire-testng</artifactId>
-              <version>${maven-surefire-plugin.version}</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>1.2</maven-enforcer-plugin.version>
-    <maven-failsafe-plugin.version>2.13</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
     <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
     <maven-pmd-plugin.version>3.5</maven-pmd-plugin.version>

--- a/system-tests/e2e-suite/pom.xml
+++ b/system-tests/e2e-suite/pom.xml
@@ -200,7 +200,8 @@
         </configuration>
         <executions>
           <execution>
-            <id>test</id>
+            <id>integration-test</id>
+            <phase>integration-test</phase>
             <goals>
               <goal>test</goal>
             </goals>

--- a/system-tests/ft-suite/pom.xml
+++ b/system-tests/ft-suite/pom.xml
@@ -90,12 +90,8 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surefire-plugin.version}</version>
-
-        <configuration>
-          <skipTests>${surefire.skip.tests}</skipTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven-failsafe-plugin.version}</version>
 
         <dependencies>
           <dependency>
@@ -104,6 +100,21 @@
             <version>${junit.platform.surefire.provider.version}</version>
           </dependency>
         </dependencies>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+
+        <configuration>
+          <includes>
+            <include>*Spec</include>
+          </includes>
+        </configuration>
       </plugin>
 
     </plugins>

--- a/system-tests/ft-suite/pom.xml
+++ b/system-tests/ft-suite/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <parent>
+    <groupId>com.hotels.styx</groupId>
+    <artifactId>styx-tests</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>styx-ft-suite</artifactId>
+
+  <name>Styx - System Tests - Functional Tests</name>
+
+  <description>Styx functional test suite.</description>
+
+  <properties>
+    <main.basedir>${project.parent.parent.basedir}</main.basedir>
+    <kotlin.version>1.3.21</kotlin.version>
+    <kotlintest.version>3.3.2</kotlintest.version>
+
+    <jackson.version>2.9.8</jackson.version>
+    <jackson.dataformat.version>2.5.1</jackson.dataformat.version>
+    <jackson.module.scala.version>2.9.7</jackson.module.scala.version>
+    <junit.platform.surefire.provider.version>1.3.2</junit.platform.surefire.provider.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.hotels.styx</groupId>
+      <artifactId>styx-proxy</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.hotels.styx</groupId>
+      <artifactId>styx-testsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-test</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.kotlintest</groupId>
+      <artifactId>kotlintest-runner-junit5</artifactId>
+      <version>${kotlintest.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Needs to be included to avoid dependency version clash with others
+         brought in by transitive dependencies: -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+
+    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+
+    <plugins>
+
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+
+        <configuration>
+          <skipTests>${surefire.skip.tests}</skipTests>
+        </configuration>
+
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>${junit.platform.surefire.provider.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/system-tests/ft-suite/pom.xml
+++ b/system-tests/ft-suite/pom.xml
@@ -69,23 +69,8 @@
     <plugins>
 
       <plugin>
-        <artifactId>kotlin-maven-plugin</artifactId>
         <groupId>org.jetbrains.kotlin</groupId>
-        <version>${kotlin.version}</version>
-        <executions>
-          <execution>
-            <id>compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>test-compile</id>
-            <goals>
-              <goal>test-compile</goal>
-            </goals>
-          </execution>
-        </executions>
+        <artifactId>kotlin-maven-plugin</artifactId>
       </plugin>
 
       <plugin>

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/ConditionRoutingSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/ConditionRoutingSpec.kt
@@ -23,7 +23,7 @@ import io.kotlintest.Spec
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
-class ConditionRoutingTest : StringSpec() {
+class ConditionRoutingSpec : StringSpec() {
     init {
         "Styx server should start" {
             println("Styx server address: ${styxServer.proxyHttpAddress()}")
@@ -34,7 +34,7 @@ class ConditionRoutingTest : StringSpec() {
         }
     }
 
-    val originsOk = fixturesHome(ConditionRoutingTest::class.java, "/conf/origins/origins-correct.yml")
+    val originsOk = fixturesHome(ConditionRoutingSpec::class.java, "/conf/origins/origins-correct.yml")
 
     val yamlText = """
         proxy:

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/ConditionRoutingTest.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/ConditionRoutingTest.kt
@@ -1,0 +1,91 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.routing
+
+import com.hotels.styx.StyxConfig
+import com.hotels.styx.StyxServer
+import com.hotels.styx.startup.StyxServerComponents
+import com.hotels.styx.support.ResourcePaths.fixturesHome
+import io.kotlintest.Spec
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+
+class ConditionRoutingTest : StringSpec() {
+    init {
+        "Styx server should start" {
+            println("Styx server address: ${styxServer.proxyHttpAddress()}")
+            println("Styx admin address: ${styxServer.adminHttpAddress()}")
+            println("I'm failing on purpose!")
+            println("hello")
+            1.shouldBe(1)
+        }
+    }
+
+    val originsOk = fixturesHome(ConditionRoutingTest::class.java, "/conf/origins/origins-correct.yml")
+
+    val yamlText = """
+        proxy:
+          connectors:
+            http:
+              port: 0
+
+        services:
+          factories:
+            backendServiceRegistry:
+              class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry${'$'}Factory"
+              config: {originsFile: "$originsOk"}
+
+        admin:
+          connectors:
+            http:
+              port: 0
+
+        httpPipeline:
+          name: "Main Pipeline"
+          type: InterceptorPipeline
+          config:
+            handler:
+              name: protocol-router
+              type: ConditionRouter
+              config:
+                routes:
+                  - condition: protocol() == "https"
+                    destination:
+                      name: proxy-to-https
+                      type: StaticResponseHandler
+                      config:
+                        status: 200
+                        body: "This is HTTPS"
+                fallback:
+                  name: proxy-to-http
+                  type: StaticResponseHandler
+                  config:
+                    status: 200
+                    body: "This is HTTP only"
+      """.trimIndent()
+
+    val styxServer = StyxServer(StyxServerComponents.Builder()
+            .styxConfig(StyxConfig.fromYaml(yamlText))
+            .build())
+
+    override fun beforeSpec(spec: Spec) {
+        styxServer.startAsync().awaitRunning()
+    }
+
+    override fun afterSpec(spec: Spec) {
+        styxServer.stopAsync().awaitTerminated()
+    }
+}

--- a/system-tests/ft-suite/src/test/resources/conf/origins/origins-correct.yml
+++ b/system-tests/ft-suite/src/test/resources/conf/origins/origins-correct.yml
@@ -1,0 +1,16 @@
+# See origins-default.yaml for explanation of config format
+---
+- id: "app"
+  path: "/"
+  connectionPool:
+    maxConnectionsPerHost: 45
+    maxPendingConnectionsPerHost: 15
+    connectTimeoutMillis: 1000
+    pendingConnectionTimeoutMillis: 8000
+  healthCheck:
+    uri: "/version.txt"
+    intervalMillis: 5000
+  responseTimeoutMillis: 60000
+  origins:
+  - { id: "app1", host: "localhost:9090" }
+  - { id: "app2", host: "localhost:9091" }

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -8,6 +8,17 @@
   <modelVersion>4.0.0</modelVersion>
 
   <description>Styx - System Tests</description>
+  <dependencies>
+    <dependency>
+      <groupId>com.hotels.styx</groupId>
+      <artifactId>styx-proxy</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.hotels.styx</groupId>
+      <artifactId>styx-testsupport</artifactId>
+    </dependency>
+  </dependencies>
 
   <packaging>pom</packaging>
 
@@ -20,6 +31,7 @@
     <module>e2e-testsupport</module>
     <module>e2e-suite</module>
     <module>example-backend-provider</module>
+    <module>ft-suite</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
This PR deprecates the old Scala e2e test suite in favour of new Kotlin based suite. The new Kotlin-based suite is called `styx-ft-suite` where "ft" stands for functional tests. Our aim is to convert all existing Scala tests to Kotlin, and to move them in `styx-ft-suite`. Existing `e2e-suite` will be removed eventually when all test are migrated. 

This PR also binds the existing e2e suite to Maven `integration-test` phase. It is currently bound to (unit) test phase.

Please check your existing workflows to ensure everything still works!
