### PR TITLE
Implement shared class loading for matching paths

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/spi/ClassSourceLocator.java
+++ b/components/proxy/src/main/java/com/hotels/styx/spi/ClassSourceLocator.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx.spi;
 
+import com.hotels.styx.common.SimpleCache;
+
 import java.nio.file.Path;
 
 import static com.hotels.styx.spi.JarResources.jars;
@@ -23,7 +25,7 @@ import static com.hotels.styx.spi.JarResources.jars;
  * Allows file-system to be mocked in the context of locating class sources (such as one or more JAR files).
  */
 public interface ClassSourceLocator {
-    ClassSourceLocator JARS = classPath -> new JarsClassSource(jars(classPath));
+    ClassSourceLocator JARS = cached(classPath -> new JarsClassSource(jars(classPath)));
 
     /**
      * Provides a class source representing the specified class-path.
@@ -32,4 +34,18 @@ public interface ClassSourceLocator {
      * @return class source
      */
     ClassSource classSource(Path classPath);
+
+    /**
+     * Wraps a class source locator, so that it will cache the result of using a particular path.
+     * This can be useful for when multiple extensions are sourced from the same place, as it will
+     * prevent loaded classes from being reloaded (and treated as new, different classes).
+     *
+     * @param locator locator
+     * @return cached locator
+     */
+    static ClassSourceLocator cached(ClassSourceLocator locator) {
+        SimpleCache<Path, ClassSource> cache = new SimpleCache<>(locator::classSource);
+
+        return cache::get;
+    }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/spi/ClassSourceLocatorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/spi/ClassSourceLocatorTest.java
@@ -1,0 +1,75 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.spi;
+
+import org.testng.annotations.Test;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hotels.styx.spi.ClassSourceLocator.JARS;
+import static com.hotels.styx.spi.ClassSourceLocator.cached;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertSame;
+
+public class ClassSourceLocatorTest {
+    @Test
+    public void canCacheClassSources() {
+        Path path = Paths.get("/this_is_a_test");
+
+        ClassSource[] classSources = {
+                mock(ClassSource.class),
+                mock(ClassSource.class),
+                mock(ClassSource.class)
+        };
+
+        AtomicInteger incrementingIndex = new AtomicInteger();
+
+        ClassSourceLocator locator = p -> classSources[incrementingIndex.getAndIncrement()];
+
+        ClassSourceLocator cached = cached(locator);
+
+        assertThat(cached.classSource(path), is(classSources[0]));
+        assertThat(cached.classSource(path), is(classSources[0]));
+        assertThat(cached.classSource(path), is(classSources[0]));
+        assertThat(cached.classSource(Paths.get("/this_is_a_test_2")), is(classSources[1]));
+    }
+
+    @Test
+    public void jarBasedClassSourceIsCached() {
+        String pluginPath = "/plugins/oneplugin/testPluginA-1.0-SNAPSHOT.jar";
+
+        URL resource = ClassSourceLocatorTest.class.getResource(pluginPath);
+
+        assertThat(resource, is(notNullValue()));
+
+        Path path = Paths.get(resource.getPath());
+
+        ClassSource firstTime = JARS.classSource(path);
+        ClassSource secondTime = JARS.classSource(path);
+        ClassSource thirdTime = JARS.classSource(path);
+
+        // Checking that the same object reference is returned each time
+        assertSame(firstTime, secondTime);
+        assertSame(secondTime, thirdTime);
+    }
+
+}

--- a/components/server/src/test/java/com/hotels/styx/server/netty/codec/NettyToStyxRequestDecoderTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/codec/NettyToStyxRequestDecoderTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR addresses a situation where two or more plugins are loaded from the same JAR and they share information via HTTP Context.

In this scenario a plugin communicates to another one by storing a custom data class in the HTTP message context. The other plugin is supposed to read the stored data class. But because the two plugins are loaded with separate class loaders, the shared data class is loaded separately in each plugin, and therefore are not compatible with each other, resulting class cast exceptions like these:

```
java.lang.ClassCastException: x.y.MyDataClass cannot be cast to x.y.MyDataClass
```