### PR TITLE
Make all origin metrics relative to the scope they are used.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/MetricRegistry.java
+++ b/components/api/src/main/java/com/hotels/styx/api/MetricRegistry.java
@@ -61,7 +61,8 @@ public interface MetricRegistry {
 
 
     /**
-     * Creates a new {@link com.codahale.metrics.Counter} and registers it under the given name.
+     * Return the {@link com.codahale.metrics.Counter} registered under {@code name} or create
+     * a new {@link com.codahale.metrics.Counter} and register it under {@code name}.
      *
      * @param name the name of the metric
      * @return a new {@link com.codahale.metrics.Counter}
@@ -69,7 +70,8 @@ public interface MetricRegistry {
     Counter counter(String name);
 
     /**
-     * Creates a new {@link com.codahale.metrics.Histogram} and registers it under the given name.
+     * Return the {@link com.codahale.metrics.Histogram} registered under {@code name} or create
+     * a new {@link com.codahale.metrics.Histogram} and register it under {@code name}.
      *
      * @param name the name of the metric
      * @return a new {@link com.codahale.metrics.Histogram}
@@ -77,7 +79,8 @@ public interface MetricRegistry {
     Histogram histogram(String name);
 
     /**
-     * Creates a new {@link com.codahale.metrics.Meter} and registers it under the given name.
+     * Return the {@link com.codahale.metrics.Meter} registered under {@code name} or create
+     * a new {@link com.codahale.metrics.Meter} and register it under {@code name}.
      *
      * @param name the name of the metric
      * @return a new {@link com.codahale.metrics.Meter}
@@ -85,7 +88,8 @@ public interface MetricRegistry {
     Meter meter(String name);
 
     /**
-     * Creates a new {@link com.codahale.metrics.Timer} and registers it under the given name.
+     * Return the {@link com.codahale.metrics.Timer} registered under {@code name} or create
+     * a new {@link com.codahale.metrics.Timer} and register it under {@code name}.
      *
      * @param name the name of the metric
      * @return a new {@link com.codahale.metrics.Timer}

--- a/components/client/src/main/java/com/hotels/styx/client/HttpRequestOperationFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/HttpRequestOperationFactory.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.hotels.styx.client;
 
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
+import com.hotels.styx.client.OriginStatsFactory.CachingOriginStatsFactory;
 import com.hotels.styx.client.netty.connectionpool.HttpRequestOperation;
 
 /**
@@ -35,7 +36,7 @@ public interface HttpRequestOperationFactory {
      * Builds HttpRequestOperationFactory objects.
      */
     class Builder {
-        OriginStatsFactory originStatsFactory = new OriginStatsFactory(new CodaHaleMetricRegistry());
+        OriginStatsFactory originStatsFactory = new CachingOriginStatsFactory(new CodaHaleMetricRegistry());
         int responseTimeoutMillis = 60000;
         boolean flowControlEnabled;
         boolean requestLoggingEnabled;

--- a/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -441,7 +441,7 @@ public final class OriginsInventory
 
                     .build();
 
-            this.gaugeName = "origins." + appId + "." + origin.id() + ".status";
+            this.gaugeName = appId + "." + origin.id() + ".status";
         }
 
         private void close() {

--- a/components/client/src/main/java/com/hotels/styx/client/StyxBackendServiceClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxBackendServiceClient.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import com.hotels.styx.api.extension.retrypolicy.spi.RetryPolicy;
 import com.hotels.styx.api.extension.service.RewriteRule;
 import com.hotels.styx.api.extension.service.StickySessionConfig;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
+import com.hotels.styx.client.OriginStatsFactory.CachingOriginStatsFactory;
 import com.hotels.styx.client.retry.RetryNTimes;
 import com.hotels.styx.client.stickysession.StickySessionLoadBalancingStrategy;
 import com.hotels.styx.server.HttpInterceptorContext;
@@ -398,7 +399,7 @@ public final class StyxBackendServiceClient implements BackendServiceClient {
 
         public StyxBackendServiceClient build() {
             if (originStatsFactory == null) {
-                originStatsFactory = new OriginStatsFactory(metricsRegistry);
+                originStatsFactory = new CachingOriginStatsFactory(metricsRegistry);
             }
             return new StyxBackendServiceClient(this);
         }

--- a/components/client/src/main/java/com/hotels/styx/client/applications/metrics/OriginMetrics.java
+++ b/components/client/src/main/java/com/hotels/styx/client/applications/metrics/OriginMetrics.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ import static java.util.Objects.requireNonNull;
  * connections scheduled on different event loops.
  */
 public class OriginMetrics implements OriginStats {
-    private static final String PREFIX = "origins";
     private static final Logger LOG = LoggerFactory.getLogger(OriginMetrics.class);
     private static final int SERVER_ERROR_CLASS = 5;
 
@@ -86,19 +85,8 @@ public class OriginMetrics implements OriginStats {
      * @return a new OriginMetrics
      */
     public static OriginMetrics create(Origin origin, MetricRegistry metricRegistry) {
-        MetricRegistry originsRootRegistry = metricRegistry.scope(OriginMetrics.PREFIX);
-        ApplicationMetrics appMetrics = new ApplicationMetrics(origin.applicationId(), originsRootRegistry);
+        ApplicationMetrics appMetrics = new ApplicationMetrics(origin.applicationId(), metricRegistry);
         return new OriginMetrics(appMetrics, origin);
-    }
-
-    /**
-     * Gets a naming scope for metrics pertaining to the given origin.
-     *
-     * @param origin an origin
-     * @return naming scope
-     */
-    public static String originMetricsScope(Origin origin) {
-        return name(OriginMetrics.PREFIX, origin.applicationId().toString(), originName(origin));
     }
 
     @Override

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/StatsReportingConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/StatsReportingConnectionPool.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import com.hotels.styx.client.Connection;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 
-import static com.hotels.styx.client.applications.metrics.OriginMetrics.originMetricsScope;
+import static com.codahale.metrics.MetricRegistry.name;
 import static java.util.Arrays.asList;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -98,7 +98,7 @@ class StatsReportingConnectionPool implements ConnectionPool {
         }
     }
 
-    private void registerMetrics(ConnectionPool hostConnectionPool, MetricRegistry scopedRegistry) {
+    private static void registerMetrics(ConnectionPool hostConnectionPool, MetricRegistry scopedRegistry) {
         ConnectionPool.Stats stats = hostConnectionPool.stats();
         scopedRegistry.register("busy-connections", (Gauge<Integer>) stats::busyConnectionCount);
         scopedRegistry.register("pending-connections", (Gauge<Integer>) stats::pendingConnectionCount);
@@ -110,6 +110,9 @@ class StatsReportingConnectionPool implements ConnectionPool {
     }
 
     private MetricRegistry getMetricScope(ConnectionPool hostConnectionPool) {
-        return this.metricRegistry.scope(com.codahale.metrics.MetricRegistry.name(originMetricsScope(hostConnectionPool.getOrigin()), METRICS_NAME));
+        return this.metricRegistry.scope(
+                name(hostConnectionPool.getOrigin().applicationId().toString(),
+                        hostConnectionPool.getOrigin().id().toString(),
+                        METRICS_NAME));
     }
 }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/OriginStatsFactoryTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/OriginStatsFactoryTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.hotels.styx.client;
 
 import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
+import com.hotels.styx.client.OriginStatsFactory.CachingOriginStatsFactory;
 import com.hotels.styx.client.applications.OriginStats;
 import org.testng.annotations.Test;
 
@@ -27,7 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class OriginStatsFactoryTest {
 
-    final OriginStatsFactory originStatsFactory = new OriginStatsFactory(new CodaHaleMetricRegistry());
+    final OriginStatsFactory originStatsFactory = new CachingOriginStatsFactory(new CodaHaleMetricRegistry());
 
     @Test
     public void returnTheSameStatsForSameOrigin() {

--- a/components/client/src/test/unit/java/com/hotels/styx/client/OriginsInventoryTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/OriginsInventoryTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class OriginsInventoryTest {
 
     @BeforeMethod
     public void setUp() {
-        metricRegistry = new CodaHaleMetricRegistry();
+        metricRegistry = new CodaHaleMetricRegistry().scope("origins");
         logger = new LoggingTestSupport(OriginsInventory.class);
         monitor = mock(OriginHealthStatusMonitor.class);
         eventBus = mock(EventBus.class);

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxBackendServiceClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxBackendServiceClientTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
@@ -91,7 +92,9 @@ public class StyxBackendServiceClientTest {
 
     @BeforeMethod
     public void setUp() {
-        metricRegistry = new CodaHaleMetricRegistry();
+        metricRegistry = new CodaHaleMetricRegistry()
+                .scope("origins")
+        ;
     }
 
     @Test
@@ -358,8 +361,14 @@ public class StyxBackendServiceClientTest {
                 .thenCancel()
                 .verify();
 
-        assertThat(metricRegistry.counter("origins.App-X.requests.cancelled").getCount(), is(1L));
-        assertThat(metricRegistry.counter("origins.App-X.Origin-Y.requests.cancelled").getCount(), is(1L));
+        assertThat(metricRegistry.getNames(), hasItems(
+                "origins.App-X.requests.cancelled",
+                "origins.App-X.Origin-Y.requests.cancelled"));
+
+        // metricRegistry is already scoped at "origins". Therefore the following metric
+        // names don't need to be prefixed with it:
+        assertThat(metricRegistry.counter("App-X.requests.cancelled").getCount(), is(1L));
+        assertThat(metricRegistry.counter("App-X.Origin-Y.requests.cancelled").getCount(), is(1L));
     }
 
     @Test

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxBackendServiceClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxBackendServiceClientTest.java
@@ -93,8 +93,7 @@ public class StyxBackendServiceClientTest {
     @BeforeMethod
     public void setUp() {
         metricRegistry = new CodaHaleMetricRegistry()
-                .scope("origins")
-        ;
+                .scope("origins");
     }
 
     @Test

--- a/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/SimpleConnectionPoolFactoryTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/SimpleConnectionPoolFactoryTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -28,17 +28,21 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.mockito.Mockito.mock;
 
 public class SimpleConnectionPoolFactoryTest {
-    private final Origin origin = newOriginBuilder("localhost", 12345).id("origin-X").applicationId("test-app").build();
+    private final Origin origin = newOriginBuilder("localhost", 12345)
+            .id("origin-X")
+            .applicationId("test-app")
+            .build();
 
     @Test
     public void registersMetricsUnderOriginsScope() {
-        MetricRegistry metricRegistry = new CodaHaleMetricRegistry();
+        MetricRegistry metricRegistry = new CodaHaleMetricRegistry()
+                .scope("origins");
+
         SimpleConnectionPoolFactory factory = new SimpleConnectionPoolFactory.Builder()
                 .connectionFactory(mock(Connection.Factory.class))
                 .connectionPoolSettings(defaultConnectionPoolSettings())
                 .metricRegistry(metricRegistry)
                 .build();
-
         factory.create(origin);
 
         assertThat(metricRegistry.getGauges().keySet(), hasItems(

--- a/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/StatsReportingConnectionPoolTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/StatsReportingConnectionPoolTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -31,8 +31,11 @@ public class StatsReportingConnectionPoolTest {
     final Origin origin = newOriginBuilder("localhost", 9090)
             .id("backend-01")
             .build();
+
+    final MetricRegistry metricRegistry = new CodaHaleMetricRegistry()
+            .scope("origins");
+
     final ConnectionPool delegate = new StubConnectionPool(origin);
-    final MetricRegistry metricRegistry = new CodaHaleMetricRegistry();
     final StatsReportingConnectionPool pool = new StatsReportingConnectionPool(delegate, metricRegistry);
 
     @Test

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
@@ -27,6 +27,7 @@ import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
 import com.hotels.styx.client.BackendServiceClient;
 import com.hotels.styx.client.Connection;
 import com.hotels.styx.client.OriginStatsFactory;
+import com.hotels.styx.client.OriginStatsFactory.CachingOriginStatsFactory;
 import com.hotels.styx.client.OriginsInventory;
 import com.hotels.styx.client.connectionpool.ConnectionPool;
 import com.hotels.styx.client.connectionpool.ExpiringConnectionFactory;
@@ -91,7 +92,7 @@ public class ProxyToBackend implements HttpHandler {
                     .get("backend.origins", JsonNode.class)
                     .orElseThrow(() -> missingAttributeError(configBlock, join(".", append(parents, "backend")), "origins"));
 
-            OriginStatsFactory originStatsFactory = new OriginStatsFactory(context.environment().metricRegistry());
+            OriginStatsFactory originStatsFactory = new CachingOriginStatsFactory(context.environment().metricRegistry());
 
             Connection.Factory connectionFactory = new NettyConnectionFactory.Builder()
                     .name("Styx")

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/StyxBackendServiceClientFactoryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/StyxBackendServiceClientFactoryTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.hotels.styx.api.configuration.Configuration.MapBackedConfiguration;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.api.extension.service.BackendService;
 import com.hotels.styx.client.OriginStatsFactory;
+import com.hotels.styx.client.OriginStatsFactory.CachingOriginStatsFactory;
 import com.hotels.styx.client.OriginsInventory;
 import com.hotels.styx.client.StyxHostHttpClient;
 import com.hotels.styx.client.StyxBackendServiceClient;
@@ -122,7 +123,7 @@ public class StyxBackendServiceClientFactoryTest {
                                     }
                                 })
                                 .build(),
-                        new OriginStatsFactory(new CodaHaleMetricRegistry()));
+                        new CachingOriginStatsFactory(new CodaHaleMetricRegistry()));
 
         LiveHttpRequest requestz = get("/some-req").cookies(requestCookie(STICKY_COOKIE, id("z").toString())).build();
         LiveHttpRequest requestx = get("/some-req").cookies(requestCookie(STICKY_COOKIE, id("x").toString())).build();
@@ -167,7 +168,7 @@ public class StyxBackendServiceClientFactoryTest {
                                     }
                                 })
                                 .build(),
-                        new OriginStatsFactory(new CodaHaleMetricRegistry()));
+                        new CachingOriginStatsFactory(new CodaHaleMetricRegistry()));
 
         LiveHttpRequest requestz = get("/some-req").cookies(requestCookie(ORIGINS_RESTRICTION_COOKIE, id("z").toString())).build();
         LiveHttpRequest requestx = get("/some-req").cookies(requestCookie(ORIGINS_RESTRICTION_COOKIE, id("x").toString())).build();


### PR DESCRIPTION
## Problem Statement

The origin metric names are not relative to the scope they are used. This makes it very inconvenient to re-use code in other context.

For example the connection pool gets to decide a metric name prefix "origins.app.origin.connectionPool". Therefore all connection pool metrics are published with that prefix even if origins, application, or origin have no context in a particular use case. This limits pools usability for other purposes.

## Fix

This PR makes all origin metrics producing components re-usable for other purposes.

The appropriate metrics scope is now injected into all relevant components: 
* Origin Stats Factory
* Connection pool
* Origins inventory (origins status metrics)


