### PR TITLE
Tidy up code in config classes

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/HealthCheckConfig.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/HealthCheckConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -261,7 +261,7 @@ public final class HealthCheckConfig {
         /**
          * Sets the socket timeout for health-checks in a specified unit.
          *
-         * @param timeout  timeout in the specified unit
+         * @param timeout timeout in the specified unit
          * @param timeUnit time unit of timeout
          * @return this builder
          */

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/HealthCheckConfig.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/HealthCheckConfig.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -52,8 +52,11 @@ public final class HealthCheckConfig {
                 builder.unhealthyThreshold);
     }
 
-    private HealthCheckConfig(Optional<String> uri, Optional<Long> intervalMillis, Optional<Long> timeoutMillis,
-                              Optional<Integer> healthyThreshold, Optional<Integer> unhealthyThreshold) {
+    private HealthCheckConfig(Optional<String> uri,
+                              Optional<Long> intervalMillis,
+                              Optional<Long> timeoutMillis,
+                              Optional<Integer> healthyThreshold,
+                              Optional<Integer> unhealthyThreshold) {
         this.uri = uri.map(this::checkValidUri);
         this.intervalMillis = zeroToAbsent(intervalMillis).orElse(DEFAULT_HEALTH_CHECK_INTERVAL);
         this.timeoutMillis = zeroToAbsent(timeoutMillis).orElse(DEFAULT_TIMEOUT_VALUE);
@@ -258,7 +261,7 @@ public final class HealthCheckConfig {
         /**
          * Sets the socket timeout for health-checks in a specified unit.
          *
-         * @param timeout timeout in the specified unit
+         * @param timeout  timeout in the specified unit
          * @param timeUnit time unit of timeout
          * @return this builder
          */

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/StickySessionConfig.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/StickySessionConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api.extension.service;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 import java.util.Optional;

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/StickySessionConfig.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/StickySessionConfig.java
@@ -15,12 +15,13 @@
  */
 package com.hotels.styx.api.extension.service;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.concurrent.TimeUnit.HOURS;
 
 /**
@@ -36,9 +37,13 @@ public class StickySessionConfig {
         this(false, TWELVE_HOURS);
     }
 
-    StickySessionConfig(boolean enabled, Integer timeoutSeconds) {
+    private StickySessionConfig(boolean enabled, Integer timeoutSeconds) {
         this.enabled = enabled;
         this.timeoutSeconds = Optional.ofNullable(timeoutSeconds).orElse(TWELVE_HOURS);
+    }
+
+    private StickySessionConfig(Builder builder) {
+        this(builder.enabled, builder.timeoutSeconds);
     }
 
     public static StickySessionConfig stickySessionDisabled() {
@@ -47,10 +52,6 @@ public class StickySessionConfig {
 
     public static Builder newStickySessionConfigBuilder() {
         return new Builder();
-    }
-
-    private StickySessionConfig(Builder builder) {
-        this(builder.enabled, builder.timeoutSeconds);
     }
 
     public boolean stickySessionEnabled() {

--- a/components/client/src/main/java/com/hotels/styx/client/HttpConfig.java
+++ b/components/client/src/main/java/com/hotels/styx/client/HttpConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/client/src/main/java/com/hotels/styx/client/HttpConfig.java
+++ b/components/client/src/main/java/com/hotels/styx/client/HttpConfig.java
@@ -18,7 +18,7 @@ package com.hotels.styx.client;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import static com.google.common.base.Objects.firstNonNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
@@ -27,9 +27,9 @@ import static java.util.Collections.emptyList;
  */
 public final class HttpConfig {
     private boolean compress;
-    private int maxInitialLineLength = 4096;
-    private int maxHeadersSize = 8192;
-    private int maxChunkSize = 8192;
+    private final int maxInitialLineLength;
+    private final int maxHeadersSize;
+    private final int maxChunkSize;
     private int maxContentLength = 65536;
     private Iterable<ChannelOptionSetting> settings = emptyList();
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -88,7 +88,7 @@ public class AdminServerBuilder {
     private final Environment environment;
     private final Configuration configuration;
     private final RoutingObjectFactory routingObjectFactory;
-    private StyxObjectStore<RoutingObjectRecord> routeDatabase;
+    private final StyxObjectStore<RoutingObjectRecord> routeDatabase;
 
     private Registry<BackendService> backendServicesRegistry;
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerConfig.java
@@ -25,7 +25,7 @@ import com.hotels.styx.server.netty.NettyServerConfig;
 import java.time.Duration;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.firstNonNull;
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 /**
  * xConfigurations for the Admin Server.
@@ -43,11 +43,9 @@ public class AdminServerConfig extends NettyServerConfig {
     private AdminServerConfig(Builder builder) {
         super(builder);
 
-        if (builder.metricsCache != null && builder.metricsCache.enabled) {
-            this.metricsCacheExpiration = Optional.of(Duration.ofMillis(builder.metricsCache.expirationMillis));
-        } else {
-            this.metricsCacheExpiration = Optional.empty();
-        }
+        this.metricsCacheExpiration = Optional.ofNullable(builder.metricsCache)
+                .filter(cache -> cache.enabled)
+                .map(cache -> Duration.ofMillis(cache.expirationMillis));
     }
 
     public Optional<Duration> metricsCacheExpiration() {
@@ -72,7 +70,7 @@ public class AdminServerConfig extends NettyServerConfig {
     /**
      * Builder.
      */
-    @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "set")
+    @JsonPOJOBuilder(withPrefix = "set")
     public static class Builder extends NettyServerConfig.Builder<Builder> {
         private MetricsCache metricsCache;
 

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteConfig.java
@@ -17,10 +17,11 @@ package com.hotels.styx.metrics.reporting.graphite;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.hotels.styx.metrics.reporting.graphite;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.MoreObjects;
 
 import java.util.Optional;
 

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyServerConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyServerConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyServerConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyServerConfig.java
@@ -48,7 +48,7 @@ public class ProxyServerConfig extends NettyServerConfig {
     /**
      * Builder.
      */
-    @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "set")
+    @JsonPOJOBuilder(withPrefix = "set")
     public static class Builder {
         private final NettyServerConfig.Builder builder = new NettyServerConfig.Builder();
         private Integer clientWorkerThreadsCount;

--- a/components/server/src/main/java/com/hotels/styx/server/HttpConnectorConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpConnectorConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/server/src/main/java/com/hotels/styx/server/HttpConnectorConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpConnectorConfig.java
@@ -18,6 +18,8 @@ package com.hotels.styx.server;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+
 /**
  * Http Connector config.
  */
@@ -63,7 +65,7 @@ public class HttpConnectorConfig implements ConnectorConfig {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return toStringHelper(this)
                 .add("port", port)
                 .toString();
     }

--- a/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpsConnectorConfig.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.hotels.styx.common.io.ResourceFactory.newResource;
 import static java.util.Objects.requireNonNull;
@@ -159,7 +159,7 @@ public final class HttpsConnectorConfig extends HttpConnectorConfig {
     /**
      * Builder for {@link HttpsConnectorConfig}.
      */
-    @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+    @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
         private int port;
 

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerConfig.java
@@ -22,14 +22,12 @@ import com.hotels.styx.server.ConnectorConfig;
 import com.hotels.styx.server.HttpConnectorConfig;
 import com.hotels.styx.server.HttpsConnectorConfig;
 
-import java.net.URI;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.lang.Math.max;
 import static java.lang.Runtime.getRuntime;
-import static java.lang.String.format;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
 

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerConfig.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerConfig.java
@@ -26,8 +26,7 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Objects.firstNonNull;
-
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.lang.Math.max;
 import static java.lang.Runtime.getRuntime;
 import static java.lang.String.format;
@@ -66,7 +65,7 @@ public class NettyServerConfig {
     public NettyServerConfig() {
         this.httpConnectorConfig = Optional.of(new HttpConnectorConfig(8080));
         this.httpsConnectorConfig = Optional.empty();
-        this.connectors = singleton((ConnectorConfig) httpConnectorConfig.get());
+        this.connectors = singleton(httpConnectorConfig.get());
     }
 
     protected NettyServerConfig(Builder<?> builder) {
@@ -219,16 +218,12 @@ public class NettyServerConfig {
         return this.nioKeepAlive;
     }
 
-    public URI endpoint() {
-        return URI.create(format("http://%s:%s", "127.0.0.1", httpConnectorConfig().get().port()));
-    }
-
     /**
      * Builder.
      *
      * @param <T> the type of the Builder
      */
-    @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "set")
+    @JsonPOJOBuilder(withPrefix = "set")
     public static class Builder<T extends Builder<T>> {
         protected Integer bossThreadsCount;
         protected Integer workerThreadsCount;


### PR DESCRIPTION
The code in these classes has not been looked at for a while.
This PR:
* Replaces calls to deprecated methods with preferred replacements
* Removes unused code
* Remove redundant field initialisation
* Adds missing `final` modifiers to fields
* Removes annotation values that duplicate default value
* Fixes inconsistent style in a couple of places