### PR TITLE
Include server name indication (SNI) in outgoing TLS connections.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
@@ -60,7 +60,7 @@ public class TlsSettings {
         this.protocols = ImmutableList.copyOf(builder.protocols);
         this.cipherSuites = ImmutableList.copyOf(builder.cipherSuites);
         this.sendSni = builder.sendSni;
-        this.sniHost = builder.sniHost;
+        this.sniHost = Optional.ofNullable(builder.sniHost);
     }
 
     private char[] toCharArray(String password) {
@@ -142,14 +142,14 @@ public class TlsSettings {
                 .add("protocols", this.protocols)
                 .add("cipherSuites", this.cipherSuites)
                 .add("sendSni", this.sendSni)
-                .add("sniHost", this.sniHost)
+                .add("sniHost", this.sniHost.orElse(""))
                 .toString();
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(trustAllCerts, sslProvider, additionalCerts,
-                trustStorePath, Arrays.hashCode(trustStorePassword), protocols, cipherSuites, sendSni, sniHost);
+                trustStorePath, Arrays.hashCode(trustStorePassword), protocols, cipherSuites, sendSni, sniHost.orElse(""));
     }
 
 
@@ -166,7 +166,7 @@ public class TlsSettings {
         private List<String> protocols = Collections.emptyList();
         private List<String> cipherSuites = Collections.emptyList();
         private boolean sendSni = true;
-        private Optional<String> sniHost = Optional.empty();
+        private String sniHost;
 
         /**
          * Skips origin authentication.
@@ -247,7 +247,7 @@ public class TlsSettings {
         }
 
         public Builder sniHost(String sniHost) {
-            this.sniHost = Optional.ofNullable(sniHost);
+            this.sniHost = sniHost;
             return this;
         }
 

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Objects.firstNonNull;
@@ -47,6 +48,8 @@ public class TlsSettings {
     private final char[] trustStorePassword;
     private final List<String> protocols;
     private final List<String> cipherSuites;
+    private final boolean sendSni;
+    private final Optional<String> sniHost;
 
     private TlsSettings(Builder builder) {
         this.trustAllCerts = requireNonNull(builder.trustAllCerts);
@@ -56,6 +59,8 @@ public class TlsSettings {
         this.trustStorePassword = toCharArray(builder.trustStorePassword);
         this.protocols = ImmutableList.copyOf(builder.protocols);
         this.cipherSuites = ImmutableList.copyOf(builder.cipherSuites);
+        this.sendSni = builder.sendSni;
+        this.sniHost = builder.sniHost;
     }
 
     private char[] toCharArray(String password) {
@@ -94,6 +99,18 @@ public class TlsSettings {
         return this.cipherSuites;
     }
 
+    public boolean sendSni() {
+        return sendSni;
+    }
+
+    public Optional<String> sniHost() {
+        return sniHost;
+    }
+
+    public  String getSniHost() {
+        return sniHost.orElse(null);
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -109,7 +126,9 @@ public class TlsSettings {
                 && Objects.equals(this.trustStorePath, other.trustStorePath)
                 && Arrays.equals(this.trustStorePassword, other.trustStorePassword)
                 && Objects.equals(this.protocols, other.protocols)
-                && Objects.equals(this.cipherSuites, other.cipherSuites);
+                && Objects.equals(this.cipherSuites, other.cipherSuites)
+                && Objects.equals(this.sniHost, other.sniHost)
+                && Objects.equals(this.sendSni, other.sendSni);
     }
 
     @Override
@@ -122,13 +141,15 @@ public class TlsSettings {
                 .add("trustStorePassword", this.trustStorePassword)
                 .add("protocols", this.protocols)
                 .add("cipherSuites", this.cipherSuites)
+                .add("sendSni", this.sendSni)
+                .add("sniHost", this.sniHost)
                 .toString();
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(trustAllCerts, sslProvider, additionalCerts,
-                trustStorePath, Arrays.hashCode(trustStorePassword), protocols, cipherSuites);
+                trustStorePath, Arrays.hashCode(trustStorePassword), protocols, cipherSuites, sendSni, sniHost);
     }
 
 
@@ -144,6 +165,8 @@ public class TlsSettings {
         private String trustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword");
         private List<String> protocols = Collections.emptyList();
         private List<String> cipherSuites = Collections.emptyList();
+        private boolean sendSni = true;
+        private Optional<String> sniHost = Optional.empty();
 
         /**
          * Skips origin authentication.
@@ -217,6 +240,17 @@ public class TlsSettings {
             this.cipherSuites = cipherSuites;
             return this;
         }
+
+        public Builder sendSni(boolean sendSni) {
+            this.sendSni = sendSni;
+            return this;
+        }
+
+        public Builder sniHost(String sniHost) {
+            this.sniHost = Optional.ofNullable(sniHost);
+            return this;
+        }
+
 
         public TlsSettings build() {
             if (!trustAllCerts && trustStorePassword == null) {

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
@@ -142,14 +142,14 @@ public class TlsSettings {
                 .add("protocols", this.protocols)
                 .add("cipherSuites", this.cipherSuites)
                 .add("sendSni", this.sendSni)
-                .add("sniHost", this.sniHost.orElse(""))
+                .add("sniHost", this.getSniHost())
                 .toString();
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(trustAllCerts, sslProvider, additionalCerts,
-                trustStorePath, Arrays.hashCode(trustStorePassword), protocols, cipherSuites, sendSni, sniHost.orElse(""));
+                trustStorePath, Arrays.hashCode(trustStorePassword), protocols, cipherSuites, sendSni, this.getSniHost());
     }
 
 

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
@@ -107,6 +107,10 @@ public class TlsSettings {
         return sniHost;
     }
 
+    /**
+     * This method will be invoked during the serialization process to return the SNI host name in a JSON-friendly format.
+     * @return configured SNI hostname or null if none
+     */
     public  String getSniHost() {
         return sniHost.orElse(null);
     }

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/FlowControllingHttpContentProducer.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/FlowControllingHttpContentProducer.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import static rx.internal.operators.BackpressureUtils.getAndAddRequest;
 
 class FlowControllingHttpContentProducer {
     private static final Logger LOGGER = LoggerFactory.getLogger(FlowControllingHttpContentProducer.class);
+    private static final int MAX_DEPTH = 1;
 
     private final StateMachine<ProducerState> stateMachine;
     private final String loggingPrefix;
@@ -65,7 +66,6 @@ class FlowControllingHttpContentProducer {
     final AtomicLong queueDepthChunks = new AtomicLong(0);
 
     private final Origin origin;
-    private final int MAX_DEPTH = 1;
 
     private volatile Subscriber<? super ByteBuf> contentSubscriber;
 

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnection.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnection.java
@@ -42,6 +42,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class NettyConnection implements Connection, TimeToFirstByteListener {
     private static final AttributeKey<Object> CLOSED_BY_STYX = AttributeKey.newInstance("CLOSED_BY_STYX");
+    private static final int IGNORED_PORT_NUMBER = -1;
 
     private final Origin origin;
     private final Channel channel;
@@ -78,7 +79,7 @@ public class NettyConnection implements Connection, TimeToFirstByteListener {
 
         if (sslContext != null) {
             SslHandler sslHandler = sendSni
-                    ? sslContext.newHandler(channel.alloc(), targetHost, -1)
+                    ? sslContext.newHandler(channel.alloc(), targetHost, IGNORED_PORT_NUMBER)
                     : sslContext.newHandler(channel.alloc());
             pipeline.addLast("ssl", sslHandler);
         }

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnection.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnection.java
@@ -77,9 +77,9 @@ public class NettyConnection implements Connection, TimeToFirstByteListener {
         ChannelPipeline pipeline = channel.pipeline();
 
         if (sslContext != null) {
-            SslHandler sslHandler = sendSni ?
-                    sslContext.newHandler(channel.alloc(), targetHost, -1) :
-                    sslContext.newHandler(channel.alloc());
+            SslHandler sslHandler = sendSni
+                    ? sslContext.newHandler(channel.alloc(), targetHost, -1)
+                    : sslContext.newHandler(channel.alloc());
             pipeline.addLast("ssl", sslHandler);
         }
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyConnectionTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyConnectionTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package com.hotels.styx.client.netty.connectionpool;
 
-import com.hotels.styx.client.Connection;
 import com.hotels.styx.api.extension.Origin;
+import com.hotels.styx.client.Connection;
 import com.hotels.styx.client.HttpConfig;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -66,7 +66,7 @@ public class NettyConnectionTest {
     }
 
     private Connection createConnection() {
-        return new NettyConnection(origin, channel, null, httpConfig, null);
+        return new NettyConnection(origin, channel, null, httpConfig, null, false, Optional.empty());
     }
 
     static class EventCapturingListener implements Connection.Listener {

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/json/mixins/TlsSettingsMixin.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/json/mixins/TlsSettingsMixin.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -54,6 +54,12 @@ public interface TlsSettingsMixin {
     @JsonProperty("cipherSuites")
     List<String> cipherSuites();
 
+    @JsonProperty("sendSni")
+    boolean sendSni();
+
+    @JsonProperty("sniHost")
+    String getSniHost();
+
     /**
      * The builder for SSL settings.
      */
@@ -82,6 +88,12 @@ public interface TlsSettingsMixin {
 
         @JsonProperty("cipherSuites")
         Builder cipherSuites(List<String> cipherSuites);
+
+        @JsonProperty("sendSni")
+        Builder sendSni(boolean sendSni);
+
+        @JsonProperty("sniHost")
+        Builder sniHost(String sniHost);
     }
 }
 

--- a/distribution/conf/styx-env.sh
+++ b/distribution/conf/styx-env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2013-2018 Expedia Inc.
+# Copyright (C) 2013-2019 Expedia Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/user-guide/configure-tls.md
+++ b/docs/user-guide/configure-tls.md
@@ -140,7 +140,11 @@ be specified as separate backends.
     When absent, enables all default protocols for the `sslProvider`.
     Possible protocol names are: `TLS`, `TLSv1`, `TLSv1.1`, and `TLSv1.2`.
 
-Attributes that accept lists can be defined with the following format: ['ITEM1', 'ITEM2']
+  - *sendSni* - Send the Origin server hostname in the TLS handshake as per the SNI extension (https://tools.ietf.org/html/rfc6066). This feature is enabled by default.
+  
+  - *sniHost* - Override the hostname of the Origin server that will be sent in the SNI (server_name) extension. When this value is not set, the hostname will be the configured in `Origins\Host`. 
+  
+Attributes that accept lists can be defined with the following format: ['ITEM1', 'ITEM2']  
 
 ## Troubleshooting TLS Configuration
 


### PR DESCRIPTION
Add support for SNI in Styx-client, so the destination ServerName will be sent in outgoing TLS requests as per RFC 6066 section 3 (https://tools.ietf.org/html/rfc6066#section-3).

