### PR TITLE
Fix connection pool error.

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
@@ -48,7 +48,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
     private final Origin origin;
 
     private final ConcurrentLinkedDeque<MonoSink<Connection>> waitingSubscribers;
-    private final Queue<Connection> activeConnections;
+    private final Queue<Connection> availableConnections;
     private final AtomicInteger borrowedCount = new AtomicInteger();
     private final SimpleConnectionPool.ConnectionPoolStats stats = new SimpleConnectionPool.ConnectionPoolStats();
     private final AtomicInteger connectionAttempts = new AtomicInteger();
@@ -63,7 +63,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
         this.poolSettings = requireNonNull(poolSettings);
         this.connectionSettings = new ConnectionSettings(poolSettings.connectTimeoutMillis());
         this.connectionFactory = requireNonNull(connectionFactory);
-        this.activeConnections = new ConcurrentLinkedDeque<>();
+        this.availableConnections = new ConcurrentLinkedDeque<>();
         this.waitingSubscribers = new ConcurrentLinkedDeque<>();
     }
 
@@ -128,10 +128,10 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
     }
 
     private Connection dequeue() {
-        Connection connection = activeConnections.poll();
+        Connection connection = availableConnections.poll();
 
         while (nonNull(connection) && !connection.isConnected()) {
-            connection = activeConnections.poll();
+            connection = availableConnections.poll();
         }
 
         return connection;
@@ -140,7 +140,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
     private void queueNewConnection(Connection connection) {
         MonoSink<Connection> subscriber = waitingSubscribers.poll();
         if (subscriber == null) {
-            activeConnections.add(connection);
+            availableConnections.add(connection);
         } else {
             borrowedCount.incrementAndGet();
             subscriber.success(connection);
@@ -180,7 +180,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
     @Override
     public void connectionClosed(Connection connection) {
         terminatedConnections.incrementAndGet();
-        activeConnections.remove(connection);
+        availableConnections.remove(connection);
     }
 
     public ConnectionPool.Stats stats() {
@@ -191,7 +191,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
     private class ConnectionPoolStats implements Stats {
         @Override
         public int availableConnectionCount() {
-            return activeConnections.size();
+            return availableConnections.size();
         }
 
         @Override
@@ -232,7 +232,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
         @Override
         public String toString() {
             return MoreObjects.toStringHelper(this)
-                    .add("\nactiveConnections", availableConnectionCount())
+                    .add("\navailableConnections", availableConnectionCount())
                     .add("\npendingConnections", pendingConnectionCount())
                     .add("\nbusyConnections", busyConnectionCount())
                     .add("\nconnectionAttempts", connectionAttempts())

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/StatsReportingConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/StatsReportingConnectionPool.java
@@ -90,7 +90,7 @@ class StatsReportingConnectionPool implements ConnectionPool {
         scopedRegistry.register("connection-failures", (Gauge<Integer>) () -> (int) stats.connectionFailures());
         scopedRegistry.register("connections-closed", (Gauge<Integer>) () -> (int) stats.closedConnections());
         scopedRegistry.register("connections-terminated", (Gauge<Integer>) () -> (int) stats.terminatedConnections());
-        scopedRegistry.register("in-establishment", (Gauge<Integer>) () -> (int) stats.connectionsInEstablishment());
+        scopedRegistry.register("connections-in-establishment", (Gauge<Integer>) () -> (int) stats.connectionsInEstablishment());
     }
 
     private void registerMetrics() {
@@ -107,7 +107,7 @@ class StatsReportingConnectionPool implements ConnectionPool {
         MetricRegistry scopedRegistry = getMetricScope(connectionPool);
         asList("busy-connections", "pending-connections", "available-connections", "ttfb",
                 "connection-attempts", "connection-failures", "connections-closed", "connections-terminated",
-                "in-establishment")
+                "connections-in-establishment")
                 .forEach(scopedRegistry::deregister);
     }
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/SimpleConnectionPoolFactoryTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/SimpleConnectionPoolFactoryTest.java
@@ -49,7 +49,7 @@ public class SimpleConnectionPoolFactoryTest {
                 "origins.test-app.origin-X.connectionspool.pending-connections",
                 "origins.test-app.origin-X.connectionspool.available-connections",
                 "origins.test-app.origin-X.connectionspool.busy-connections",
-                "origins.test-app.origin-X.connectionspool.in-establishment"
+                "origins.test-app.origin-X.connectionspool.connections-in-establishment"
         ));
     }
 }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/StatsReportingConnectionPoolTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/StatsReportingConnectionPoolTest.java
@@ -45,7 +45,7 @@ public class StatsReportingConnectionPoolTest {
                 "origins.generic-app.backend-01.connectionspool.busy-connections",
                 "origins.generic-app.backend-01.connectionspool.pending-connections",
                 "origins.generic-app.backend-01.connectionspool.connection-attempts",
-                "origins.generic-app.backend-01.connectionspool.in-establishment",
+                "origins.generic-app.backend-01.connectionspool.connections-in-establishment",
                 "origins.generic-app.backend-01.connectionspool.connection-failures",
                 "origins.generic-app.backend-01.connectionspool.connections-closed",
                 "origins.generic-app.backend-01.connectionspool.connections-terminated"


### PR DESCRIPTION
`Publisher<Connection>` was not emitted in some corner cases, leading to unnecessary timeouts from `borrowConnection`.

Also, `connectionsInEstablishment` was not decremented in some corner cases, resulting in a slow drift up that could end up preventing new connections from being established.
