### PR TITLE
Fix load test script on Mac OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ release: clean
 release-no-tests: clean
 	mvn install -Prelease,$(PLATFORM) -Dmaven.test.skip=true
 
+##
+## To run the load tests, install `wrk2` from homebrew (Mac OSX) using
+## the instructions in:
+## https://github.com/giltene/wrk2/wiki/Installing-wrk2-on-Mac
+##
 GIT_BRANCH=$(shell basename $(shell git symbolic-ref --short HEAD))
 LOAD_TEST_DIR=$(CURRENT_DIR)/logs/load-test-$(GIT_BRANCH)-$(shell date "+%Y_%m_%d_%H:%M:%S")
 RATE=3000
@@ -62,22 +67,20 @@ ENDPOINT=http://localhost:8080/landing/demo
 SSL_ENDPOINT=https://localhost:8443/landing/demo
 LOAD_TEST_TOOL=scripts/load-test-tool/load_test.py
 PERF_DIR=system-tests/performance
+PYTHON=python2.7
 
-wrk2:
-	git clone https://github.com/giltene/wrk2.git
-
-wrk2/wrk: wrk2
-	# Assumes openssl has been installed using homebrew, *AND* the homebrew
-	# installation directory is /usr/local
-	(cd wrk2/; LIBRARY_PATH=/usr/local/opt/openssl/lib C_INCLUDE_PATH=/usr/local/opt/openssl/include make)
+## To collect JFR recording, set:
+##   JFR=--jfr
+## Or leave empty to unset:
+JFR=
 
 ## Run a load test against Styx - launch styx with: make start STACK=perf-local
-load-test: wrk2/wrk
-	(cd $(PERF_DIR); python $(LOAD_TEST_TOOL) -o'$(LOAD_TEST_DIR)' -d $(DURATION) -c $(CONNECTIONS) --times $(TIMES) -R $(RATE) $(ENDPOINT))
+load-test:
+	(cd $(PERF_DIR); $(PYTHON) $(LOAD_TEST_TOOL) ${JFR} -o'$(LOAD_TEST_DIR)' -d $(DURATION) -c $(CONNECTIONS) --times $(TIMES) -R $(RATE) $(ENDPOINT))
 
 ## Run a load test against Styx's HTTPS endpoint - launch styx with: make start STACK=perf-local
 load-test-https:
-	(cd $(PERF_DIR); python $(LOAD_TEST_TOOL) -o'$(LOAD_TEST_DIR)' -d $(DURATION) -c $(CONNECTIONS) --times $(TIMES) -R $(RATE) $(SSL_ENDPOINT))
+	(cd $(PERF_DIR); $(PYTHON) $(LOAD_TEST_TOOL) ${JFR} -o'$(LOAD_TEST_DIR)' -d $(DURATION) -c $(CONNECTIONS) --times $(TIMES) -R $(RATE) $(SSL_ENDPOINT))
 
 ## A more primitive load-test - do we need this?
 load-simple:

--- a/system-tests/performance/scripts/load-test-tool/settings.py
+++ b/system-tests/performance/scripts/load-test-tool/settings.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2017 Expedia Inc.
+# Copyright (C) 2013-2019 Expedia Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import os
 
 JFC_FILE = "scripts/load-test-tool/configuration/load_test.jfc"
 
-WRK_CMD = "../../wrk2/wrk"
+WRK_CMD = "wrk2"
 
 LUA_SCRIPTS_DIR = "scripts/load-test-tool/configuration"
 LUA_CONFIG_SCRIPT = "scripts/load-test-tool/configuration/wrk_config.lua"


### PR DESCRIPTION
Small improvements:
- Specifically use python2.7 on Mac OSX
- Assume `wrk2` from home brew
- Optionally collect JFR logs
