### PR TITLE
Configurable docker base image version.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG=11-jre-slim
+ARG TAG=11-jdk
 FROM openjdk:${TAG}
 
 ARG STYX_VERSION=""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+ARG TAG=11-jre-slim
+FROM openjdk:${TAG}
 
 ARG STYX_VERSION=""
 ARG STYX_IMAGE=https://github.com/HotelsDotCom/styx/releases/download/${STYX_VERSION}/${STYX_VERSION}-linux-x86_64.zip


### PR DESCRIPTION
Add a build time parameter to choose a Docker base image tag.

This allows to choose between the JRE only (default) base, and full JDK that has `jps`, `jcmd` & other tools handy for development purposes.
