### PR TITLE
Add insert/remove/watch functionality to Object Store

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/configuration/ObjectStore.java
+++ b/components/api/src/main/java/com/hotels/styx/api/configuration/ObjectStore.java
@@ -28,8 +28,8 @@ public interface ObjectStore<T> {
     /**
      * A repository of named objects.
      *
-     * @param key Object's name.
-     * @return An object if known.
+     * @param key object's name
+     * @return an object if known
      */
     Optional<T> get(String key);
 }

--- a/components/api/src/main/java/com/hotels/styx/api/configuration/ObjectStore.java
+++ b/components/api/src/main/java/com/hotels/styx/api/configuration/ObjectStore.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  *
  * @param <T> Stored object type
  */
-public interface ObjectStoreSnapshot<T> {
+public interface ObjectStore<T> {
 
     /**
      * A repository of named objects.

--- a/components/api/src/main/java/com/hotels/styx/api/configuration/ObjectStoreSnapshot.java
+++ b/components/api/src/main/java/com/hotels/styx/api/configuration/ObjectStoreSnapshot.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  *
  * @param <T> Stored object type
  */
-public interface ObjectStore<T> {
+public interface ObjectStoreSnapshot<T> {
 
     /**
      * Gets an object with given key.
@@ -32,15 +32,4 @@ public interface ObjectStore<T> {
      * @return
      */
     Optional<T> get(String key);
-
-    /**
-     * Inserts an object against key.
-     *
-     * If a key already exists, the object registered is replaced.
-     *
-     * @param key
-     * @param payload
-     */
-    void insert(String key, T payload);
-
 }

--- a/components/api/src/main/java/com/hotels/styx/api/configuration/ObjectStoreSnapshot.java
+++ b/components/api/src/main/java/com/hotels/styx/api/configuration/ObjectStoreSnapshot.java
@@ -26,10 +26,10 @@ import java.util.Optional;
 public interface ObjectStoreSnapshot<T> {
 
     /**
-     * Gets an object with given key.
+     * A repository of named objects.
      *
-     * @param key
-     * @return
+     * @param key Object's name.
+     * @return An object if known.
      */
     Optional<T> get(String key);
 }

--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -161,14 +161,11 @@
     <dependency>
       <groupId>org.pcollections</groupId>
       <artifactId>pcollections</artifactId>
-      <version>3.0.3</version>
     </dependency>
 
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-test</artifactId>
-      <version>3.2.0.RELEASE</version>
-      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -158,6 +158,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.pcollections</groupId>
+      <artifactId>pcollections</artifactId>
+      <version>3.0.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <version>3.2.0.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingObjectFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingObjectFactory.java
@@ -50,7 +50,7 @@ public class RoutingObjectFactory {
             .build();
 
     private final Environment environment;
-    private StyxObjectStore<RoutingObjectRecord> routeObjectStore;
+    private final StyxObjectStore<RoutingObjectRecord> routeObjectStore;
     private final Iterable<NamedPlugin> plugins;
     private final BuiltinInterceptorsFactory interceptorFactory;
     private final Map<String, HttpHandlerFactory> builtInObjectTypes;

--- a/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
@@ -20,6 +20,7 @@ import org.pcollections.HashTreePMap
 import org.pcollections.PMap
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
+import reactor.core.publisher.FluxSink
 import java.util.Optional
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executors
@@ -107,15 +108,18 @@ class StyxObjectStore<T> : ObjectStore<T> {
             }
 
             watchers.add(watcher)
-
             queue {
-                sink.next(ObjectStore { key ->
-                    Optional
-                            .ofNullable(objects().get(key))
-                            .map { it.payload }
-                })
+                emitInitialSnapshot(sink)
             }
         }
+    }
+
+    private fun emitInitialSnapshot(sink: FluxSink<ObjectStore<T>>) {
+        sink.next(ObjectStore { key ->
+            Optional
+                    .ofNullable(objects().get(key))
+                    .map { it.payload }
+        })
     }
 
     internal fun watchers() = watchers.size

--- a/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
@@ -15,7 +15,7 @@
  */
 package com.hotels.styx.routing.db;
 
-import com.hotels.styx.api.configuration.ObjectStoreSnapshot
+import com.hotels.styx.api.configuration.ObjectStore
 import org.pcollections.HashTreePMap
 import org.pcollections.PMap
 import org.reactivestreams.Publisher
@@ -24,30 +24,71 @@ import java.util.Optional
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
-import java.util.function.Consumer
 
 /**
  * Styx Route Database.
  */
-class StyxObjectStore<T> : ObjectStoreSnapshot<T> {
+class StyxObjectStore<T> : ObjectStore<T> {
     private val objects: AtomicReference<PMap<String, Record<T>>> = AtomicReference(HashTreePMap.empty())
     private val watchers = CopyOnWriteArrayList<ChangeWatcher<T>>()
-    private val executor = Executors.newSingleThreadExecutor()
+
+    companion object {
+        private val executor = Executors.newSingleThreadExecutor()
+    }
+
+    /**
+     * Retrieves an object from this object store.
+     *
+     * Returns `Optional.empty` when an object with `key` doesn't exist.
+     *
+     * This method is thread safe. It can be called simultaneously from many threads.
+     *
+     * @property key object name
+     * @return an optional object
+     */
 
     override fun get(name: String): Optional<T> {
         return Optional.ofNullable(objects().get(name))
                 .map { it.payload }
     }
 
+    /**
+     * Inserts a new object in object store.
+     *
+     * If an object already exist with same `key`, then the previous object is
+     * replaced with new one.
+     *
+     * Notifies watchers.
+     *
+     * This method is thread safe. It can be called simultaneously from many threads.
+     *
+     * @property key object name
+     * @property payload the object itself
+     */
     fun insert(key: String, payload: T) {
         insert(key, setOf(), payload)
     }
 
+    /**
+     * Removes an object from this object store.
+     *
+     * Watchers are notified after successful removal.
+     *
+     * If `key` doesn't exist, then nothing happens and watcher's are not notified.
+     *
+     * This method is thread safe. It can be called simultaneously from many threads.
+     *
+     * @property key object name
+     * @property payload the object itself
+     */
     fun remove(key: T) {
         queue {
             val nextVersion = objects().minus(key)
-            objects.set(nextVersion)
-            notifyWatchers(nextVersion)
+
+            if (nextVersion != objects()) {
+                objects.set(nextVersion)
+                notifyWatchers(nextVersion)
+            }
         }
     }
 
@@ -57,13 +98,9 @@ class StyxObjectStore<T> : ObjectStoreSnapshot<T> {
      * Watch activates on subscription only.
      * Watch removed on unsubscription.
      */
-    fun watch(): Publisher<ObjectStoreSnapshot<T>> {
+    fun watch(): Publisher<ObjectStore<T>> {
         return Flux.push { sink ->
-            val watcher = object : ChangeWatcher<T> {
-                override fun accept(objectStoreSnapshot: ObjectStoreSnapshot<T>) {
-                    sink.next(objectStoreSnapshot)
-                }
-            }
+            val watcher: ChangeWatcher<T> = { sink.next(it) }
 
             sink.onDispose {
                 watchers.remove(watcher)
@@ -72,7 +109,7 @@ class StyxObjectStore<T> : ObjectStoreSnapshot<T> {
             watchers.add(watcher)
 
             queue {
-                sink.next(ObjectStoreSnapshot { key ->
+                sink.next(ObjectStore { key ->
                     Optional
                             .ofNullable(objects().get(key))
                             .map { it.payload }
@@ -99,16 +136,16 @@ class StyxObjectStore<T> : ObjectStoreSnapshot<T> {
 
     private fun notifyWatchers(objectsV2: PMap<String, Record<T>>) {
         watchers.forEach { listener ->
-            listener.accept(snapshot(objectsV2))
+            listener.invoke(snapshot(objectsV2))
         }
     }
 
-    private fun snapshot(snapshot: PMap<String, Record<T>>) = object : ObjectStoreSnapshot<T> {
-        override fun get(key: String?): Optional<T> = Optional
-                .ofNullable(snapshot.get(key))
+    private fun snapshot(snapshot: PMap<String, Record<T>>) = ObjectStore<T> { key: String ->
+        Optional.ofNullable(snapshot.get(key))
                 .map { it.payload }
     }
 }
 
-private interface ChangeWatcher<T> : Consumer<ObjectStoreSnapshot<T>>
+private typealias ChangeWatcher<T> = (ObjectStore<T>) -> Unit
+
 private data class Record<T>(val key: String, val tags: Set<String>, val payload: T)

--- a/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
@@ -74,7 +74,7 @@ class StyxObjectStore<T> : ObjectStore<T> {
      *
      * Watchers are notified after successful removal.
      *
-     * If `key` doesn't exist, then nothing happens and watcher's are not notified.
+     * If `key` doesn't exist, then nothing happens and watchers are not notified.
      *
      * This method is thread safe. It can be called simultaneously from many threads.
      *

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/db/StyxObjectStoreTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/db/StyxObjectStoreTest.kt
@@ -57,7 +57,7 @@ class StyxObjectStoreTest : FeatureSpec() {
             scenario("Notifies watchers for any change") {
                 val db = StyxObjectStore<String>()
 
-                StepVerifier.create<ObjectStore<String>>(db.watch())
+                StepVerifier.create(db.watch())
                         .expectNextCount(1)
                         .then { db.insert("x", "x") }
                         .assertNext {
@@ -96,7 +96,7 @@ class StyxObjectStoreTest : FeatureSpec() {
             scenario("Replaces already existing object") {
                 val db = StyxObjectStore<String>()
 
-                StepVerifier.create<ObjectStore<String>>(db.watch())
+                StepVerifier.create(db.watch())
                         .expectNextCount(1)
                         .then { db.insert("x", "x") }
                         .assertNext {
@@ -137,7 +137,7 @@ class StyxObjectStoreTest : FeatureSpec() {
             scenario("Non-existent object doesn't trigger watchers") {
                 val db = StyxObjectStore<String>()
 
-                StepVerifier.create<ObjectStore<String>>(db.watch())
+                StepVerifier.create(db.watch())
                         .expectNextCount(1)
                         .then { db.remove("x") }
                         .expectNoEvent(250.milliseconds)
@@ -146,7 +146,7 @@ class StyxObjectStoreTest : FeatureSpec() {
 
                 db.insert("y", "Y")
 
-                StepVerifier.create<ObjectStore<String>>(db.watch())
+                StepVerifier.create(db.watch())
                         .expectNextCount(1)
                         .then { db.remove("x") }
                         .expectNoEvent(250.milliseconds)

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
     <rxjava.version>1.1.6</rxjava.version>
     <reactive-streams.version>1.0.2</reactive-streams.version>
     <reactor.version>3.2.0.RELEASE</reactor.version>
+    <pcollections.version>3.0.3</pcollections.version>
 
     <!--Kotlin -->
     <kotlin.version>1.3.21</kotlin.version>
@@ -268,6 +269,12 @@
         <artifactId>reactor-test</artifactId>
         <version>${reactor.version}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.pcollections</groupId>
+        <artifactId>pcollections</artifactId>
+        <version>${pcollections.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Adds Object Store functionality for

- inserting new objects
- removing existing objects
- watching for changes

Concurrency issues:

- Objects are stored in a persistent map. Each modification (insert/remove) creates a new, immutable object store snapshot. The snapshot is then serially published to all watchers.

Watching for Changes:

- Consumers can listen for database changes by calling a `watch` method. It supports watching for the full database only. Watching for individual objects will be implemented in future when necessary.

- A `watch` returns a reactive streams `Publisher`. When subscribed, the publisher emits the current object store snapshot, followed by a new snapshot every time database changes. The publisher keeps emitting the change events in perpetuity until unsubscribed.
