### PR TITLE
Use 'maxdepth' instead of 'depth' in find command 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ quality: clean
 quality-no-tests:
 	mvn -Dmaven.test.skip=true clean install -Pquality -Dmaven.test.skip=true
 
-STYX_BUILD_ARTIFACT = $(shell find  distribution/target -name "styx*.zip" -depth 1)
-STYX_LINUX_ARTIFACT = $(shell find  distribution/target -name "styx*linux-x86_64.zip" -depth 1)
+STYX_BUILD_ARTIFACT = $(shell find  distribution/target -maxdepth 1 -name "styx*.zip")
+STYX_LINUX_ARTIFACT = $(shell find  distribution/target -maxdepth 1 -name "styx*linux-x86_64.zip")
 STYX_HOME = $(CURRENT_DIR)/distribution/target/styx/styx
 DOCKER_CONTEXT = $(CURRENT_DIR)/distribution/target/styx/docker
 CONFIG_ROOT := $(STYX_HOME)/conf/env-$(STACK)


### PR DESCRIPTION
Use 'maxdepth' instead of 'depth' in find command  to support both MacOS and Linux (Debian).