### PR TITLE
Fix kotlin test sources

### DIFF
--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -205,6 +205,25 @@
           </dependency>
         </dependencies>
       </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-kotlin-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/test/kotlin</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
The Kotlin test source directory in the `proxy` module was not being treated as test-sources. This PR fixes that.