### PR TITLE
Make the services.factories.backendServiceRegistry config optional.

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/StyxPipelineFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxPipelineFactory.java
@@ -21,6 +21,7 @@ import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.extension.service.BackendService;
 import com.hotels.styx.api.extension.service.spi.Registry;
 import com.hotels.styx.api.extension.service.spi.StyxService;
+import com.hotels.styx.infrastructure.MemoryBackedRegistry;
 import com.hotels.styx.proxy.plugin.NamedPlugin;
 import com.hotels.styx.routing.HttpPipelineFactory;
 import com.hotels.styx.routing.RoutingObject;
@@ -96,8 +97,15 @@ public final class StyxPipelineFactory implements PipelineFactory {
                     return (HttpPipelineFactory) () -> Builtins.build(ImmutableList.of("httpPipeline"), routingObjectFactoryContext, node);
                 })
                 .orElseGet(() -> {
-                    Registry<BackendService> backendServicesRegistry = (Registry<BackendService>) services.get("backendServiceRegistry");
-                    return new StaticPipelineFactory(environment, backendServicesRegistry, plugins, eventLoopGroup, nettySocketChannelClass, requestTracking);
+                    Registry<BackendService> registry = (Registry<BackendService>) services.get("backendServiceRegistry");
+
+                    return new StaticPipelineFactory(
+                            environment,
+                            registry != null ? registry : new MemoryBackedRegistry<>(),
+                            plugins,
+                            eventLoopGroup,
+                            nettySocketChannelClass,
+                            requestTracking);
                 });
 
         return pipelineBuilder.build();

--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -25,6 +25,7 @@ import com.hotels.styx.api.extension.service.BackendService;
 import com.hotels.styx.api.extension.service.spi.Registry;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.config.schema.SchemaValidationException;
+import com.hotels.styx.infrastructure.MemoryBackedRegistry;
 import com.hotels.styx.infrastructure.configuration.ConfigurationParser;
 import com.hotels.styx.infrastructure.configuration.yaml.YamlConfiguration;
 import com.hotels.styx.server.HttpServer;
@@ -246,8 +247,10 @@ public final class StyxServer extends AbstractService {
     }
 
     private static HttpServer createAdminServer(StyxServerComponents config) {
+        Registry<BackendService> registry = (Registry<BackendService>) config.services().get("backendServiceRegistry");
+
         return new AdminServerBuilder(config)
-                .backendServicesRegistry((Registry<BackendService>) config.services().get("backendServiceRegistry"))
+                .backendServicesRegistry(registry != null ? registry : new MemoryBackedRegistry<>())
                 .build();
     }
 

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/ConditionRoutingSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/ConditionRoutingSpec.kt
@@ -22,7 +22,6 @@ import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.client.StyxHttpClient
 import com.hotels.styx.startup.StyxServerComponents
-import com.hotels.styx.support.ResourcePaths.fixturesHome
 import io.kotlintest.Spec
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
@@ -64,7 +63,6 @@ class ConditionRoutingSpec : StringSpec() {
         }
     }
 
-    val originsOk = fixturesHome(ConditionRoutingSpec::class.java, "/conf/origins/origins-correct.yml")
     val yamlText = """
         proxy:
           connectors:
@@ -76,12 +74,6 @@ class ConditionRoutingSpec : StringSpec() {
               sslProvider: JDK
               sessionTimeoutMillis: 300000
               sessionCacheSize: 20000
-
-        services:
-          factories:
-            backendServiceRegistry:
-              class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry${'$'}Factory"
-              config: {originsFile: "$originsOk"}
 
         admin:
           connectors:

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/HostProxySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/HostProxySpec.kt
@@ -27,7 +27,6 @@ import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.client.StyxHttpClient
 import com.hotels.styx.server.HttpConnectorConfig
 import com.hotels.styx.servers.MockOriginServer
-import com.hotels.styx.support.ResourcePaths
 import com.hotels.styx.support.StyxServerProvider
 import com.hotels.styx.support.metrics
 import com.hotels.styx.support.newRoutingObject
@@ -55,8 +54,6 @@ class HostProxySpec : FeatureSpec() {
     // Run the tests sequentially:
     override fun isolationMode(): IsolationMode = IsolationMode.SingleInstance
 
-    val originsOk = ResourcePaths.fixturesHome(ConditionRoutingSpec::class.java, "/conf/origins/origins-correct.yml")
-
     override fun beforeSpec(spec: Spec) {
         testServer.restart()
         styxServer.restart()
@@ -82,7 +79,7 @@ class HostProxySpec : FeatureSpec() {
                         """.trimIndent()) shouldBe CREATED
 
                     client.send(get("/").header(HOST, styxServer().proxyHttpHostHeader()).build())
-                            .wait()
+                            .wait()!!
                             .status() shouldBe OK
 
                     styxServer().removeRoutingObject("hostProxy")
