### PR TITLE
Fix Kotlin main sources

### DIFF
--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -229,7 +229,7 @@
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>add-kotlin-test-sources</id>
+            <id>add-kotlin-sources</id>
             <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>

--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -230,6 +230,18 @@
         <executions>
           <execution>
             <id>add-kotlin-test-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/main/kotlin</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-kotlin-test-sources</id>
             <phase>generate-test-sources</phase>
             <goals>
               <goal>add-test-source</goal>


### PR DESCRIPTION
The Kotlin main source directory in the `proxy` module was not being treated as sources. This PR fixes that.

Same problem as #397