### PR TITLE
Open a RESTful API for Styx Object Store

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -244,7 +244,7 @@ public final class StyxServer extends AbstractService {
     }
 
     private static HttpServer createAdminServer(StyxServerComponents config) {
-        return new AdminServerBuilder(config.environment())
+        return new AdminServerBuilder(config.environment(), config)
                 .backendServicesRegistry((Registry<BackendService>) config.services().get("backendServiceRegistry"))
                 .build();
     }

--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -244,7 +244,7 @@ public final class StyxServer extends AbstractService {
     }
 
     private static HttpServer createAdminServer(StyxServerComponents config) {
-        return new AdminServerBuilder(config.environment(), config)
+        return new AdminServerBuilder(config)
                 .backendServicesRegistry((Registry<BackendService>) config.services().get("backendServiceRegistry"))
                 .build();
     }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -88,11 +88,11 @@ public class AdminServerBuilder {
 
     private Registry<BackendService> backendServicesRegistry;
 
-    public AdminServerBuilder(Environment environment, StyxServerComponents serverComponents) {
-        this.environment = environment;
-        this.configuration = environment.configuration();
+    public AdminServerBuilder(StyxServerComponents serverComponents) {
+        this.environment = requireNonNull(serverComponents.environment());
         this.routeDatabase = requireNonNull(serverComponents.routeDatabase());
         this.routingObjectFactory = requireNonNull(serverComponents.routingObjectFactory());
+        this.configuration = this.environment.configuration();
     }
 
     public AdminServerBuilder backendServicesRegistry(Registry<BackendService> backendServicesRegistry) {
@@ -133,7 +133,6 @@ public class AdminServerBuilder {
 
         RoutingObjectHandler routingObjectHandler = new RoutingObjectHandler(routeDatabase, routingObjectFactory);
         httpRouter.add("/admin/routing", routingObjectHandler);
-
         httpRouter.add("/admin/routing/", routingObjectHandler);
 
         // Dashboard

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -32,6 +32,7 @@ import com.hotels.styx.admin.handlers.OriginsInventoryHandler;
 import com.hotels.styx.admin.handlers.PingHandler;
 import com.hotels.styx.admin.handlers.PluginListHandler;
 import com.hotels.styx.admin.handlers.PluginToggleHandler;
+import com.hotels.styx.admin.handlers.RoutingObjectHandler;
 import com.hotels.styx.admin.handlers.StartupConfigHandler;
 import com.hotels.styx.admin.handlers.StyxConfigurationHandler;
 import com.hotels.styx.admin.handlers.ThreadsHandler;
@@ -45,12 +46,16 @@ import com.hotels.styx.api.extension.service.spi.Registry;
 import com.hotels.styx.common.http.handler.HttpMethodFilteringHandler;
 import com.hotels.styx.common.http.handler.StaticBodyHttpHandler;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
+import com.hotels.styx.routing.RoutingObjectRecord;
+import com.hotels.styx.routing.config.RoutingObjectFactory;
+import com.hotels.styx.routing.db.StyxObjectStore;
 import com.hotels.styx.server.HttpServer;
 import com.hotels.styx.server.StandardHttpRouter;
 import com.hotels.styx.server.handlers.ClassPathResourceHandler;
 import com.hotels.styx.server.netty.NettyServerBuilderSpec;
 import com.hotels.styx.server.netty.WebServerConnectorFactory;
 import com.hotels.styx.server.track.CurrentRequestTracker;
+import com.hotels.styx.startup.StyxServerComponents;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -78,12 +83,16 @@ public class AdminServerBuilder {
 
     private final Environment environment;
     private final Configuration configuration;
+    private final RoutingObjectFactory routingObjectFactory;
+    private StyxObjectStore<RoutingObjectRecord> routeDatabase;
 
     private Registry<BackendService> backendServicesRegistry;
 
-    public AdminServerBuilder(Environment environment) {
+    public AdminServerBuilder(Environment environment, StyxServerComponents serverComponents) {
         this.environment = environment;
         this.configuration = environment.configuration();
+        this.routeDatabase = requireNonNull(serverComponents.routeDatabase());
+        this.routingObjectFactory = requireNonNull(serverComponents.routingObjectFactory());
     }
 
     public AdminServerBuilder backendServicesRegistry(Registry<BackendService> backendServicesRegistry) {
@@ -121,6 +130,11 @@ public class AdminServerBuilder {
         httpRouter.add("/admin/origins/status", new OriginsInventoryHandler(environment.eventBus()));
         httpRouter.add("/admin/configuration/logging", new LoggingConfigurationHandler(styxConfig.startupConfig().logConfigLocation()));
         httpRouter.add("/admin/configuration/startup", new StartupConfigHandler(styxConfig.startupConfig()));
+
+        RoutingObjectHandler routingObjectHandler = new RoutingObjectHandler(routeDatabase, routingObjectFactory);
+        httpRouter.add("/admin/routing", routingObjectHandler);
+
+        httpRouter.add("/admin/routing/", routingObjectHandler);
 
         // Dashboard
         httpRouter.add("/admin/dashboard/data.json", dashboardDataHandler(styxConfig));

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/RoutingObjectHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/RoutingObjectHandler.java
@@ -1,0 +1,163 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.admin.handlers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.hotels.styx.api.Eventual;
+import com.hotels.styx.api.HttpHandler;
+import com.hotels.styx.api.HttpInterceptor;
+import com.hotels.styx.api.HttpRequest;
+import com.hotels.styx.api.HttpResponse;
+import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.routing.RoutingObjectRecord;
+import com.hotels.styx.routing.config.RoutingObjectDefinition;
+import com.hotels.styx.routing.config.RoutingObjectFactory;
+import com.hotels.styx.routing.db.StyxObjectStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.fasterxml.jackson.core.JsonParser.Feature.AUTO_CLOSE_SOURCE;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.hotels.styx.admin.handlers.UrlPatternRouter.placeholders;
+import static com.hotels.styx.api.HttpResponse.response;
+import static com.hotels.styx.api.HttpResponseStatus.BAD_REQUEST;
+import static com.hotels.styx.api.HttpResponseStatus.CREATED;
+import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
+import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static com.hotels.styx.infrastructure.configuration.json.ObjectMappers.addStyxMixins;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Provides admin interface access to Styx routing configuration.
+ */
+public class RoutingObjectHandler implements HttpHandler  {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoutingObjectHandler.class);
+
+    private static final ObjectMapper YAML_MAPPER = addStyxMixins(new ObjectMapper(new YAMLFactory()))
+            .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(AUTO_CLOSE_SOURCE, true);
+
+    private final UrlPatternRouter urlRouter;
+
+
+    public RoutingObjectHandler(StyxObjectStore<RoutingObjectRecord> routeDatabase, RoutingObjectFactory objectFactory) {
+        urlRouter = new UrlPatternRouter.Builder()
+                .get("/admin/routing/objects", httpHandler((request, context) -> {
+                    String output = routeDatabase.entrySet()
+                            .stream()
+                            .map(entry -> serialise(entry.getFirst(), entry.getSecond()))
+                            .collect(Collectors.joining("\n"));
+
+                    return Eventual.of(response(OK)
+                            .body(output, UTF_8)
+                            .build());
+                }))
+                .get("/admin/routing/objects/:objectName", httpHandler((request, context) -> {
+                    String name = placeholders(context).get("objectName");
+
+                    try {
+                        String object = routeDatabase.get(name)
+                                .map(record-> serialise(name, record))
+                                .orElseThrow(ResourceNotFoundException::new);
+
+                        return Eventual.of(response(OK).body(object, UTF_8).build());
+                    } catch (ResourceNotFoundException e) {
+                        return Eventual.of(response(NOT_FOUND).build());
+                    }
+                }))
+                .put("/admin/routing/objects/:objectName", httpHandler((request, context) -> {
+                    String body = request.bodyAs(UTF_8);
+                    String name = placeholders(context).get("objectName");
+
+                    try {
+                        RoutingObjectDefinition payload = YAML_MAPPER.readValue(body, RoutingObjectDefinition.class);
+                        HttpHandler httpHandler = objectFactory.build(Collections.emptyList(), payload);
+
+                        routeDatabase.insert(name, new RoutingObjectRecord(payload.type(), payload.config(), httpHandler));
+
+                        return Eventual.of(response(CREATED).build());
+                    } catch (IOException | RuntimeException cause) {
+                        return Eventual.of(response(BAD_REQUEST).body(cause.toString(), UTF_8).build());
+                    }
+                }))
+                .delete("/admin/routing/objects/:objectName", httpHandler((request, context) -> {
+                    String name = placeholders(context).get("objectName");
+
+                    if (!routeDatabase.get(name).isPresent()) {
+                        return Eventual.of(response(NOT_FOUND).build());
+                    }
+
+                    routeDatabase.remove(name);
+                    return Eventual.of(response(OK).build());
+                }))
+                .build();
+    }
+
+    private static String serialise(String name, RoutingObjectRecord app) {
+        JsonNode node = YAML_MAPPER
+                .addMixIn(RoutingObjectDefinition.class, RoutingObjectDefMixin.class)
+                .valueToTree(new RoutingObjectDefinition(name, app.getType(), Collections.emptyList(), app.getConfig()));
+
+        ((ObjectNode) node).set("config", app.getConfig());
+
+        try {
+            return YAML_MAPPER.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static HttpHandler httpHandler(FullHttpHandler delegate) {
+        return (request, context) -> request.aggregate(1000000)
+                .flatMap(fullRequest -> delegate.handle(fullRequest, context))
+                .map(HttpResponse::stream);
+    }
+
+    @Override
+    public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
+        return urlRouter.handle(request, context);
+    }
+
+    private interface FullHttpHandler {
+        Eventual<HttpResponse> handle(HttpRequest request, HttpInterceptor.Context context);
+    }
+
+    private static class ResourceNotFoundException extends RuntimeException { }
+
+    private abstract static class RoutingObjectDefMixin {
+        @JsonProperty("name")
+        public abstract String name();
+
+        @JsonProperty("type")
+        public abstract String type();
+
+        @JsonProperty("tags")
+        public abstract List<String> tags();
+    }
+
+}
+

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/UrlPatternRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/UrlPatternRouter.java
@@ -36,6 +36,9 @@ import static com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
 import static com.hotels.styx.api.LiveHttpResponse.response;
 
+/**
+ * A configurable router.
+ */
 public class UrlPatternRouter implements HttpHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(UrlPatternRouter.class);
     private static final String PLACEHOLDERS_KEY = "UrlRouter.placeholders";
@@ -54,6 +57,9 @@ public class UrlPatternRouter implements HttpHandler {
         for (RouteDescriptor route : alternatives) {
             if (request.method().equals(route.method())) {
                 Matcher match = route.pattern().matcher(request.path());
+
+                LOGGER.debug("Request path '{}' matching against route pattern '{}' matches: {}", new Object[] {
+                        request.path(), route.pattern(), match.matches()});
 
                 if (match.matches()) {
                     Map<String, String> placeholders = route.placeholderNames().stream()
@@ -74,6 +80,9 @@ public class UrlPatternRouter implements HttpHandler {
         return Eventual.of(response(NOT_FOUND).build());
     }
 
+    /**
+     * A builder class.
+     */
     public static class Builder {
         private final List<RouteDescriptor> alternatives = new LinkedList<>();
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/UrlPatternRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/UrlPatternRouter.java
@@ -61,10 +61,10 @@ public class UrlPatternRouter implements HttpHandler {
     public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
         for (RouteDescriptor route : alternatives) {
             if (request.method().equals(route.method())) {
-                Matcher match = route.pattern().matcher(request.path());
+                Matcher match = route.uriPattern().matcher(request.path());
 
                 LOGGER.debug("Request path '{}' matching against route pattern '{}' matches: {}", new Object[] {
-                        request.path(), route.pattern(), match.matches()});
+                        request.path(), route.uriPattern(), match.matches()});
 
                 if (match.matches()) {
                     Map<String, String> placeholders = route.placeholderNames().stream()
@@ -91,23 +91,23 @@ public class UrlPatternRouter implements HttpHandler {
     public static class Builder {
         private final List<RouteDescriptor> alternatives = new LinkedList<>();
 
-        public Builder get(String regexp, HttpHandler handler) {
-            alternatives.add(new RouteDescriptor(GET, regexp, handler));
+        public Builder get(String uriPattern, HttpHandler handler) {
+            alternatives.add(new RouteDescriptor(GET, uriPattern, handler));
             return this;
         }
 
-        public Builder post(String regexp, HttpHandler handler) {
-            alternatives.add(new RouteDescriptor(POST, regexp, handler));
+        public Builder post(String uriPattern, HttpHandler handler) {
+            alternatives.add(new RouteDescriptor(POST, uriPattern, handler));
             return this;
         }
 
-        public Builder put(String regexp, HttpHandler handler) {
-            alternatives.add(new RouteDescriptor(PUT, regexp, handler));
+        public Builder put(String uriPattern, HttpHandler handler) {
+            alternatives.add(new RouteDescriptor(PUT, uriPattern, handler));
             return this;
         }
 
-        public Builder delete(String regexp, HttpHandler handler) {
-            alternatives.add(new RouteDescriptor(DELETE, regexp, handler));
+        public Builder delete(String uriPattern, HttpHandler handler) {
+            alternatives.add(new RouteDescriptor(DELETE, uriPattern, handler));
             return this;
         }
 
@@ -117,25 +117,26 @@ public class UrlPatternRouter implements HttpHandler {
     }
 
     private static class RouteDescriptor {
-        private final HttpMethod method;
-        private final Pattern pattern;
-        private final HttpHandler handler;
-        private final List<String> placeholderNames;
         private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile(":([a-zA-Z0-9-_]+)");
 
-        public RouteDescriptor(HttpMethod method, String pattern, HttpHandler handler) {
+        private final HttpMethod method;
+        private final Pattern uriPattern;
+        private final HttpHandler handler;
+        private final List<String> placeholderNames;
+
+        public RouteDescriptor(HttpMethod method, String uriPattern, HttpHandler handler) {
             this.method = method;
             this.handler = handler;
-            this.placeholderNames = placeholders(pattern);
-            this.pattern = compilePattern(pattern);
+            this.placeholderNames = placeholders(uriPattern);
+            this.uriPattern = compilePattern(uriPattern);
         }
 
         public HttpMethod method() {
             return method;
         }
 
-        public Pattern pattern() {
-            return pattern;
+        public Pattern uriPattern() {
+            return uriPattern;
         }
 
         public HttpHandler handler() {

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/UrlPatternRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/UrlPatternRouter.java
@@ -1,0 +1,154 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.admin.handlers;
+
+import com.hotels.styx.api.Eventual;
+import com.hotels.styx.api.HttpHandler;
+import com.hotels.styx.api.HttpInterceptor;
+import com.hotels.styx.api.HttpMethod;
+import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.api.LiveHttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
+import static com.hotels.styx.api.LiveHttpResponse.response;
+
+public class UrlPatternRouter implements HttpHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UrlPatternRouter.class);
+    private static final String PLACEHOLDERS_KEY = "UrlRouter.placeholders";
+    private final List<RouteDescriptor> alternatives;
+
+    private UrlPatternRouter(List<RouteDescriptor> alternatives) {
+        this.alternatives = alternatives;
+    }
+
+    public static Map<String, String> placeholders(HttpInterceptor.Context context) {
+        return context.getIfAvailable(PLACEHOLDERS_KEY, Map.class).get();
+    }
+
+    @Override
+    public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
+        for (RouteDescriptor route : alternatives) {
+            if (request.method().equals(route.method())) {
+                Matcher match = route.pattern().matcher(request.path());
+
+                if (match.matches()) {
+                    Map<String, String> placeholders = route.placeholderNames().stream()
+                            .collect(Collectors.toMap(name -> name, match::group));
+
+                    context.add(PLACEHOLDERS_KEY, placeholders);
+
+                    try {
+                        return route.handler().handle(request, context);
+                    } catch (Exception cause) {
+                        LOGGER.error("ERROR: {} {}", new Object[] {request.method(), request.path(), cause});
+                        return Eventual.of(response(INTERNAL_SERVER_ERROR).build());
+                    }
+                }
+            }
+        }
+
+        return Eventual.of(response(NOT_FOUND).build());
+    }
+
+    public static class Builder {
+        private final List<RouteDescriptor> alternatives = new LinkedList<>();
+
+        public Builder get(String regexp, HttpHandler handler) {
+            alternatives.add(new RouteDescriptor(HttpMethod.GET, regexp, handler));
+            return this;
+        }
+
+        public Builder post(String regexp, HttpHandler handler) {
+            alternatives.add(new RouteDescriptor(HttpMethod.POST, regexp, handler));
+            return this;
+        }
+
+        public Builder put(String regexp, HttpHandler handler) {
+            alternatives.add(new RouteDescriptor(HttpMethod.PUT, regexp, handler));
+            return this;
+        }
+
+        public Builder delete(String regexp, HttpHandler handler) {
+            alternatives.add(new RouteDescriptor(HttpMethod.DELETE, regexp, handler));
+            return this;
+        }
+
+        public UrlPatternRouter build() {
+            return new UrlPatternRouter(alternatives);
+        }
+    }
+
+    private static class RouteDescriptor {
+        private final HttpMethod method;
+        private final Pattern pattern;
+        private final HttpHandler handler;
+        private final List<String> placeholderNames;
+
+        public RouteDescriptor(HttpMethod method, String pattern, HttpHandler handler) {
+            this.method = method;
+            this.handler = handler;
+            this.placeholderNames = placeholcers(pattern);
+            this.pattern = compilePattern(pattern);
+        }
+
+        public HttpMethod method() {
+            return method;
+        }
+
+        public Pattern pattern() {
+            return pattern;
+        }
+
+        public HttpHandler handler() {
+            return handler;
+        }
+
+        public List<String> placeholderNames() {
+            return placeholderNames;
+        }
+
+        private Pattern compilePattern(String pattern) {
+            Pattern x = Pattern.compile(":([a-zA-Z0-9-_]+)");
+            Matcher matcher = x.matcher(pattern);
+            return Pattern.compile(matcher.replaceAll("(?<$1>[a-zA-Z0-9-_]+)"));
+        }
+
+        private List<String> placeholcers(String pattern) {
+            Pattern x = Pattern.compile(":([a-zA-Z0-9-_]+)");
+            Matcher matcher = x.matcher(pattern);
+
+            List<String> outcome = new ArrayList<>();
+
+            while (matcher.find()) {
+                outcome.add(matcher.group(1));
+            }
+
+            return outcome;
+        }
+
+    }
+}

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HttpInterceptorPipeline.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HttpInterceptorPipeline.java
@@ -82,13 +82,13 @@ public class HttpInterceptorPipeline implements HttpHandler {
             JsonNode pipeline = configBlock.config().get("pipeline");
             List<HttpInterceptor> interceptors = getHttpInterceptors(append(parents, "pipeline"), toMap(context.plugins()), context.builtinInterceptorsFactory(), pipeline);
 
-            RoutingObjectDefinition handlerConfig = new JsonNodeConfig(configBlock.config())
-                    .get("handler", RoutingObjectDefinition.class)
+            JsonNode handlerConfig = new JsonNodeConfig(configBlock.config())
+                    .get("handler", JsonNode.class)
                     .orElseThrow(() -> missingAttributeError(configBlock, join(".", parents), "handler"));
 
             return new HttpInterceptorPipeline(
                     interceptors,
-                    context.factory().build(append(parents, "handler"), handlerConfig),
+                    context.factory().build(append(parents, "handler"), toRoutingConfigNode(handlerConfig)),
                     context.requestTracking());
         }
 

--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.AsyncEventBus;
 import com.hotels.styx.Environment;
 import com.hotels.styx.StyxConfig;
@@ -93,7 +92,7 @@ public class StyxServerComponents {
                 .orElse(ImmutableMap.of())
                 .forEach((name, record) -> {
                     HttpHandler handler = routingObjectFactory.build(ImmutableList.of(name), record);
-                    routeObjectStore.insert(name, new RoutingObjectRecord(name, ImmutableSet.of(), record, handler));
+                    routeObjectStore.insert(name, new RoutingObjectRecord(record.type(), record.config(), handler));
                 });
     }
 

--- a/components/proxy/src/main/kotlin/com/hotels/styx/routing/RoutingObjectRecord.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/routing/RoutingObjectRecord.kt
@@ -15,11 +15,10 @@
  */
 package com.hotels.styx.routing
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.hotels.styx.api.HttpHandler
-import com.hotels.styx.routing.config.RoutingObjectDefinition
 
 data class RoutingObjectRecord(
-        val name: String,
-        val tags: Set<String>,
-        val routingObjectDefinition: RoutingObjectDefinition,
+        val type: String,
+        val config: JsonNode,
         val handler: HttpHandler)

--- a/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
@@ -102,8 +102,8 @@ class StyxObjectStore<T> : ObjectStore<T> {
             new = current.minus(key)
         }
 
-        queue {
-            if (current != new) {
+        if (current != new) {
+            queue {
                 notifyWatchers(new)
             }
         }

--- a/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
@@ -93,7 +93,7 @@ class StyxObjectStore<T> : ObjectStore<T> {
      * @property key object name
      * @property payload the object itself
      */
-    fun remove(key: T) {
+    fun remove(key: String) {
         var current = objects.get()
         var new = current.minus(key)
 

--- a/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/RoutingObjectHandlerTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/RoutingObjectHandlerTest.kt
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.hotels.styx.Environment
 import com.hotels.styx.api.Eventual
 import com.hotels.styx.api.HttpRequest
+import com.hotels.styx.api.HttpRequest.delete
+import com.hotels.styx.api.HttpRequest.put
 import com.hotels.styx.api.HttpResponseStatus.CREATED
 import com.hotels.styx.api.HttpResponseStatus.NOT_FOUND
 import com.hotels.styx.api.HttpResponseStatus.OK
@@ -48,7 +50,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
             val handler = RoutingObjectHandler(routeDatabase, objectFactory)
 
             handler.handle(
-                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                    put("/admin/routing/objects/staticResponse")
                             .body("""
                             name: "staticResponse"
                             type: "StaticResponseHandler"
@@ -75,7 +77,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
             val handler = RoutingObjectHandler(routeDatabase, objectFactory)
 
             handler.handle(
-                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                    put("/admin/routing/objects/staticResponse")
                             .body("""
                             type: StaticResponseHandler
                             config:
@@ -113,7 +115,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
             val handler = RoutingObjectHandler(routeDatabase, objectFactory)
 
             handler.handle(
-                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                    put("/admin/routing/objects/staticResponse")
                             .body("""
                             type: StaticResponseHandler
                             config:
@@ -129,7 +131,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
                     ?.status() shouldBe CREATED
 
             val r = handler.handle(
-                    HttpRequest.put("/admin/routing/objects/conditionRouter")
+                    put("/admin/routing/objects/conditionRouter")
                             .body("""
                             type: ConditionRouter
                             config:
@@ -183,7 +185,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
             val handler = RoutingObjectHandler(routeDatabase, objectFactory)
 
             handler.handle(
-                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                    put("/admin/routing/objects/staticResponse")
                             .body("""
                             type: StaticResponseHandler
                             config:
@@ -203,7 +205,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
             val previousHandler = routeDatabase.get("staticResponse").get().handler
 
             handler.handle(
-                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                    put("/admin/routing/objects/staticResponse")
                             .body("""
                             type: StaticResponseHandler
                             config:
@@ -228,7 +230,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
             val handler = RoutingObjectHandler(routeDatabase, objectFactory)
 
             handler.handle(
-                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                    put("/admin/routing/objects/staticResponse")
                             .body("""
                             type: StaticResponseHandler
                             config:
@@ -246,7 +248,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
             routeDatabase.get("staticResponse").isPresent shouldBe true
 
             handler.handle(
-                    HttpRequest.delete("/admin/routing/objects/staticResponse").build().stream(),
+                    delete("/admin/routing/objects/staticResponse").build().stream(),
                     HttpInterceptorContext.create())
                     .flatMap { it.aggregate(2000) }
                     .toMono()
@@ -260,7 +262,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
             val handler = RoutingObjectHandler(routeDatabase, objectFactory)
 
             handler.handle(
-                    HttpRequest.delete("/admin/routing/objects/staticResponse").build().stream(),
+                    delete("/admin/routing/objects/staticResponse").build().stream(),
                     HttpInterceptorContext.create())
                     .flatMap { it.aggregate(2000) }
                     .toMono()

--- a/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/RoutingObjectHandlerTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/RoutingObjectHandlerTest.kt
@@ -1,0 +1,274 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.admin.handlers
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.hotels.styx.Environment
+import com.hotels.styx.api.Eventual
+import com.hotels.styx.api.HttpRequest
+import com.hotels.styx.api.HttpResponseStatus.CREATED
+import com.hotels.styx.api.HttpResponseStatus.NOT_FOUND
+import com.hotels.styx.api.HttpResponseStatus.OK
+import com.hotels.styx.routing.RoutingObjectRecord
+import com.hotels.styx.routing.config.RoutingObjectFactory
+import com.hotels.styx.routing.db.StyxObjectStore
+import com.hotels.styx.routing.handlers.StaticResponseHandler
+import com.hotels.styx.server.HttpInterceptorContext
+import io.kotlintest.matchers.types.shouldBeTypeOf
+import io.kotlintest.matchers.types.shouldNotBeSameInstanceAs
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FeatureSpec
+import io.mockk.mockk
+import reactor.core.publisher.Mono
+import java.nio.charset.StandardCharsets.UTF_8
+
+class RoutingObjectHandlerTest : FeatureSpec({
+
+    val environment = Environment.Builder().build()
+
+    val routeDatabase = StyxObjectStore<RoutingObjectRecord>()
+
+    val objectFactory = RoutingObjectFactory(environment, routeDatabase, listOf(), mockk(), true)
+
+    feature("Route database management") {
+        scenario("Injecting new objects") {
+            val handler = RoutingObjectHandler(routeDatabase, objectFactory)
+
+            handler.handle(
+                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                            .body("""
+                            name: "staticResponse"
+                            type: "StaticResponseHandler"
+                            tags: []
+                            config:
+                               status: 200
+                               content: "Hello, world!"
+                            """.trimIndent(),
+                                    UTF_8)
+                            .build()
+                            .stream(), HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe CREATED
+
+            routeDatabase.get("staticResponse").isPresent shouldBe true
+            routeDatabase.get("staticResponse").get().type shouldBe "StaticResponseHandler"
+            routeDatabase.get("staticResponse").get().config.shouldBeTypeOf<ObjectNode>()
+            routeDatabase.get("staticResponse").get().handler.shouldBeTypeOf<StaticResponseHandler>()
+        }
+
+        scenario("Retrieving objects") {
+            val handler = RoutingObjectHandler(routeDatabase, objectFactory)
+
+            handler.handle(
+                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                            .body("""
+                            type: StaticResponseHandler
+                            config:
+                               status: 200
+                               content: "Hello, world!"
+                            """.trimIndent(),
+                                    UTF_8)
+                            .build()
+                            .stream(), HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe CREATED
+
+            val response = handler.handle(HttpRequest.get("/admin/routing/objects/staticResponse").build().stream(), HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+
+            response!!.status() shouldBe OK
+            response.bodyAs(UTF_8).trim() shouldBe """
+                            ---
+                            name: "staticResponse"
+                            type: "StaticResponseHandler"
+                            tags: []
+                            config:
+                              status: 200
+                              content: "Hello, world!"
+                              """
+                    .trimIndent()
+                    .trim()
+        }
+
+        scenario("Fetching all routing objects") {
+            val handler = RoutingObjectHandler(routeDatabase, objectFactory)
+
+            handler.handle(
+                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                            .body("""
+                            type: StaticResponseHandler
+                            config:
+                               status: 200
+                               content: "Hello, world!"
+                            """.trimIndent(),
+                                    UTF_8)
+                            .build()
+                            .stream(), HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe CREATED
+
+            val r = handler.handle(
+                    HttpRequest.put("/admin/routing/objects/conditionRouter")
+                            .body("""
+                            type: ConditionRouter
+                            config:
+                               routes:
+                                 - condition: path() == "/bar"
+                                   destination: b
+                               fallback: fb
+                            """.trimIndent(),
+                                    UTF_8)
+                            .build()
+                            .stream(), HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+
+            println(r?.bodyAs(UTF_8))
+            r?.status() shouldBe CREATED
+
+
+            val response = handler.handle(
+                    HttpRequest.get("/admin/routing/objects").build()
+                            .stream(), HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+
+            response?.status() shouldBe OK
+
+            response?.bodyAs(UTF_8)?.trim() shouldBe """
+                ---
+                name: "conditionRouter"
+                type: "ConditionRouter"
+                tags: []
+                config:
+                  routes:
+                  - condition: "path() == \"/bar\""
+                    destination: "b"
+                  fallback: "fb"
+
+                ---
+                name: "staticResponse"
+                type: "StaticResponseHandler"
+                tags: []
+                config:
+                  status: 200
+                  content: "Hello, world!"
+            """.trimIndent().trim()
+        }
+
+        scenario("Replacing existing objects") {
+            val handler = RoutingObjectHandler(routeDatabase, objectFactory)
+
+            handler.handle(
+                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                            .body("""
+                            type: StaticResponseHandler
+                            config:
+                               status: 200
+                               content: "Hello, world!"
+                            """.trimIndent(),
+                                    UTF_8)
+                            .build()
+                            .stream(), HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe CREATED
+
+            routeDatabase.get("staticResponse").isPresent shouldBe true
+            val previousConfig = routeDatabase.get("staticResponse").get().config
+            val previousHandler = routeDatabase.get("staticResponse").get().handler
+
+            handler.handle(
+                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                            .body("""
+                            type: StaticResponseHandler
+                            config:
+                               status: 200
+                               content: "Hey man!"
+                            """.trimIndent(),
+                                    UTF_8)
+                            .build()
+                            .stream(), HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe CREATED
+
+            routeDatabase.get("staticResponse").isPresent shouldBe true
+            routeDatabase.get("staticResponse").get().type shouldBe "StaticResponseHandler"
+            routeDatabase.get("staticResponse").get().config shouldNotBeSameInstanceAs previousConfig
+            routeDatabase.get("staticResponse").get().handler shouldNotBeSameInstanceAs previousHandler
+        }
+
+        scenario("Removing existing objects") {
+            val handler = RoutingObjectHandler(routeDatabase, objectFactory)
+
+            handler.handle(
+                    HttpRequest.put("/admin/routing/objects/staticResponse")
+                            .body("""
+                            type: StaticResponseHandler
+                            config:
+                               status: 200
+                               content: "Hello, world!"
+                            """.trimIndent(),
+                                    UTF_8)
+                            .build()
+                            .stream(), HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe CREATED
+
+            routeDatabase.get("staticResponse").isPresent shouldBe true
+
+            handler.handle(
+                    HttpRequest.delete("/admin/routing/objects/staticResponse").build().stream(),
+                    HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe OK
+
+            routeDatabase.get("staticResponse").isPresent shouldBe false
+        }
+
+        scenario("Removing a non-existent object") {
+            val handler = RoutingObjectHandler(routeDatabase, objectFactory)
+
+            handler.handle(
+                    HttpRequest.delete("/admin/routing/objects/staticResponse").build().stream(),
+                    HttpInterceptorContext.create())
+                    .flatMap { it.aggregate(2000) }
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe NOT_FOUND
+        }
+
+    }
+})
+
+fun <T> Eventual<T>.toMono() = Mono.from(this)

--- a/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/RoutingObjectHandlerTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/RoutingObjectHandlerTest.kt
@@ -34,7 +34,7 @@ import io.kotlintest.matchers.types.shouldNotBeSameInstanceAs
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.FeatureSpec
 import io.mockk.mockk
-import reactor.core.publisher.Mono
+import reactor.core.publisher.toMono
 import java.nio.charset.StandardCharsets.UTF_8
 
 class RoutingObjectHandlerTest : FeatureSpec({
@@ -272,5 +272,3 @@ class RoutingObjectHandlerTest : FeatureSpec({
 
     }
 })
-
-fun <T> Eventual<T>.toMono() = Mono.from(this)

--- a/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/UrlPatternRouterTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/UrlPatternRouterTest.kt
@@ -1,0 +1,202 @@
+package com.hotels.styx.admin.handlers
+
+import ch.qos.logback.classic.Level
+import com.hotels.styx.api.Eventual
+import com.hotels.styx.api.HttpInterceptor
+import com.hotels.styx.api.HttpResponseStatus
+import com.hotels.styx.api.HttpResponseStatus.ACCEPTED
+import com.hotels.styx.api.HttpResponseStatus.CREATED
+import com.hotels.styx.api.HttpResponseStatus.NO_CONTENT
+import com.hotels.styx.api.HttpResponseStatus.OK
+import com.hotels.styx.api.LiveHttpRequest
+import com.hotels.styx.api.LiveHttpRequest.post
+import com.hotels.styx.api.LiveHttpResponse
+import com.hotels.styx.api.LiveHttpResponse.response
+import com.hotels.styx.server.HttpInterceptorContext
+import com.hotels.styx.support.matchers.LoggingTestSupport
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FeatureSpec
+import reactor.core.publisher.Mono
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicReference
+
+class UrlPatternRouterTest : FeatureSpec({
+    val LOGGER = LoggingTestSupport(UrlPatternRouter::class.java);
+
+    val router = UrlPatternRouter.Builder()
+            .get("/admin/apps/:appId") { request, context -> Eventual.of(
+                    response(OK)
+                            .header("appId", UrlPatternRouter.placeholders(context)["appId"])
+                            .build())
+            }
+            .get("/admin/apps/:appId/origin/:originId") { request, context -> Eventual.of(
+                    response(OK)
+                            .header("appId", UrlPatternRouter.placeholders(context)["appId"])
+                            .header("originId", UrlPatternRouter.placeholders(context)["originId"])
+                            .build())
+            }
+            .post("/admin/apps/:appId") { request, context -> Eventual.of(
+                    response(CREATED)
+                            .header("appId", UrlPatternRouter.placeholders(context)["appId"])
+                            .build()
+            )}
+            .post("/admin/apps/:appId/origin/:originId") { request, context -> Eventual.of(
+                    response(CREATED)
+                            .header("appId", UrlPatternRouter.placeholders(context)["appId"])
+                            .header("originId", UrlPatternRouter.placeholders(context)["originId"])
+                            .build()
+            )}
+            .put("/admin/apps/:appId") { request, context -> Eventual.of(
+                    response(NO_CONTENT)
+                            .header("appId", UrlPatternRouter.placeholders(context)["appId"])
+                            .build()
+            )}
+            .put("/admin/apps/:appId/origin/:originId") { request, context -> Eventual.of(
+                    response(NO_CONTENT)
+                            .header("appId", UrlPatternRouter.placeholders(context)["appId"])
+                            .header("originId", UrlPatternRouter.placeholders(context)["originId"])
+                            .build()
+            )}
+            .delete("/admin/apps/:appId") { request, context -> Eventual.of(
+                    response(ACCEPTED)
+                            .header("appId", UrlPatternRouter.placeholders(context)["appId"])
+                            .build()
+            )}
+            .delete("/admin/apps/:appId/origin/:originId") { request, context -> Eventual.of(
+                    response(ACCEPTED)
+                            .header("appId", UrlPatternRouter.placeholders(context)["appId"])
+                            .header("originId", UrlPatternRouter.placeholders(context)["originId"])
+                            .build()
+            )}
+            .build()
+
+
+    feature("Request routing") {
+        scenario("GET requests") {
+            val response1 = Mono.from(
+                    router.handle(LiveHttpRequest.get("/admin/apps/234").build(), HttpInterceptorContext.create())
+                            .flatMap { it.aggregate(10000) })
+                    .block()
+
+            response1!!.status() shouldBe OK
+            response1.header("appId") shouldBe Optional.of("234")
+            response1.header("originId") shouldBe Optional.empty()
+
+            val response2 = Mono.from(
+                    router.handle(LiveHttpRequest.get("/admin/apps/234/origin/123").build(), HttpInterceptorContext.create())
+                            .flatMap { it.aggregate(10000) })
+                    .block()
+
+            response2!!.status() shouldBe OK
+            response2.header("appId") shouldBe Optional.of("234")
+            response2.header("originId") shouldBe Optional.of("123")
+        }
+
+        scenario("POST requests") {
+            val response1 = Mono.from(
+                    router.handle(LiveHttpRequest.post("/admin/apps/234").build(), HttpInterceptorContext.create())
+                            .flatMap { it.aggregate(10000) })
+                    .block()
+
+            response1!!.status() shouldBe CREATED
+            response1.header("appId") shouldBe Optional.of("234")
+            response1.header("originId") shouldBe Optional.empty()
+
+            val response2 = Mono.from(
+                    router.handle(LiveHttpRequest.post("/admin/apps/234/origin/123").build(), HttpInterceptorContext.create())
+                            .flatMap { it.aggregate(10000) })
+                    .block()
+
+            response2!!.status() shouldBe CREATED
+            response2.header("appId") shouldBe Optional.of("234")
+            response2.header("originId") shouldBe Optional.of("123")
+        }
+
+        scenario("PUT requests") {
+            val response1 = Mono.from(
+                    router.handle(LiveHttpRequest.put("/admin/apps/234").build(), HttpInterceptorContext.create())
+                            .flatMap { it.aggregate(10000) })
+                    .block()
+
+            response1!!.status() shouldBe NO_CONTENT
+            response1.header("appId") shouldBe Optional.of("234")
+            response1.header("originId") shouldBe Optional.empty()
+
+            val response2 = Mono.from(
+                    router.handle(LiveHttpRequest.put("/admin/apps/234/origin/123").build(), HttpInterceptorContext.create())
+                            .flatMap { it.aggregate(10000) })
+                    .block()
+
+            response2!!.status() shouldBe NO_CONTENT
+            response2.header("appId") shouldBe Optional.of("234")
+            response2.header("originId") shouldBe Optional.of("123")
+        }
+
+        scenario("DELETE requests") {
+            val response1 = Mono.from(
+                    router.handle(LiveHttpRequest.delete("/admin/apps/234").build(), HttpInterceptorContext.create())
+                            .flatMap { it.aggregate(10000) })
+                    .block()
+
+            response1!!.status() shouldBe ACCEPTED
+            response1.header("appId") shouldBe Optional.of("234")
+            response1.header("originId") shouldBe Optional.empty()
+
+            val response2 = Mono.from(
+                    router.handle(LiveHttpRequest.delete("/admin/apps/234/origin/123").build(), HttpInterceptorContext.create())
+                            .flatMap { it.aggregate(10000) })
+                    .block()
+
+            response2!!.status() shouldBe ACCEPTED
+            response2.header("appId") shouldBe Optional.of("234")
+            response2.header("originId") shouldBe Optional.of("123")
+        }
+
+    }
+
+
+    feature("Route Callbacks Invocation") {
+        scenario("Catches and logs user exceptions") {
+            val contextCapture = AtomicReference<HttpInterceptor.Context>()
+
+            val router = UrlPatternRouter.Builder()
+                    .post("/admin/apps/:appId/:originId") { request, context -> throw RuntimeException("Something went wrong") }
+                    .build()
+
+            val response = Mono.from(
+                    router.handle(post("/admin/apps/appx/appx-01").build(), HttpInterceptorContext.create())
+                            .flatMap { it.aggregate(10000) })
+                    .block()
+
+            response!!.status() shouldBe HttpResponseStatus.INTERNAL_SERVER_ERROR
+
+            LOGGER.lastMessage().level shouldBe Level.ERROR
+            LOGGER.lastMessage().formattedMessage shouldBe "ERROR: POST /admin/apps/appx/appx-01"
+        }
+    }
+
+    feature("Placeholders") {
+        scenario("Are exposed in HTTP context") {
+            val contextCapture = AtomicReference<HttpInterceptor.Context>()
+
+            val router = UrlPatternRouter.Builder()
+                    .post("/admin/apps/:appId/:originId") { request, context ->
+                        contextCapture.set(context)
+                        Eventual.of<LiveHttpResponse>(response(OK).build())
+                    }
+                    .build()
+
+            val response = Mono.from(
+                    router.handle(post("/admin/apps/appx/appx-01").build(), HttpInterceptorContext.create())
+                            .flatMap { it.aggregate(10000) })
+                    .block()
+
+
+            response!!.status() shouldBe OK
+
+            val placeholders = UrlPatternRouter.placeholders(contextCapture.get())
+            placeholders["appId"] shouldBe "appx"
+            placeholders["originId"] shouldBe "appx-01"
+        }
+    }
+})

--- a/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/UrlPatternRouterTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/UrlPatternRouterTest.kt
@@ -18,9 +18,9 @@ package com.hotels.styx.admin.handlers
 import ch.qos.logback.classic.Level
 import com.hotels.styx.api.Eventual
 import com.hotels.styx.api.HttpInterceptor
-import com.hotels.styx.api.HttpResponseStatus
 import com.hotels.styx.api.HttpResponseStatus.ACCEPTED
 import com.hotels.styx.api.HttpResponseStatus.CREATED
+import com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR
 import com.hotels.styx.api.HttpResponseStatus.NO_CONTENT
 import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.LiveHttpRequest
@@ -183,7 +183,7 @@ class UrlPatternRouterTest : FeatureSpec({
                             .flatMap { it.aggregate(10000) })
                     .block()
 
-            response!!.status() shouldBe HttpResponseStatus.INTERNAL_SERVER_ERROR
+            response!!.status() shouldBe INTERNAL_SERVER_ERROR
 
             LOGGER.lastMessage().level shouldBe Level.ERROR
             LOGGER.lastMessage().formattedMessage shouldBe "ERROR: POST /admin/apps/appx/appx-01"

--- a/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/UrlPatternRouterTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/UrlPatternRouterTest.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 package com.hotels.styx.admin.handlers
 
 import ch.qos.logback.classic.Level

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/config/RoutingObjectFactoryTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/config/RoutingObjectFactoryTest.kt
@@ -39,7 +39,7 @@ class RoutingObjectFactoryTest : StringSpec({
     }
 
     val routeObjectStore = mockk<StyxObjectStore<RoutingObjectRecord>>()
-    every { routeObjectStore.get("aHandler") } returns Optional.of(RoutingObjectRecord("name", setOf(), mockk(), mockHandler))
+    every { routeObjectStore.get("aHandler") } returns Optional.of(RoutingObjectRecord("type", mockk(), mockHandler))
     
     "Builds a new handler as per RoutingObjectDefinition" {
         val routeDef = RoutingObjectDefinition("handler-def", "DelegateHandler", mockk())

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/db/StyxObjectStoreTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/db/StyxObjectStoreTest.kt
@@ -26,7 +26,7 @@ import io.kotlintest.specs.FeatureSpec
 import reactor.core.publisher.Flux
 import reactor.test.StepVerifier
 import java.util.Optional
-import java.util.concurrent.Executors
+import java.util.concurrent.Executors.newFixedThreadPool
 import java.util.concurrent.TimeUnit.SECONDS
 
 // We can remove AssertionError::class.java argument from the
@@ -88,7 +88,7 @@ class StyxObjectStoreTest : FeatureSpec() {
 
             scenario("Maintains database integrity in concurrent operations") {
                 val db = StyxObjectStore<String>()
-                val executor = Executors.newFixedThreadPool(8)
+                val executor = newFixedThreadPool(8)
 
                 for (i in 1..10000) {
                     executor.execute { db.insert("redirect-$i", "Record-$i") }
@@ -190,7 +190,7 @@ class StyxObjectStoreTest : FeatureSpec() {
                 }
 
                 // Then remove everyting, concurrently:
-                val executor = Executors.newFixedThreadPool(8)
+                val executor = newFixedThreadPool(8)
                 for (i in 1..10000) {
                     executor.execute { db.remove("redirect-$i") }
                 }

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/ConditionRouterConfigTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/ConditionRouterConfigTest.kt
@@ -44,15 +44,13 @@ class ConditionRouterConfigTest : StringSpec({
     val routeObjectStore = mockk<StyxObjectStore<RoutingObjectRecord>>()
     every { routeObjectStore.get("secureHandler") } returns
             Optional.of(RoutingObjectRecord(
-                    "secureHandler",
-                    setOf(),
+                    "StaticResponseHandler",
                     mockk(),
                     HttpHandler { _, _ -> Eventual.of(response(OK).header("source", "secure").build()) }))
 
     every { routeObjectStore.get("fallbackHandler") } returns
             Optional.of(RoutingObjectRecord(
-                    "fallbackHandler",
-                    setOf(),
+                    "StaticResponseHandler",
                     mockk(),
                     HttpHandler { _, _ -> Eventual.of(response(OK).header("source", "fallback").build()) }))
 

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/RoutingRestApiSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/RoutingRestApiSpec.kt
@@ -1,0 +1,202 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.routing
+
+import com.hotels.styx.StyxConfig
+import com.hotels.styx.StyxServer
+import com.hotels.styx.api.HttpHeaderNames.HOST
+import com.hotels.styx.api.HttpRequest.delete
+import com.hotels.styx.api.HttpRequest.get
+import com.hotels.styx.api.HttpRequest.put
+import com.hotels.styx.api.HttpResponseStatus.CREATED
+import com.hotels.styx.api.HttpResponseStatus.NOT_FOUND
+import com.hotels.styx.api.HttpResponseStatus.OK
+import com.hotels.styx.client.StyxHttpClient
+import com.hotels.styx.startup.StyxServerComponents
+import com.hotels.styx.support.ResourcePaths.fixturesHome
+import io.kotlintest.Spec
+import io.kotlintest.TestCase
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import reactor.core.publisher.toMono
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+class RoutingRestApiSpec : StringSpec() {
+
+    val originsOk = fixturesHome(RoutingRestApiSpec::class.java, "/conf/origins/origins-correct.yml")
+    val yamlText = """
+        proxy:
+          connectors:
+            http:
+              port: 0
+
+            https:
+              port: 0
+              sslProvider: JDK
+              sessionTimeoutMillis: 300000
+              sessionCacheSize: 20000
+
+        services:
+          factories:
+            backendServiceRegistry:
+              class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry${'$'}Factory"
+              config: {originsFile: "$originsOk"}
+
+        admin:
+          connectors:
+            http:
+              port: 0
+
+        httpPipeline: root
+      """.trimIndent()
+
+    init {
+        "Creates and updates new routing object" {
+            client.send(
+                    put("/admin/routing/objects/responder")
+                            .header(HOST, "${styxServer.adminHttpAddress().hostName}:${styxServer.adminHttpAddress().port}")
+                            .body("""
+                                type: StaticResponseHandler
+                                config:
+                                  status: 200
+                                  content: "Responder"
+                            """.trimIndent(), UTF_8)
+                            .build())
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe CREATED
+
+            client.send(
+                    put("/admin/routing/objects/root")
+                            .header(HOST, "${styxServer.adminHttpAddress().hostName}:${styxServer.adminHttpAddress().port}")
+                            .body("""
+                                type: InterceptorPipeline
+                                config:
+                                  handler: responder
+                            """.trimIndent(), UTF_8)
+                            .build())
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe CREATED
+
+            val response = client.send(
+                    get("/11")
+                            .header(HOST, "${styxServer.proxyHttpAddress().hostName}:${styxServer.proxyHttpAddress().port}")
+                            .build())
+                    .toMono()
+                    .block();
+
+            response?.status() shouldBe (OK)
+            response?.bodyAs(UTF_8) shouldBe ("Responder")
+        }
+
+        "Removes routing objects" {
+            client.send(
+                    delete("/admin/routing/objects/root")
+                            .header(HOST, "${styxServer.adminHttpAddress().hostName}:${styxServer.adminHttpAddress().port}")
+                            .build())
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe OK
+
+            client.send(
+                    get("/11")
+                            .header(HOST, "${styxServer.proxyHttpAddress().hostName}:${styxServer.proxyHttpAddress().port}")
+                            .build())
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe NOT_FOUND
+        }
+
+        "Lists routing objects" {
+            client.send(
+                    put("/admin/routing/objects/responder")
+                            .header(HOST, "${styxServer.adminHttpAddress().hostName}:${styxServer.adminHttpAddress().port}")
+                            .body("""
+                                type: StaticResponseHandler
+                                config:
+                                  status: 200
+                                  content: "Responder"
+                            """.trimIndent(), UTF_8)
+                            .build())
+                    .toMono()
+                    .block()
+                    ?.status() shouldBe CREATED
+
+            val info = client.send(
+                    get("/admin/routing/objects")
+                            .header(HOST, "${styxServer.adminHttpAddress().hostName}:${styxServer.adminHttpAddress().port}")
+                            .build())
+                    .toMono()
+                    .block()
+
+            info?.status() shouldBe OK
+            info?.bodyAs(UTF_8)?.trim() shouldBe """
+                ---
+                name: "responder"
+                type: "StaticResponseHandler"
+                tags: []
+                config:
+                  status: 200
+                  content: "Responder"
+
+                ---
+                name: "root"
+                type: "StaticResponseHandler"
+                tags: []
+                config:
+                  status: 200
+                  content: "Root"
+                """.trimIndent().trim()
+        }
+    }
+
+    val client: StyxHttpClient = StyxHttpClient.Builder()
+            .threadName("functional-test-client")
+            .connectTimeout(1000, MILLISECONDS)
+            .maxHeaderSize(2 * 8192)
+            .build()
+
+    val styxServer = StyxServer(StyxServerComponents.Builder()
+            .styxConfig(StyxConfig.fromYaml(yamlText))
+            .build())
+
+    override fun beforeTest(testCase: TestCase) {
+        super.beforeTest(testCase)
+        client.send(
+                put("/admin/routing/objects/root")
+                        .header(HOST, "${styxServer.adminHttpAddress().hostName}:${styxServer.adminHttpAddress().port}")
+                        .body("""
+                                type: StaticResponseHandler
+                                config:
+                                  status: 200
+                                  content: "Root"
+                            """.trimIndent(), UTF_8)
+                        .build())
+                .toMono()
+                .block()
+                ?.status() shouldBe CREATED
+    }
+
+    override fun beforeSpec(spec: Spec) {
+        styxServer.startAsync().awaitRunning()
+    }
+
+    override fun afterSpec(spec: Spec) {
+        styxServer.stopAsync().awaitTerminated()
+    }
+}


### PR DESCRIPTION
I'm adding a new `UrlPatternRouter`. To configure this router, you specify a regular expression pattern for each endpoint per HTTP verb. It also captures patterns from URL and exposes them as values in HTTP context. See the unit tests as an example.

I have also added a new `RoutingObjectHandler` that builds on `UrlPatternRouter`. It allows Styx Routing Object Store to be modified via RESTful API. It supports, addition, removal, and replacement of routing objects.

The ObjectStore is updated accordingly, to support these features. Notice that ObjectStore concurrency model is improved. Object store modifications (insert/remove) now take place, always, in the calling thread. The executor simply delivers the watch notifications.
