### PR TITLE
Close a TCP connection when indicated by Connection: Close header.

### DIFF
--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagatorTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagatorTest.java
@@ -50,6 +50,8 @@ import static com.hotels.styx.api.extension.Origin.newOriginBuilder;
 import static com.hotels.styx.client.netty.connectionpool.NettyToStyxResponsePropagator.toStyxResponse;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
 import static io.netty.buffer.Unpooled.copiedBuffer;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderValues.CLOSE;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static io.netty.handler.codec.http.LastHttpContent.EMPTY_LAST_CONTENT;
@@ -321,6 +323,38 @@ public class NettyToStyxResponsePropagatorTest {
         channel.pipeline().fireChannelInactive();
 
         assertThat(httpContentOne.refCnt(), is(0));
+    }
+
+    @Test
+    public void closesConnectionWhenConnectionCloseHeaderIsPresent() {
+        NettyToStyxResponsePropagator handler = new NettyToStyxResponsePropagator(responseSubscriber, SOME_ORIGIN);
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+        DefaultHttpResponse responseHeaders = new DefaultHttpResponse(HTTP_1_1, OK);
+        responseHeaders.headers().add(CONNECTION, CLOSE);
+
+        channel.writeInbound(responseHeaders);
+        channel.writeInbound(newHttpContent("one"));
+        channel.writeInbound(EMPTY_LAST_CONTENT);
+
+        assertThat(channel.isOpen(), is(false));
+        assertThat(channel.isActive(), is(false));
+    }
+
+    @Test
+    public void ignoresCaseOfConnectionCloseHeader() {
+        NettyToStyxResponsePropagator handler = new NettyToStyxResponsePropagator(responseSubscriber, SOME_ORIGIN);
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+        DefaultHttpResponse responseHeaders = new DefaultHttpResponse(HTTP_1_1, OK);
+        responseHeaders.headers().add("CONNECTION", "CLOSE");
+
+        channel.writeInbound(responseHeaders);
+        channel.writeInbound(newHttpContent("one"));
+        channel.writeInbound(EMPTY_LAST_CONTENT);
+
+        assertThat(channel.isOpen(), is(false));
+        assertThat(channel.isActive(), is(false));
     }
 
     private static io.netty.handler.codec.http.HttpResponse newCorruptedResponse() {


### PR DESCRIPTION
## Introduction

Close the TCP connection when indicated by `Connection: close` header in the received response.

## Background

So far, Styx has ignored the received `Connection: close` header, and relied on sender to close the TCP connection, and on Netty to deliver a `channelInactive` event. This behaviour introduces a race condition that subtly increases failed requests manifesting in Styx 502 responses.

This behaviour unnecessarily delays the connection removal, and is a problematic specifically with pooled connections. A pooled connection may be reused for another request wile the operating system and/or TCP protocol is processing connection closure (transmitting FIN). When a request is sent on such a connection, it will be rejected by the remote peer, resulting in a TCP reset.

## Solution

Check if the `Connection: close` header is present in a response. If so, close the connection straight away. This taints the connection so that it won't be used for any future requests, eliminating the race condition.