@@ -105,7 +102,7 @@ class HostProxySpec : FeatureSpec() {
                     client.send(get("/slow/n")
                             .header(HOST, styxServer().proxyHttpHostHeader())
                             .build())
-                            .wait()
+                            .wait()!!
                             .status() shouldBe GATEWAY_TIMEOUT
                 }.let { delay ->
                     delay shouldBe (beGreaterThan(600) and beLessThan(1000))
@@ -185,7 +182,7 @@ class HostProxySpec : FeatureSpec() {
                 client.send(get("/")
                         .header(HOST, styxServer().proxyHttpHostHeader())
                         .build())
-                        .wait()
+                        .wait()!!
                         .status() shouldBe OK
 
                 eventually(1.seconds, AssertionError::class.java) {
@@ -201,7 +198,7 @@ class HostProxySpec : FeatureSpec() {
                 client.send(get("/")
                         .header(HOST, styxServer().proxyHttpHostHeader())
                         .build())
-                        .wait()
+                        .wait()!!
                         .status() shouldBe OK
 
                 eventually(1.seconds, AssertionError::class.java) {
@@ -349,12 +346,6 @@ class HostProxySpec : FeatureSpec() {
                                     http:
                                       port: 0
 
-                                services:
-                                  factories:
-                                    backendServiceRegistry:
-                                      class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry${'$'}Factory"
-                                      config: {originsFile: "$originsOk"}
-
                                 httpPipeline: hostProxy
                               """.trimIndent())
 
@@ -370,12 +361,6 @@ class HostProxySpec : FeatureSpec() {
                                   connectors:
                                     http:
                                       port: 0
-
-                                services:
-                                  factories:
-                                    backendServiceRegistry:
-                                      class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry${'$'}Factory"
-                                      config: {originsFile: "$originsOk"}
 
                                 httpPipeline:
                                   type: ConditionRouter

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/PathPrefixRoutingSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/PathPrefixRoutingSpec.kt
@@ -21,7 +21,6 @@ import com.hotels.styx.api.HttpHeaderNames.HOST
 import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.client.StyxHttpClient
 import com.hotels.styx.startup.StyxServerComponents
-import com.hotels.styx.support.ResourcePaths.fixturesHome
 import io.kotlintest.Spec
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
@@ -50,7 +49,6 @@ class PathPrefixRoutingSpec : StringSpec() {
         }
     }
 
-    val originsOk = fixturesHome(ConditionRoutingSpec::class.java, "/conf/origins/origins-correct.yml")
     val yamlText = """
         proxy:
           connectors:
@@ -62,12 +60,6 @@ class PathPrefixRoutingSpec : StringSpec() {
               sslProvider: JDK
               sessionTimeoutMillis: 300000
               sessionCacheSize: 20000
-
-        services:
-          factories:
-            backendServiceRegistry:
-              class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry${'$'}Factory"
-              config: {originsFile: "$originsOk"}
 
         admin:
           connectors:

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/RoutingRestApiSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/RoutingRestApiSpec.kt
@@ -26,7 +26,6 @@ import com.hotels.styx.api.HttpResponseStatus.NOT_FOUND
 import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.client.StyxHttpClient
 import com.hotels.styx.startup.StyxServerComponents
-import com.hotels.styx.support.ResourcePaths.fixturesHome
 import io.kotlintest.Spec
 import io.kotlintest.TestCase
 import io.kotlintest.shouldBe
@@ -36,7 +35,6 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 class RoutingRestApiSpec : StringSpec() {
 
-    val originsOk = fixturesHome(RoutingRestApiSpec::class.java, "/conf/origins/origins-correct.yml")
     val yamlText = """
         proxy:
           connectors:
@@ -48,12 +46,6 @@ class RoutingRestApiSpec : StringSpec() {
               sslProvider: JDK
               sessionTimeoutMillis: 300000
               sessionCacheSize: 20000
-
-        services:
-          factories:
-            backendServiceRegistry:
-              class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry${'$'}Factory"
-              config: {originsFile: "$originsOk"}
 
         admin:
           connectors:

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/VersionFilesPropertySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/VersionFilesPropertySpec.kt
@@ -31,13 +31,11 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 class VersionFilesPropertySpec : StringSpec() {
     val fileLocation = fixturesHome(VersionFilesPropertySpec::class.java,"/version.txt")
-    val originsOk = fixturesHome(VersionFilesPropertySpec::class.java, "/conf/origins/origins-correct.yml")
     val yamlText = """
-        services:
-          factories:
-            backendServiceRegistry:
-              class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry${'$'}Factory"
-              config: {originsFile: "$originsOk"}
+        proxy:
+          connectors:
+            http:
+              port: 0
 
         admin:
           connectors:

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/support/StyxServerProvider.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/support/StyxServerProvider.kt
@@ -103,7 +103,7 @@ fun StyxServer.metrics(): Map<String, Map<String, Any>> {
             .send(HttpRequest.get("/admin/metrics")
                     .header(HttpHeaderNames.HOST, this.adminHostHeader())
                     .build())
-            .wait()
+            .wait()!!
             .bodyAs(StandardCharsets.UTF_8)
 
     return flattenMetricsMap(metricsText) as Map<String, Map<String, Any>>


### PR DESCRIPTION
The `services.factories.backendServiceRegistry` attribute is de-facto mandatory. When absent, Styx fails to start.

This is not such a big deal for normal usage. But it does add considerable amount of noise to our system and functional tests, where it is less often necessary.

Therefore, making it optional, and tidying up test cases.
