### PR TITLE
Routing object lifecycle management

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/StyxPipelineFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxPipelineFactory.java
@@ -23,6 +23,7 @@ import com.hotels.styx.api.extension.service.spi.Registry;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
 import com.hotels.styx.routing.HttpPipelineFactory;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.RoutingObjectRecord;
 import com.hotels.styx.routing.StaticPipelineFactory;
 import com.hotels.styx.routing.config.RoutingObjectConfiguration;
@@ -74,7 +75,7 @@ public final class StyxPipelineFactory implements PipelineFactory {
                 requestTracking);
     }
 
-    private HttpHandler configuredPipeline(RoutingObjectFactory routingObjectFactory) {
+    private RoutingObject configuredPipeline(RoutingObjectFactory routingObjectFactory) {
         boolean requestTracking = environment.configuration().get("requestTracking", Boolean.class).orElse(false);
 
         Optional<JsonNode> rootHandlerNode = environment.configuration().get("httpPipeline", JsonNode.class);

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/RoutingObjectHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/RoutingObjectHandler.java
@@ -28,6 +28,7 @@ import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.RoutingObjectRecord;
 import com.hotels.styx.routing.config.RoutingObjectDefinition;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
@@ -95,7 +96,7 @@ public class RoutingObjectHandler implements HttpHandler  {
 
                     try {
                         RoutingObjectDefinition payload = YAML_MAPPER.readValue(body, RoutingObjectDefinition.class);
-                        HttpHandler httpHandler = objectFactory.build(emptyList(), payload);
+                        RoutingObject httpHandler = objectFactory.build(emptyList(), payload);
 
                         routeDatabase.insert(name, new RoutingObjectRecord(payload.type(), payload.config(), httpHandler));
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/RoutingObjectHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/RoutingObjectHandler.java
@@ -99,8 +99,7 @@ public class RoutingObjectHandler implements HttpHandler {
                         RoutingObject httpHandler = objectFactory.build(emptyList(), payload);
 
                         routeDatabase.insert(name, new RoutingObjectRecord(payload.type(), payload.config(), httpHandler))
-                                .ifPresent(previous -> previous.getRoutingObject().stop())
-                        ;
+                                .ifPresent(previous -> previous.getRoutingObject().stop());
 
                         return Eventual.of(response(CREATED).build());
                     } catch (IOException | RuntimeException cause) {

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/InterceptorPipelineBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/InterceptorPipelineBuilder.java
@@ -17,10 +17,10 @@ package com.hotels.styx.proxy;
 
 import com.google.common.collect.ImmutableList;
 import com.hotels.styx.Environment;
-import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.proxy.plugin.InstrumentedPlugin;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.handlers.HttpInterceptorPipeline;
 
 import java.util.List;
@@ -35,17 +35,17 @@ import static java.util.stream.StreamSupport.stream;
 public class InterceptorPipelineBuilder {
     private final Environment environment;
     private final Iterable<NamedPlugin> plugins;
-    private final HttpHandler handler;
+    private final RoutingObject handler;
     private final boolean trackRequests;
 
-    public InterceptorPipelineBuilder(Environment environment, Iterable<NamedPlugin> plugins, HttpHandler handler, boolean trackRequests) {
+    public InterceptorPipelineBuilder(Environment environment, Iterable<NamedPlugin> plugins, RoutingObject handler, boolean trackRequests) {
         this.environment = requireNonNull(environment);
         this.plugins = requireNonNull(plugins);
         this.handler = requireNonNull(handler);
         this.trackRequests = trackRequests;
     }
 
-    public HttpHandler build() {
+    public RoutingObject build() {
         List<HttpInterceptor> interceptors = ImmutableList.copyOf(instrument(plugins, environment));
         return new HttpInterceptorPipeline(interceptors, handler, trackRequests);
     }

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/RouteHandlerAdapter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/RouteHandlerAdapter.java
@@ -20,13 +20,14 @@ import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.server.HttpRouter;
 import com.hotels.styx.server.NoServiceConfiguredException;
 
 /**
  * A {@link HttpHandler} implementation.
  */
-public class RouteHandlerAdapter implements HttpHandler {
+public class RouteHandlerAdapter implements RoutingObject {
     private final HttpRouter router;
 
     public RouteHandlerAdapter(HttpRouter router) {

--- a/components/proxy/src/main/java/com/hotels/styx/routing/HttpPipelineFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/HttpPipelineFactory.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
   limitations under the License.
  */
 package com.hotels.styx.routing;
-
-import com.hotels.styx.api.HttpHandler;
 
 /**
  * A base type for HTTP pipeline builders.

--- a/components/proxy/src/main/java/com/hotels/styx/routing/HttpPipelineFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/HttpPipelineFactory.java
@@ -21,5 +21,5 @@ import com.hotels.styx.api.HttpHandler;
  * A base type for HTTP pipeline builders.
  */
 public interface HttpPipelineFactory {
-    HttpHandler build();
+    RoutingObject build();
 }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/RoutingObject.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/RoutingObject.java
@@ -13,11 +13,21 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-package com.hotels.styx.routing
+package com.hotels.styx.routing;
 
-import com.fasterxml.jackson.databind.JsonNode
+import com.hotels.styx.api.HttpHandler;
 
-data class RoutingObjectRecord(
-        val type: String,
-        val config: JsonNode,
-        val routingObject: RoutingObject)
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+/**
+ * A Styx routing object interface.
+ *
+ * It is a HttpHandler associated with lifecycle methods.
+ */
+public interface RoutingObject extends HttpHandler {
+    default CompletableFuture<Void> stop() {
+        return completedFuture(null);
+    };
+}

--- a/components/proxy/src/main/java/com/hotels/styx/routing/StaticPipelineFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/StaticPipelineFactory.java
@@ -17,7 +17,6 @@ package com.hotels.styx.routing;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.Environment;
-import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.extension.service.BackendService;
 import com.hotels.styx.api.extension.service.spi.Registry;
 import com.hotels.styx.proxy.BackendServiceClientFactory;
@@ -63,7 +62,7 @@ public class StaticPipelineFactory implements HttpPipelineFactory {
     }
 
     @Override
-    public HttpHandler build() {
+    public RoutingObject build() {
         BackendServicesRouter backendServicesRouter = new BackendServicesRouter(clientFactory, environment);
         registry.addListener(backendServicesRouter);
         RouteHandlerAdapter router = new RouteHandlerAdapter(backendServicesRouter);

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/HttpHandlerFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/HttpHandlerFactory.java
@@ -16,8 +16,8 @@
 package com.hotels.styx.routing.config;
 
 import com.hotels.styx.Environment;
-import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.RoutingObjectRecord;
 import com.hotels.styx.routing.db.StyxObjectStore;
 
@@ -44,7 +44,7 @@ public interface HttpHandlerFactory {
      * @param configBlock
      * @return
      */
-    HttpHandler build(List<String> parents, HttpHandlerFactory.Context context, RoutingObjectDefinition configBlock);
+    RoutingObject build(List<String> parents, Context context, RoutingObjectDefinition configBlock);
 
     /**
      * Contextual information for factory class.
@@ -63,15 +63,15 @@ public interface HttpHandlerFactory {
         public Context(
                 Environment environment,
                 StyxObjectStore<RoutingObjectRecord> routeDb,
-                RoutingObjectFactory routingObjectFactory,
+                RoutingObjectFactory factory,
                 Iterable<NamedPlugin> plugins,
-                BuiltinInterceptorsFactory interceptorsFactory,
+                BuiltinInterceptorsFactory builtinInterceptorsFactory,
                 boolean requestTracking) {
             this.environment = requireNonNull(environment);
             this.routeDb = requireNonNull(routeDb);
-            this.routingObjectFactory = requireNonNull(routingObjectFactory);
+            this.routingObjectFactory = requireNonNull(factory);
             this.plugins = requireNonNull(plugins);
-            this.interceptorsFactory = requireNonNull(interceptorsFactory);
+            this.interceptorsFactory = requireNonNull(builtinInterceptorsFactory);
             this.requestTracking = requestTracking;
         }
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingObjectFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingObjectFactory.java
@@ -20,12 +20,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.Environment;
 import com.hotels.styx.api.Eventual;
-import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.config.schema.Schema;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.RoutingObjectRecord;
 import com.hotels.styx.routing.db.StyxObjectStore;
 import com.hotels.styx.routing.handlers.ConditionRouter;
+import com.hotels.styx.routing.handlers.HostProxy;
 import com.hotels.styx.routing.handlers.HttpInterceptorPipeline;
 import com.hotels.styx.routing.handlers.PathPrefixRouter;
 import com.hotels.styx.routing.handlers.ProxyToBackend;
@@ -58,6 +59,7 @@ public class RoutingObjectFactory {
     private static final String INTERCEPTOR_PIPELINE = "InterceptorPipeline";
     private static final String PROXY_TO_BACKEND = "ProxyToBackend";
     private static final String PATH_PREFIX_ROUTER = "PathPrefixRouter";
+    private static final String HOST_PROXY = "HostProxy";
 
 
     static {
@@ -67,6 +69,7 @@ public class RoutingObjectFactory {
                 .put(INTERCEPTOR_PIPELINE, new HttpInterceptorPipeline.Factory())
                 .put(PROXY_TO_BACKEND, new ProxyToBackend.Factory())
                 .put(PATH_PREFIX_ROUTER, new PathPrefixRouter.Factory())
+                .put(HOST_PROXY, new HostProxy.Factory())
                 .build();
 
         BUILTIN_HANDLER_SCHEMAS = ImmutableMap.<String, Schema.FieldType>builder()
@@ -75,6 +78,7 @@ public class RoutingObjectFactory {
                 .put(INTERCEPTOR_PIPELINE, HttpInterceptorPipeline.SCHEMA)
                 .put(PROXY_TO_BACKEND, ProxyToBackend.SCHEMA)
                 .put(PATH_PREFIX_ROUTER, PathPrefixRouter.SCHEMA)
+                .put(HOST_PROXY, HostProxy.SCHEMA)
                 .build();
     }
 
@@ -108,8 +112,8 @@ public class RoutingObjectFactory {
         this(DEFAULT_REFERENCE_LOOKUP, BUILTIN_HANDLER_FACTORIES, new Environment.Builder().build(), routeObjectStore, ImmutableList.of(), new BuiltinInterceptorsFactory(), false);
     }
 
-    public RoutingObjectFactory(RouteRefLookup refLookup, Map<String, HttpHandlerFactory> handlerFactories) {
-        this(refLookup, handlerFactories, new Environment.Builder().build(), new StyxObjectStore<>(), ImmutableList.of(), new BuiltinInterceptorsFactory(), false);
+    public RoutingObjectFactory(RouteRefLookup refLookup, Map<String, HttpHandlerFactory> builtinObjectTypes) {
+        this(refLookup, builtinObjectTypes, new Environment.Builder().build(), new StyxObjectStore<>(), ImmutableList.of(), new BuiltinInterceptorsFactory(), false);
     }
 
     public RoutingObjectFactory(RouteRefLookup refLookup) {
@@ -126,11 +130,11 @@ public class RoutingObjectFactory {
                 false);
     }
 
-    public HttpHandler build(RoutingObjectConfiguration configNode) {
+    public RoutingObject build(RoutingObjectConfiguration configNode) {
         return build(ImmutableList.of(), configNode);
     }
 
-    public HttpHandler build(List<String> parents, RoutingObjectConfiguration configNode) {
+    public RoutingObject build(List<String> parents, RoutingObjectConfiguration configNode) {
         if (configNode instanceof RoutingObjectDefinition) {
             RoutingObjectDefinition configBlock = (RoutingObjectDefinition) configNode;
             String type = configBlock.type();

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingObjectFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingObjectFactory.java
@@ -58,7 +58,6 @@ public class RoutingObjectFactory {
     private static final String INTERCEPTOR_PIPELINE = "InterceptorPipeline";
     private static final String PROXY_TO_BACKEND = "ProxyToBackend";
     private static final String PATH_PREFIX_ROUTER = "PathPrefixRouter";
-    private static final String HOST_PROXY = "HostProxy";
 
 
     static {

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingObjectFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingObjectFactory.java
@@ -26,7 +26,6 @@ import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.RoutingObjectRecord;
 import com.hotels.styx.routing.db.StyxObjectStore;
 import com.hotels.styx.routing.handlers.ConditionRouter;
-import com.hotels.styx.routing.handlers.HostProxy;
 import com.hotels.styx.routing.handlers.HttpInterceptorPipeline;
 import com.hotels.styx.routing.handlers.PathPrefixRouter;
 import com.hotels.styx.routing.handlers.ProxyToBackend;
@@ -69,7 +68,6 @@ public class RoutingObjectFactory {
                 .put(INTERCEPTOR_PIPELINE, new HttpInterceptorPipeline.Factory())
                 .put(PROXY_TO_BACKEND, new ProxyToBackend.Factory())
                 .put(PATH_PREFIX_ROUTER, new PathPrefixRouter.Factory())
-                .put(HOST_PROXY, new HostProxy.Factory())
                 .build();
 
         BUILTIN_HANDLER_SCHEMAS = ImmutableMap.<String, Schema.FieldType>builder()
@@ -78,7 +76,6 @@ public class RoutingObjectFactory {
                 .put(INTERCEPTOR_PIPELINE, HttpInterceptorPipeline.SCHEMA)
                 .put(PROXY_TO_BACKEND, ProxyToBackend.SCHEMA)
                 .put(PATH_PREFIX_ROUTER, PathPrefixRouter.SCHEMA)
-                .put(HOST_PROXY, HostProxy.SCHEMA)
                 .build();
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/BackendServiceProxy.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/BackendServiceProxy.java
@@ -18,7 +18,6 @@ package com.hotels.styx.routing.handlers;
 import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.Environment;
 import com.hotels.styx.api.Eventual;
-import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
@@ -29,6 +28,7 @@ import com.hotels.styx.proxy.BackendServiceClientFactory;
 import com.hotels.styx.proxy.BackendServicesRouter;
 import com.hotels.styx.proxy.RouteHandlerAdapter;
 import com.hotels.styx.proxy.StyxBackendServiceClientFactory;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.config.HttpHandlerFactory;
 import com.hotels.styx.routing.config.RoutingObjectDefinition;
 
@@ -41,9 +41,9 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 
 /**
- * A HTTP handler that proxies requests to backend services based on the path prefix.
+ * A HTTP routingObject that proxies requests to backend services based on the path prefix.
  */
-public class BackendServiceProxy implements HttpHandler {
+public class BackendServiceProxy implements RoutingObject {
 
     private final RouteHandlerAdapter handler;
 
@@ -84,7 +84,7 @@ public class BackendServiceProxy implements HttpHandler {
         }
 
         @Override
-        public HttpHandler build(List<String> parents, Context context, RoutingObjectDefinition configBlock) {
+        public RoutingObject build(List<String> parents, Context context, RoutingObjectDefinition configBlock) {
             JsonNodeConfig config = new JsonNodeConfig(configBlock.config());
             String provider = config.get("backendProvider")
                     .orElseThrow(() -> missingAttributeError(configBlock, join(".", parents), "backendProvider"));

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ConditionRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ConditionRouter.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.hotels.styx.api.HttpResponseStatus.BAD_GATEWAY;
 import static com.hotels.styx.routing.config.RoutingConfigParser.toRoutingConfigNode;
@@ -88,27 +87,10 @@ public class ConditionRouter implements HttpRouter {
         return Optional.ofNullable(fallback);
     }
 
-    private static class Route {
-        private final AntlrMatcher matcher;
-        private final RoutingObject routingObject;
-
-        Route(String condition, RoutingObject routingObject) {
-            this.matcher = AntlrMatcher.antlrMatcher(condition);
-            this.routingObject = routingObject;
-        }
-
-        public HttpHandler match(LiveHttpRequest request, HttpInterceptor.Context context) {
-            return matcher.apply(request, context) ? routingObject : null;
-        }
-    }
-
     /**
      * Builds a condition router from the yaml routing configuration.
      */
     public static class Factory implements HttpHandlerFactory {
-
-        public Factory() {
-        }
 
         private static RoutingObject buildFallbackHandler(
                 List<String> parents,
@@ -172,7 +154,6 @@ public class ConditionRouter implements HttpRouter {
                     return completedFuture(null);
                 }
             };
-
         }
 
         private static class ConditionRouterConfig {
@@ -196,6 +177,20 @@ public class ConditionRouter implements HttpRouter {
                 this.destination = toRoutingConfigNode(destination);
             }
         }
-
     }
+
+    private static class Route {
+        private final AntlrMatcher matcher;
+        private final RoutingObject routingObject;
+
+        Route(String condition, RoutingObject routingObject) {
+            this.matcher = AntlrMatcher.antlrMatcher(condition);
+            this.routingObject = routingObject;
+        }
+
+        public HttpHandler match(LiveHttpRequest request, HttpInterceptor.Context context) {
+            return matcher.apply(request, context) ? routingObject : null;
+        }
+    }
+
 }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HttpInterceptorPipeline.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HttpInterceptorPipeline.java
@@ -26,6 +26,7 @@ import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.config.schema.Schema;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.config.BuiltinInterceptorsFactory;
 import com.hotels.styx.routing.config.HttpHandlerFactory;
 import com.hotels.styx.routing.config.RoutingObjectConfiguration;
@@ -54,7 +55,7 @@ import static java.util.stream.StreamSupport.stream;
 /**
  * A HTTP handler that contains HTTP interceptor pipeline.
  */
-public class HttpInterceptorPipeline implements HttpHandler {
+public class HttpInterceptorPipeline implements RoutingObject {
     public static final Schema.FieldType SCHEMA = object(
             field("pipeline", list(string())),
             field("handler", routingObject())
@@ -78,7 +79,7 @@ public class HttpInterceptorPipeline implements HttpHandler {
     public static class Factory implements HttpHandlerFactory {
 
         @Override
-        public HttpHandler build(List<String> parents, Context context, RoutingObjectDefinition configBlock) {
+        public RoutingObject build(List<String> parents, Context context, RoutingObjectDefinition configBlock) {
             JsonNode pipeline = configBlock.config().get("pipeline");
             List<HttpInterceptor> interceptors = getHttpInterceptors(append(parents, "pipeline"), toMap(context.plugins()), context.builtinInterceptorsFactory(), pipeline);
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HttpInterceptorPipeline.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HttpInterceptorPipeline.java
@@ -48,6 +48,7 @@ import static com.hotels.styx.routing.config.RoutingConfigParser.toRoutingConfig
 import static com.hotels.styx.routing.config.RoutingSupport.append;
 import static com.hotels.styx.routing.config.RoutingSupport.missingAttributeError;
 import static java.lang.String.join;
+import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 import static java.util.stream.StreamSupport.stream;
 
@@ -65,7 +66,7 @@ public class HttpInterceptorPipeline implements RoutingObject {
 
     public HttpInterceptorPipeline(List<HttpInterceptor> interceptors, RoutingObject handler, boolean trackRequests) {
         RequestTracker tracker = trackRequests ? CurrentRequestTracker.INSTANCE : RequestTracker.NO_OP;
-        this.handler = handler;
+        this.handler = requireNonNull(handler);
         this.pipeline = new StandardHttpPipeline(interceptors, handler, tracker);
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
@@ -112,7 +112,7 @@ public class PathPrefixRouter {
 
                 @Override
                 public CompletableFuture<Void> stop() {
-                    pathPrefixRouter.routes.forEach((route, value) -> value.stop());
+                    pathPrefixRouter.routes.forEach((route, routingObject) -> routingObject.stop());
                     return completedFuture(null);
                 }
             };

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
@@ -18,7 +18,6 @@ package com.hotels.styx.routing.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.Eventual;
-import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
@@ -37,6 +36,7 @@ import com.hotels.styx.config.schema.Schema;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 import com.hotels.styx.proxy.BackendServiceClientFactory;
 import com.hotels.styx.proxy.StyxBackendServiceClientFactory;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.config.HttpHandlerFactory;
 import com.hotels.styx.routing.config.RoutingObjectDefinition;
 
@@ -53,7 +53,7 @@ import static java.lang.String.join;
 /**
  * Routing object that proxies a request to a configured backend.
  */
-public class ProxyToBackend implements HttpHandler {
+public class ProxyToBackend implements RoutingObject {
     public static final Schema.FieldType SCHEMA = object(
             field("backend", object(opaque()))
     );
@@ -73,7 +73,7 @@ public class ProxyToBackend implements HttpHandler {
      */
     public static class Factory implements HttpHandlerFactory {
         @VisibleForTesting
-        static HttpHandler build(List<String> parents, Context context, RoutingObjectDefinition configBlock, BackendServiceClientFactory clientFactory) {
+        static RoutingObject build(List<String> parents, Context context, RoutingObjectDefinition configBlock, BackendServiceClientFactory clientFactory) {
             JsonNodeConfig jsConfig = new JsonNodeConfig(configBlock.config());
 
             BackendService backendService = jsConfig
@@ -130,7 +130,7 @@ public class ProxyToBackend implements HttpHandler {
         }
 
         @Override
-        public HttpHandler build(List<String> parents, Context context, RoutingObjectDefinition configBlock) {
+        public RoutingObject build(List<String> parents, Context context, RoutingObjectDefinition configBlock) {
             return build(parents, context, configBlock, new StyxBackendServiceClientFactory(context.environment()));
         }
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/RouteRefLookup.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/RouteRefLookup.java
@@ -16,7 +16,7 @@
 package com.hotels.styx.routing.handlers;
 
 import com.hotels.styx.api.Eventual;
-import com.hotels.styx.api.HttpHandler;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.RoutingObjectRecord;
 import com.hotels.styx.routing.config.RoutingObjectReference;
 import com.hotels.styx.routing.db.StyxObjectStore;
@@ -30,7 +30,10 @@ import static java.util.Objects.requireNonNull;
  * Resolves a routing object reference from route database.
  */
 public interface RouteRefLookup {
-    HttpHandler apply(RoutingObjectReference route);
+    // TODO: Mikko: this interface should return Optional<RoutingObject>
+    // Then we can move .orElse handler to RoutingObjectFactory.
+    // This will prevent NPEs in test RouteRefLookup implementations.
+    RoutingObject apply(RoutingObjectReference route);
 
     /**
      * A StyxObjectStore based route reference lookup function.
@@ -43,9 +46,9 @@ public interface RouteRefLookup {
         }
 
         @Override
-        public HttpHandler apply(RoutingObjectReference route) {
+        public RoutingObject apply(RoutingObjectReference route) {
             return this.routeDatabase.get(route.name())
-                    .map(RoutingObjectRecord::getHandler)
+                    .map(RoutingObjectRecord::getRoutingObject)
                     .orElse((liveRequest, na) -> {
                         liveRequest.consume();
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/RouteRefLookup.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/RouteRefLookup.java
@@ -30,9 +30,9 @@ import static java.util.Objects.requireNonNull;
  * Resolves a routing object reference from route database.
  */
 public interface RouteRefLookup {
-    // TODO: Mikko: this interface should return Optional<RoutingObject>
-    // Then we can move .orElse handler to RoutingObjectFactory.
-    // This will prevent NPEs in test RouteRefLookup implementations.
+    // Consider modifying this interface to return Optional<RoutingObject>.
+    // Then we can move .orElse handler to RoutingObjectFactory. This will
+    // prevent NPEs in test RouteRefLookup implementations.
     RoutingObject apply(RoutingObjectReference route);
 
     /**

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StandardHttpPipeline.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StandardHttpPipeline.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StaticResponseHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StaticResponseHandler.java
@@ -19,12 +19,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hotels.styx.api.Buffer;
 import com.hotels.styx.api.ByteStream;
 import com.hotels.styx.api.Eventual;
-import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.config.schema.Schema;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.config.HttpHandlerFactory;
 import com.hotels.styx.routing.config.RoutingObjectDefinition;
 import reactor.core.publisher.Flux;
@@ -44,7 +44,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A HTTP handler for returning a static response.
  */
-public class StaticResponseHandler implements HttpHandler {
+public class StaticResponseHandler implements RoutingObject {
     public static final Schema.FieldType SCHEMA = object(
             field("status", integer()),
             optional("content", string()));
@@ -77,7 +77,7 @@ public class StaticResponseHandler implements HttpHandler {
      * Builds a static response handler from Yaml configuration.
      */
     public static class Factory implements HttpHandlerFactory {
-        public HttpHandler build(List<String> parents, Context context, RoutingObjectDefinition configBlock) {
+        public RoutingObject build(List<String> parents, Context context, RoutingObjectDefinition configBlock) {
             requireNonNull(configBlock.config());
 
             StaticResponseConfig config = new JsonNodeConfig(configBlock.config())

--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
@@ -23,7 +23,6 @@ import com.google.common.eventbus.AsyncEventBus;
 import com.hotels.styx.Environment;
 import com.hotels.styx.StyxConfig;
 import com.hotels.styx.Version;
-import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.MetricRegistry;
 import com.hotels.styx.api.configuration.Configuration;
 import com.hotels.styx.api.extension.service.spi.StyxService;
@@ -31,6 +30,7 @@ import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.api.plugins.spi.Plugin;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.RoutingObjectRecord;
 import com.hotels.styx.routing.config.BuiltinInterceptorsFactory;
 import com.hotels.styx.routing.config.RoutingObjectDefinition;
@@ -95,7 +95,7 @@ public class StyxServerComponents {
                 .map(StyxServerComponents::readHttpHandlers)
                 .orElse(ImmutableMap.of())
                 .forEach((name, record) -> {
-                    HttpHandler handler = routingObjectFactory.build(ImmutableList.of(name), record);
+                    RoutingObject handler = routingObjectFactory.build(ImmutableList.of(name), record);
                     routeObjectStore.insert(name, new RoutingObjectRecord(record.type(), record.config(), handler));
                 });
     }

--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
@@ -96,7 +96,8 @@ public class StyxServerComponents {
                 .orElse(ImmutableMap.of())
                 .forEach((name, record) -> {
                     RoutingObject handler = routingObjectFactory.build(ImmutableList.of(name), record);
-                    routeObjectStore.insert(name, new RoutingObjectRecord(record.type(), record.config(), handler));
+                    routeObjectStore.insert(name, new RoutingObjectRecord(record.type(), record.config(), handler))
+                            .ifPresent(previous -> previous.getRoutingObject().stop());
                 });
     }
 

--- a/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/routing/db/StyxObjectStore.kt
@@ -76,10 +76,10 @@ class StyxObjectStore<T> : ObjectStore<T> {
      *
      * @property key object name
      * @property payload the object itself
+     * @return the previous value
      */
-    fun insert(key: String, payload: T) {
-        insert(key, setOf(), payload)
-    }
+    fun insert(key: String, payload: T) = insert(key, setOf(), payload)
+
 
     /**
      * Removes an object from this object store.
@@ -92,8 +92,9 @@ class StyxObjectStore<T> : ObjectStore<T> {
      *
      * @property key object name
      * @property payload the object itself
+     * @return the removed value
      */
-    fun remove(key: String) {
+    fun remove(key: String): Optional<T> {
         var current = objects.get()
         var new = current.minus(key)
 
@@ -107,6 +108,8 @@ class StyxObjectStore<T> : ObjectStore<T> {
                 notifyWatchers(new)
             }
         }
+
+        return Optional.ofNullable(current[key]?.payload)
     }
 
     /**
@@ -146,7 +149,7 @@ class StyxObjectStore<T> : ObjectStore<T> {
         executor.submit(task)
     }
 
-    private fun insert(key: String, tags: Set<String>, payload: T) {
+    private fun insert(key: String, tags: Set<String>, payload: T): Optional<T> {
         var current = objects.get()
         var new = current.plus(key, Record(key, tags, payload))
 
@@ -158,6 +161,8 @@ class StyxObjectStore<T> : ObjectStore<T> {
         queue {
             notifyWatchers(new)
         }
+
+        return Optional.ofNullable(current[key]?.payload)
     }
 
     private fun notifyWatchers(objectsV2: PMap<String, Record<T>>) {

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/InterceptorPipelineBuilderTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/InterceptorPipelineBuilderTest.java
@@ -24,6 +24,7 @@ import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
+import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -43,7 +44,7 @@ import static org.mockito.Mockito.when;
 public class InterceptorPipelineBuilderTest {
     private Environment environment;
     private Iterable<NamedPlugin> plugins;
-    private HttpHandler handler;
+    private RoutingObject handler;
 
     @BeforeMethod
     public void setUp() {
@@ -65,7 +66,7 @@ public class InterceptorPipelineBuilderTest {
                                                 .build()))
         );
 
-        handler = mock(HttpHandler.class);
+        handler = mock(RoutingObject.class);
         when(handler.handle(any(LiveHttpRequest.class), any(HttpInterceptor.Context.class))).thenReturn(Eventual.of(response(OK).build()));
     }
 

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/StyxProxyTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/StyxProxyTest.java
@@ -75,10 +75,11 @@ public class StyxProxyTest extends SSLSetup {
     @Test
     public void startsServerWithHttpConnector() {
         HttpInterceptor echoInterceptor = (request, chain) -> textResponse("Response from http connector");
+        StandardHttpRouter handler = new StandardHttpRouter();
 
         HttpServer server = NettyServerBuilder.newBuilder()
                 .setHttpConnector(connector(0))
-                .handlerFactory(() -> new HttpInterceptorPipeline(ImmutableList.of(echoInterceptor), new StandardHttpRouter(), false))
+                .handlerFactory(() -> new HttpInterceptorPipeline(ImmutableList.of(echoInterceptor), handler::handle, false))
                 .build();
         server.startAsync().awaitRunning();
         assertThat("Server should be running", server.isRunning());

--- a/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/RoutingObjectHandlerTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/admin/handlers/RoutingObjectHandlerTest.kt
@@ -62,7 +62,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
             routeDatabase.get("staticResponse").isPresent shouldBe true
             routeDatabase.get("staticResponse").get().type shouldBe "StaticResponseHandler"
             routeDatabase.get("staticResponse").get().config.shouldBeTypeOf<ObjectNode>()
-            routeDatabase.get("staticResponse").get().handler.shouldBeTypeOf<StaticResponseHandler>()
+            routeDatabase.get("staticResponse").get().routingObject.shouldBeTypeOf<StaticResponseHandler>()
         }
 
         scenario("Retrieving objects") {
@@ -163,7 +163,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
 
             routeDatabase.get("staticResponse").isPresent shouldBe true
             val previousConfig = routeDatabase.get("staticResponse").get().config
-            val previousHandler = routeDatabase.get("staticResponse").get().handler
+            val previousHandler = routeDatabase.get("staticResponse").get().routingObject
 
             handler.handle(
                     put("/admin/routing/objects/staticResponse")
@@ -181,7 +181,7 @@ class RoutingObjectHandlerTest : FeatureSpec({
             routeDatabase.get("staticResponse").isPresent shouldBe true
             routeDatabase.get("staticResponse").get().type shouldBe "StaticResponseHandler"
             routeDatabase.get("staticResponse").get().config shouldNotBeSameInstanceAs previousConfig
-            routeDatabase.get("staticResponse").get().handler shouldNotBeSameInstanceAs previousHandler
+            routeDatabase.get("staticResponse").get().routingObject shouldNotBeSameInstanceAs previousHandler
         }
 
         scenario("Removing existing objects") {

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/config/RoutingObjectFactoryTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/config/RoutingObjectFactoryTest.kt
@@ -16,11 +16,11 @@
 package com.hotels.styx.routing.config
 
 import com.hotels.styx.api.Eventual
-import com.hotels.styx.api.HttpHandler
 import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.api.HttpResponse.response
 import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.LiveHttpResponse
+import com.hotels.styx.routing.RoutingObject
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.RoutingObjectFactory.DEFAULT_REFERENCE_LOOKUP
 import com.hotels.styx.routing.db.StyxObjectStore
@@ -38,7 +38,7 @@ import java.util.Optional
 
 class RoutingObjectFactoryTest : StringSpec({
 
-    val mockHandler = mockk<HttpHandler> {
+    val mockHandler = mockk<RoutingObject> {
         every { handle(any(), any()) } returns Eventual.of(LiveHttpResponse.response(OK).build())
     }
 
@@ -75,7 +75,7 @@ class RoutingObjectFactoryTest : StringSpec({
     }
 
     "Returns handler from a configuration reference" {
-        val routeDb = mapOf("aHandler" to HttpHandler { request, context -> Eventual.of(response(OK).build().stream()) })
+        val routeDb = mapOf("aHandler" to RoutingObject { request, context -> Eventual.of(response(OK).build().stream()) })
         val routingObjectFactory = RoutingObjectFactory( { ref -> routeDb[ref.name()] } )
 
         val handler = routingObjectFactory.build(listOf(), RoutingObjectReference("aHandler"))
@@ -89,7 +89,7 @@ class RoutingObjectFactoryTest : StringSpec({
 
     "Looks up handler for every request" {
         val referenceLookup = mockk<RouteRefLookup>()
-        every {referenceLookup.apply(RoutingObjectReference("aHandler")) } returns HttpHandler { request, context -> Eventual.of(response(OK).build().stream()) }
+        every {referenceLookup.apply(RoutingObjectReference("aHandler")) } returns RoutingObject { request, context -> Eventual.of(response(OK).build().stream()) }
 
         val routingObjectFactory = RoutingObjectFactory(referenceLookup)
 
@@ -108,7 +108,7 @@ class RoutingObjectFactoryTest : StringSpec({
 })
 
 
-fun httpHandlerFactory(handler: HttpHandler): HttpHandlerFactory {
+fun httpHandlerFactory(handler: RoutingObject): HttpHandlerFactory {
     val factory: HttpHandlerFactory = mockk()
 
     every {

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/db/StyxObjectStoreTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/db/StyxObjectStoreTest.kt
@@ -120,6 +120,19 @@ class StyxObjectStoreTest : FeatureSpec() {
 
                 db.get("x") shouldBe Optional.of("x2")
             }
+
+            scenario("Returns Optional.empty, when no previous value exists") {
+                val db = StyxObjectStore<String>()
+
+                db.insert("key", "a-value") shouldBe Optional.empty()
+            }
+
+            scenario("Returns previous, replaced value") {
+                val db = StyxObjectStore<String>()
+
+                db.insert("key", "old-value") shouldBe Optional.empty()
+                db.insert("key", "new-value") shouldBe Optional.of("old-value")
+            }
         }
 
         feature("Remove") {
@@ -176,8 +189,8 @@ class StyxObjectStoreTest : FeatureSpec() {
                 db.remove("y")
 
                 eventually(1.seconds, java.lang.AssertionError::class.java) {
-                    watchEvents.last().get("x") shouldBe Optional.empty()
-                    watchEvents.last().get("y") shouldBe Optional.empty()
+                    watchEvents.last()["x"] shouldBe Optional.empty()
+                    watchEvents.last()["y"] shouldBe Optional.empty()
                 }
             }
 
@@ -199,6 +212,20 @@ class StyxObjectStoreTest : FeatureSpec() {
                 executor.awaitTermination(2, SECONDS)
 
                 db.entrySet() shouldBe emptyList()
+            }
+
+            scenario("Returns Optional.empty, when previous value doesn't exist") {
+                val db = StyxObjectStore<String>()
+
+                db.remove("key") shouldBe Optional.empty()
+            }
+
+            scenario("Returns previous, replaced value") {
+                val db = StyxObjectStore<String>()
+
+                db.insert("key", "a-value") shouldBe Optional.empty()
+
+                db.remove("key") shouldBe Optional.of("a-value")
             }
 
         }

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/ProxyToBackendTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/ProxyToBackendTest.kt
@@ -23,7 +23,9 @@ import com.hotels.styx.api.LiveHttpResponse
 import com.hotels.styx.client.BackendServiceClient
 import com.hotels.styx.proxy.BackendServiceClientFactory
 import com.hotels.styx.routing.RoutingContext
+import com.hotels.styx.routing.routeLookup
 import com.hotels.styx.routing.routingObjectDef
+import com.hotels.styx.routing.routingObjectFactory
 import com.hotels.styx.server.HttpInterceptorContext
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
@@ -49,7 +51,11 @@ class ProxyToBackendTest : StringSpec({
 
           """.trimIndent())
 
-    val context = RoutingContext(environment = environment, routingObjectFactory = routingObjectFactory()).get()
+    val context = RoutingContext(
+            environment = environment,
+            factory = routingObjectFactory(
+                    routeLookup { }
+            )).get()
 
     "builds ProxyToBackend handler" {
         val handler = ProxyToBackend.Factory.build(listOf(), context, config, clientFactory());
@@ -97,15 +103,15 @@ class ProxyToBackendTest : StringSpec({
 
 private fun clientFactory() = BackendServiceClientFactory { backendService, originsInventory, originStatsFactory ->
     BackendServiceClient { request ->
-                backendService.id() shouldBe (id("ba"))
+        backendService.id() shouldBe (id("ba"))
         backendService.connectionPoolConfig().maxConnectionsPerHost() shouldBe (45)
         backendService.connectionPoolConfig().maxPendingConnectionsPerHost() shouldBe (15)
         backendService.responseTimeoutMillis() shouldBe (60000)
-        backendService.origins().first()?.id() shouldBe(id("ba1"))
-        backendService.origins().first()?.port() shouldBe(9094)
+        backendService.origins().first()?.id() shouldBe (id("ba1"))
+        backendService.origins().first()?.port() shouldBe (9094)
         Mono.just(LiveHttpResponse.response(OK)
-                    .addHeader("X-Backend-Service", "y")
-                    .build())
+                .addHeader("X-Backend-Service", "y")
+                .build())
 
     }
 }

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/RouteRefLookupTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/RouteRefLookupTest.kt
@@ -17,10 +17,10 @@ package com.hotels.styx.routing.handlers
 
 import com.hotels.styx.api.Buffer
 import com.hotels.styx.api.ByteStream
-import com.hotels.styx.api.HttpHandler
 import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.api.HttpResponseStatus.NOT_FOUND
 import com.hotels.styx.api.LiveHttpRequest
+import com.hotels.styx.routing.RoutingObject
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.RoutingObjectReference
 import com.hotels.styx.routing.db.StyxObjectStore
@@ -39,7 +39,7 @@ import java.util.Optional
 
 class RouteRefLookupTest : StringSpec({
     "Retrieves handler from route database" {
-        val handler = mockk<HttpHandler>()
+        val handler = mockk<RoutingObject>()
 
         val routeDb = mockk<StyxObjectStore<RoutingObjectRecord>>()
         every { routeDb.get(any()) } returns Optional.of(RoutingObjectRecord("StaticResponseHandler", mockk(), handler))

--- a/system-tests/ft-suite/pom.xml
+++ b/system-tests/ft-suite/pom.xml
@@ -59,6 +59,12 @@
       <artifactId>jackson-annotations</artifactId>
       <version>${jackson.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.hotels.styx</groupId>
+      <artifactId>styx-e2e-testsupport</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/system-tests/ft-suite/pom.xml
+++ b/system-tests/ft-suite/pom.xml
@@ -59,12 +59,6 @@
       <artifactId>jackson-annotations</artifactId>
       <version>${jackson.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.hotels.styx</groupId>
-      <artifactId>styx-e2e-testsupport</artifactId>
-      <version>1.0-SNAPSHOT</version>
-      <scope>test</scope>
-    </dependency>
 
   </dependencies>
 


### PR DESCRIPTION
Lifecycle management is needed for cleaning up stateful resources that routing objects may have.

This is necessary for a new `HostProxy` object (under development) for proxying traffic to an individual remote host. It maintains a connection pool which needs shutting after the object is removed.

This PR introduces a new `RoutingObject` interface that extends an `HttpHandler`. It adds a `stop` lifecycle method. Each routing object implements a `RoutingObject` and the `stop` along with it. The default implementation for `stop` lifecycle method is to do nothing.

