### PR TITLE
Consume request body on early return

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/ByteStream.java
+++ b/components/api/src/main/java/com/hotels/styx/api/ByteStream.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import io.netty.buffer.Unpooled;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.nio.charset.Charset;
 import java.util.Optional;
@@ -117,6 +118,20 @@ public class ByteStream implements Publisher<Buffer> {
         return new ByteStream(Flux.from(stream)
                 .doOnNext(buffer -> buffer.delegate().release())
                 .filter(buffer -> false));
+    }
+
+    /**
+     * Transform the stream by dropping all {@link Buffer} objects.
+     *
+     * The {@code drop} returns a new {@code ByteStream} object with all upstream
+     * buffers removed. The {@code drop} automatically decrements the reference
+     * counts for each dropped {@link Buffer}.
+     *
+     * @return an empty {@link ByteStream}
+     */
+    ByteStream drop(int maxContentBytes) {
+        return new ByteStream(Mono.fromFuture(
+                new ByteStreamDropper(this.stream, maxContentBytes).apply()));
     }
 
     /**

--- a/components/api/src/main/java/com/hotels/styx/api/ByteStreamDropper.java
+++ b/components/api/src/main/java/com/hotels/styx/api/ByteStreamDropper.java
@@ -1,0 +1,87 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.api;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+class ByteStreamDropper implements Subscriber<Buffer> {
+    private final Publisher<Buffer> upstream;
+    private final int maxSize;
+    private final CompletableFuture<Buffer> future = new CompletableFuture<>();
+    private final AtomicBoolean active = new AtomicBoolean();
+    private Subscription subscription;
+    private final AtomicInteger byteCount = new AtomicInteger();
+
+    ByteStreamDropper(Publisher<Buffer> upstream, int maxSize) {
+        this.upstream = requireNonNull(upstream);
+        this.maxSize = maxSize;
+    }
+
+    public CompletableFuture<Buffer> apply() {
+        if (active.compareAndSet(false, true)) {
+            this.upstream.subscribe(this);
+            return future;
+        } else {
+            throw new IllegalStateException(getClass().getSimpleName() + " may only be started once.");
+        }
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        if (this.subscription == null) {
+            this.subscription = subscription;
+            this.subscription.request(Long.MAX_VALUE);
+        } else {
+            subscription.cancel();
+            throw new IllegalStateException(getClass().getSimpleName() + " supports only one Producer instance.");
+        }
+    }
+
+    @Override
+    public void onNext(Buffer part) {
+        long newSize = byteCount.addAndGet(part.size());
+
+        part.delegate().release();
+
+        if (newSize > maxSize) {
+            subscription.cancel();
+            this.future.completeExceptionally(
+                    new ContentOverflowException(format("Maximum content size exceeded. Maximum size allowed is %d bytes.", maxSize)));
+        }
+    }
+
+    @Override
+    public void onError(Throwable cause) {
+        subscription.cancel();
+        future.completeExceptionally(cause);
+    }
+
+    @Override
+    public void onComplete() {
+        future.complete(new Buffer(EMPTY_BUFFER));
+    }
+
+}

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpMessage.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpMessage.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
   limitations under the License.
  */
 package com.hotels.styx.api;
+
+import org.reactivestreams.Publisher;
 
 import java.util.List;
 import java.util.Optional;
@@ -102,6 +104,7 @@ interface LiveHttpMessage {
      * <p>
      */
     default void consume() {
+        // TODO is there any point to this aggregate call? Can't we just do body().drop().subscribe(...) or something?
         body().drop().aggregate(1)
                 .thenApply(buffer -> {
                     buffer.delegate().release();
@@ -109,5 +112,8 @@ interface LiveHttpMessage {
                 });
     }
 
-
+    default <T> Eventual<T> consume2() {
+        // Note: since the ByteStream will have zero elements, we can safely ignoring the original element type of body().drop().
+        return new Eventual<T>((Publisher) body().drop());
+    }
 }

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpMessage.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpMessage.java
@@ -105,6 +105,8 @@ interface LiveHttpMessage {
      * all the traffic. This has the benefit of keeping the underlying TCP connection
      * open for connection pooling.
      * <p>
+     *
+     * The consumption begins immediately, running in the background.
      */
     default void consumeInBackground() {
         consume().subscribe(new Subscriber<Object>() {
@@ -131,5 +133,15 @@ interface LiveHttpMessage {
         });
     }
 
+    /**
+     * Consume the message by discarding the message body.
+     * <p>
+     * This method reads the entire message body from the networks and black holes
+     * all the traffic. This has the benefit of keeping the underlying TCP connection
+     * open for connection pooling.
+     * <p>
+     *
+     * The consumption doesn't begin until the returned Eventual is subscribed to.
+     */
     <T extends LiveHttpMessage> Eventual<T> consume();
 }

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpMessage.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpMessage.java
@@ -15,16 +15,11 @@
  */
 package com.hotels.styx.api;
 
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-
 import java.util.List;
 import java.util.Optional;
 
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
-import static java.lang.Long.MAX_VALUE;
-import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * All behaviour common to both streaming requests and streaming responses.
@@ -97,51 +92,4 @@ interface LiveHttpMessage {
     default boolean chunked() {
         return HttpMessageSupport.chunked(headers());
     }
-
-    /**
-     * Consume the message by discarding the message body.
-     * <p>
-     * This method reads the entire message body from the networks and black holes
-     * all the traffic. This has the benefit of keeping the underlying TCP connection
-     * open for connection pooling.
-     * <p>
-     *
-     * The consumption begins immediately, running in the background.
-     */
-    default void consumeInBackground() {
-        consume().subscribe(new Subscriber<Object>() {
-            @Override
-            public void onSubscribe(Subscription s) {
-                s.request(MAX_VALUE);
-            }
-
-            @Override
-            public void onNext(Object o) {
-                // ignore
-            }
-
-            @Override
-            public void onError(Throwable t) {
-                // this will get the implementation class
-                getLogger(LiveHttpMessage.this.getClass()).error("Unexpected error", t);
-            }
-
-            @Override
-            public void onComplete() {
-                // ignore
-            }
-        });
-    }
-
-    /**
-     * Consume the message by discarding the message body.
-     * <p>
-     * This method reads the entire message body from the networks and black holes
-     * all the traffic. This has the benefit of keeping the underlying TCP connection
-     * open for connection pooling.
-     * <p>
-     *
-     * The consumption doesn't begin until the returned Eventual is subscribed to.
-     */
-    <T extends LiveHttpMessage> Eventual<T> consume();
 }

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpMessage.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpMessage.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -107,8 +106,8 @@ interface LiveHttpMessage {
      * open for connection pooling.
      * <p>
      */
-    default void consume() {
-        consume2().subscribe(new Subscriber<Object>() {
+    default void consumeInBackground() {
+        consume().subscribe(new Subscriber<Object>() {
             @Override
             public void onSubscribe(Subscription s) {
                 s.request(MAX_VALUE);
@@ -132,8 +131,5 @@ interface LiveHttpMessage {
         });
     }
 
-    default <T> Eventual<T> consume2() {
-        // Note: since the ByteStream will have zero elements, we can safely ignoring the original element type of body().drop().
-        return new Eventual<T>((Publisher) body().drop());
-    }
+    <T extends LiveHttpMessage> Eventual<T> consume();
 }

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpRequest.java
@@ -383,6 +383,10 @@ public class LiveHttpRequest implements LiveHttpMessage {
                 .findFirst();
     }
 
+    public Eventual<LiveHttpRequest> consume() {
+        return MessageBodyConsumption.consume(this, LiveHttpRequest.class);
+    }
+
     @Override
     public String toString() {
         return toStringHelper(this)

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpRequest.java
@@ -383,9 +383,18 @@ public class LiveHttpRequest implements LiveHttpMessage {
                 .findFirst();
     }
 
-    @Override
-    public Eventual<LiveHttpRequest> consume() {
-        return MessageBodyConsumption.consume(this, LiveHttpRequest.class);
+    /**
+     * Consume the message by discarding the message body.
+     * <p>
+     * This method reads the entire message body from the networks and black holes
+     * all the traffic. This has the benefit of keeping the underlying TCP connection
+     * open for connection pooling.
+     * <p>
+     *
+     * The consumption doesn't begin until the returned Eventual is subscribed to.
+     */
+    public Eventual<LiveHttpRequest> consume(int maxContentBytes) {
+        return MessageBodyConsumption.consume(this, maxContentBytes);
     }
 
     @Override

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpRequest.java
@@ -383,6 +383,7 @@ public class LiveHttpRequest implements LiveHttpMessage {
                 .findFirst();
     }
 
+    @Override
     public Eventual<LiveHttpRequest> consume() {
         return MessageBodyConsumption.consume(this, LiveHttpRequest.class);
     }

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpResponse.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -228,6 +228,10 @@ public class LiveHttpResponse implements LiveHttpMessage {
         return cookies().stream()
                 .filter(cookie -> cookie.name().equals(name))
                 .findFirst();
+    }
+
+    public Eventual<LiveHttpResponse> consume() {
+        return MessageBodyConsumption.consume(this, LiveHttpResponse.class);
     }
 
     @Override

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpResponse.java
@@ -230,6 +230,7 @@ public class LiveHttpResponse implements LiveHttpMessage {
                 .findFirst();
     }
 
+    @Override
     public Eventual<LiveHttpResponse> consume() {
         return MessageBodyConsumption.consume(this, LiveHttpResponse.class);
     }

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpResponse.java
@@ -230,9 +230,18 @@ public class LiveHttpResponse implements LiveHttpMessage {
                 .findFirst();
     }
 
-    @Override
-    public Eventual<LiveHttpResponse> consume() {
-        return MessageBodyConsumption.consume(this, LiveHttpResponse.class);
+    /**
+     * Consume the message by discarding the message body.
+     * <p>
+     * This method reads the entire message body from the networks and black holes
+     * all the traffic. This has the benefit of keeping the underlying TCP connection
+     * open for connection pooling.
+     * <p>
+     *
+     * The consumption doesn't begin until the returned Eventual is subscribed to.
+     */
+    public Eventual<LiveHttpResponse> consume(int maxContentBytes) {
+        return MessageBodyConsumption.consume(this, maxContentBytes);
     }
 
     @Override

--- a/components/api/src/main/java/com/hotels/styx/api/MessageBodyConsumption.java
+++ b/components/api/src/main/java/com/hotels/styx/api/MessageBodyConsumption.java
@@ -1,0 +1,38 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.api;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+final class MessageBodyConsumption {
+    private MessageBodyConsumption() {
+    }
+
+    static <T extends LiveHttpMessage> Eventual<T> consume(T message, Class<T> type) {
+        // Not strictly necessary, but we're playing with generics and unchecked casting here,
+        // so this will probably help us if any bugs appear due to misuse of this method.
+        if (!type.isInstance(message)) {
+            throw new IllegalArgumentException("Incorrect type: " + type);
+        }
+
+        // Note: since the ByteStream will have zero elements, we can ignore the original element type of body().drop().
+        Publisher typeErased = message.body().drop();
+        Mono<T> replaceWithOriginalMessage = Mono.from(typeErased).concatWith(Mono.just(message)).single();
+
+        return new Eventual<>(replaceWithOriginalMessage);
+    }
+}

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
@@ -43,8 +43,6 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
  * for implementing a StyxSerive interface.
  */
 public abstract class AbstractStyxService implements StyxService {
-    private static final int MAX_CONTENT_BYTES_FOR_STATUS_PAGE = 1024;
-
     private final String name;
     private final AtomicReference<StyxServiceStatus> status = new AtomicReference<>(CREATED);
 
@@ -100,7 +98,7 @@ public abstract class AbstractStyxService implements StyxService {
     @Override
     public Map<String, HttpHandler> adminInterfaceHandlers() {
         return ImmutableMap.of("status", (request, context) ->
-                request.aggregate(MAX_CONTENT_BYTES_FOR_STATUS_PAGE).map(anyRequest ->
+                request.consume().map(anyRequest ->
                         response(OK)
                                 .addHeader(CONTENT_TYPE, APPLICATION_JSON)
                                 .body(format("{ name: \"%s\" status: \"%s\" }", name, status), UTF_8)

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
@@ -98,7 +98,7 @@ public abstract class AbstractStyxService implements StyxService {
     @Override
     public Map<String, HttpHandler> adminInterfaceHandlers() {
         return ImmutableMap.of("status", (request, context) ->
-                request.consume().map(anyRequest ->
+                request.consume(1024).map(anyRequest ->
                         response(OK)
                                 .addHeader(CONTENT_TYPE, APPLICATION_JSON)
                                 .body(format("{ name: \"%s\" status: \"%s\" }", name, status), UTF_8)

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package com.hotels.styx.api.extension.service.spi;
 
 import com.google.common.collect.ImmutableMap;
-import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 
 import java.util.Map;
@@ -39,7 +38,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 
 /**
  * A helper class for implementing StyxService interface.
- *
+ * <p>
  * AbstractStyxService provides service state management facilities
  * for implementing a StyxSerive interface.
  */
@@ -98,12 +97,13 @@ public abstract class AbstractStyxService implements StyxService {
 
     @Override
     public Map<String, HttpHandler> adminInterfaceHandlers() {
-        return ImmutableMap.of("status", (request, context) -> Eventual.of(
-                response(OK)
-                        .addHeader(CONTENT_TYPE, APPLICATION_JSON)
-                        .body(format("{ name: \"%s\" status: \"%s\" }", name, status), UTF_8)
-                        .build()
-                        .stream()));
+        return ImmutableMap.of("status", (request, context) ->
+                request.aggregate(1_000_000).map(anyRequest ->
+                        response(OK)
+                                .addHeader(CONTENT_TYPE, APPLICATION_JSON)
+                                .body(format("{ name: \"%s\" status: \"%s\" }", name, status), UTF_8)
+                                .build()
+                                .stream()));
     }
 
     public String serviceName() {

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
@@ -43,6 +43,8 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
  * for implementing a StyxSerive interface.
  */
 public abstract class AbstractStyxService implements StyxService {
+    private static final int MAX_CONTENT_BYTES_FOR_STATUS_PAGE = 1024;
+
     private final String name;
     private final AtomicReference<StyxServiceStatus> status = new AtomicReference<>(CREATED);
 
@@ -98,7 +100,7 @@ public abstract class AbstractStyxService implements StyxService {
     @Override
     public Map<String, HttpHandler> adminInterfaceHandlers() {
         return ImmutableMap.of("status", (request, context) ->
-                request.aggregate(1_000_000).map(anyRequest ->
+                request.aggregate(MAX_CONTENT_BYTES_FOR_STATUS_PAGE).map(anyRequest ->
                         response(OK)
                                 .addHeader(CONTENT_TYPE, APPLICATION_JSON)
                                 .body(format("{ name: \"%s\" status: \"%s\" }", name, status), UTF_8)

--- a/components/api/src/test/java/com/hotels/styx/api/LiveHttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/LiveHttpResponseTest.java
@@ -334,7 +334,7 @@ public class LiveHttpResponseTest {
     }
 
     @Test
-    public void consumesBody() {
+    public void consumesBodyInBackground() {
         Buffer buf1 = new Buffer("foo", UTF_8);
         Buffer buf2 = new Buffer("bar", UTF_8);
 
@@ -349,7 +349,7 @@ public class LiveHttpResponseTest {
     }
 
     @Test
-    public void consumesBody2() {
+    public void consumesBodyInFlow() {
         Buffer buf1 = new Buffer("foo", UTF_8);
         Buffer buf2 = new Buffer("bar", UTF_8);
 

--- a/components/api/src/test/java/com/hotels/styx/api/LiveHttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/LiveHttpResponseTest.java
@@ -334,7 +334,7 @@ public class LiveHttpResponseTest {
     }
 
     @Test
-    public void consumesBodyInBackground() {
+    public void consumesBody() {
         Buffer buf1 = new Buffer("foo", UTF_8);
         Buffer buf2 = new Buffer("bar", UTF_8);
 
@@ -342,14 +342,14 @@ public class LiveHttpResponseTest {
                 .body(new ByteStream(Flux.just(buf1, buf2)))
                 .build();
 
-        response.consumeInBackground();
+        Mono.from(response.consume(1024)).block();
 
         assertEquals(buf1.delegate().refCnt(), 0);
         assertEquals(buf2.delegate().refCnt(), 0);
     }
 
-    @Test
-    public void consumesBodyInFlow() {
+    @Test(expectedExceptions = ContentOverflowException.class, expectedExceptionsMessageRegExp = "Maximum content size exceeded. Maximum size allowed is 1 bytes.")
+    public void bodyConsumptionLimitsMaxBytes() {
         Buffer buf1 = new Buffer("foo", UTF_8);
         Buffer buf2 = new Buffer("bar", UTF_8);
 
@@ -357,10 +357,7 @@ public class LiveHttpResponseTest {
                 .body(new ByteStream(Flux.just(buf1, buf2)))
                 .build();
 
-        Mono.from(response.consume()).block();
-
-        assertEquals(buf1.delegate().refCnt(), 0);
-        assertEquals(buf2.delegate().refCnt(), 0);
+        Mono.from(response.consume(1)).block();
     }
 
     @Test

--- a/components/api/src/test/java/com/hotels/styx/api/LiveHttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/LiveHttpResponseTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -342,7 +342,22 @@ public class LiveHttpResponseTest {
                 .body(new ByteStream(Flux.just(buf1, buf2)))
                 .build();
 
-        response.consume();
+        response.consumeInBackground();
+
+        assertEquals(buf1.delegate().refCnt(), 0);
+        assertEquals(buf2.delegate().refCnt(), 0);
+    }
+
+    @Test
+    public void consumesBody2() {
+        Buffer buf1 = new Buffer("foo", UTF_8);
+        Buffer buf2 = new Buffer("bar", UTF_8);
+
+        LiveHttpResponse response = response()
+                .body(new ByteStream(Flux.just(buf1, buf2)))
+                .build();
+
+        Mono.from(response.consume()).block();
 
         assertEquals(buf1.delegate().refCnt(), 0);
         assertEquals(buf2.delegate().refCnt(), 0);

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxHostHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxHostHttpClientTest.java
@@ -69,7 +69,7 @@ public class StyxHostHttpClientTest {
         StyxHostHttpClient hostClient = new StyxHostHttpClient(pool);
 
         StepVerifier.create(hostClient.sendRequest(request))
-                .consumeNextWith(response -> Mono.from(response.consume()).block())
+                .consumeNextWith(response -> Mono.from(response.consume(1000)).block())
                 .expectComplete()
                 .verify();
 
@@ -100,7 +100,7 @@ public class StyxHostHttpClientTest {
         verify(pool, never()).closeConnection(any(Connection.class));
 
         // ... until response body is consumed:
-        Mono.from(transformedResponse.get().consume()).block();
+        Mono.from(transformedResponse.get().consume(1000)).block();
 
         // Finally, the connection is returned after the response body is fully consumed:
         verify(pool).returnConnection(any(Connection.class));
@@ -145,7 +145,7 @@ public class StyxHostHttpClientTest {
                 .expectError()
                 .verify();
 
-        Mono.from(newResponse.get().consume()).block();
+        Mono.from(newResponse.get().consume(1000)).block();
 
         verify(pool).returnConnection(any(Connection.class));
     }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxHostHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxHostHttpClientTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 import rx.Observable;
@@ -68,7 +69,7 @@ public class StyxHostHttpClientTest {
         StyxHostHttpClient hostClient = new StyxHostHttpClient(pool);
 
         StepVerifier.create(hostClient.sendRequest(request))
-                .consumeNextWith(response -> response.consume())
+                .consumeNextWith(response -> Mono.from(response.consume()).block())
                 .expectComplete()
                 .verify();
 
@@ -99,7 +100,7 @@ public class StyxHostHttpClientTest {
         verify(pool, never()).closeConnection(any(Connection.class));
 
         // ... until response body is consumed:
-        transformedResponse.get().consume();
+        Mono.from(transformedResponse.get().consume()).block();
 
         // Finally, the connection is returned after the response body is fully consumed:
         verify(pool).returnConnection(any(Connection.class));
@@ -144,7 +145,7 @@ public class StyxHostHttpClientTest {
                 .expectError()
                 .verify();
 
-        newResponse.get().consume();
+        Mono.from(newResponse.get().consume()).block();
 
         verify(pool).returnConnection(any(Connection.class));
     }

--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagatorTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagatorTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/common/src/main/java/com/hotels/styx/api/EarlyReturn.java
+++ b/components/common/src/main/java/com/hotels/styx/api/EarlyReturn.java
@@ -21,6 +21,7 @@ package com.hotels.styx.api;
  * The main purpose of this is to ensure that the request is consumed, as well as cutting down on boilerplate.
  */
 public final class EarlyReturn {
+    private static final int BYTE_LIMIT = 1000_000;
 
     /**
      * Consume request content and return an error.
@@ -30,7 +31,7 @@ public final class EarlyReturn {
      * @return eventual live response
      */
     public static Eventual<LiveHttpResponse> returnEarlyWithError(LiveHttpRequest request, Throwable error) {
-        return request.consume().flatMap(any -> Eventual.error(error));
+        return request.consume(BYTE_LIMIT).flatMap(any -> Eventual.error(error));
     }
 
     /**
@@ -41,7 +42,7 @@ public final class EarlyReturn {
      * @return live response
      */
     public static Eventual<LiveHttpResponse> returnEarlyWithResponse(LiveHttpRequest request, LiveHttpResponse response) {
-        return request.consume().flatMap(any -> Eventual.of(response));
+        return request.consume(BYTE_LIMIT).flatMap(any -> Eventual.of(response));
     }
 
     /**
@@ -52,7 +53,7 @@ public final class EarlyReturn {
      * @return live response
      */
     public static Eventual<LiveHttpResponse> returnEarlyWithResponse(LiveHttpRequest request, HttpResponse response) {
-        return request.consume().flatMap(any -> Eventual.of(response.stream()));
+        return request.consume(BYTE_LIMIT).flatMap(any -> Eventual.of(response.stream()));
     }
 
     private EarlyReturn() {

--- a/components/common/src/main/java/com/hotels/styx/api/EarlyReturn.java
+++ b/components/common/src/main/java/com/hotels/styx/api/EarlyReturn.java
@@ -1,0 +1,39 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.api;
+
+/**
+ * Some convenience methods and values for early-return behaviour.
+ */
+public final class EarlyReturn {
+    public static final int REQUEST_BYTE_LIMIT_ON_ERROR = 1_000_000;
+
+    public static Eventual<LiveHttpResponse> returnEarlyWithError(LiveHttpRequest request, Throwable error) {
+        return request.aggregate(REQUEST_BYTE_LIMIT_ON_ERROR).flatMap(anyRequest ->
+                Eventual.error(error));
+    }
+
+    public static Eventual<LiveHttpResponse> returnEarlyWithResponse(LiveHttpRequest request, LiveHttpResponse response) {
+        return request.aggregate(REQUEST_BYTE_LIMIT_ON_ERROR).map(anyRequest -> response);
+    }
+
+    public static Eventual<LiveHttpResponse> returnEarlyWithResponse(LiveHttpRequest request, HttpResponse response) {
+        return request.aggregate(REQUEST_BYTE_LIMIT_ON_ERROR).map(anyRequest -> response.stream());
+    }
+
+    private EarlyReturn() {
+    }
+}

--- a/components/common/src/main/java/com/hotels/styx/api/EarlyReturn.java
+++ b/components/common/src/main/java/com/hotels/styx/api/EarlyReturn.java
@@ -17,19 +17,46 @@ package com.hotels.styx.api;
 
 /**
  * Some convenience methods and values for early-return behaviour.
+ *
+ * The main purpose of this is to ensure that the request is consumed, as well as cutting down on boilerplate.
  */
 public final class EarlyReturn {
+    /**
+     * Number of bytes to limit request body aggregation to, in order to mitigate denial-of-service attacks.
+     * This value is used by the methods in this class, but can also be used by external code, if desired.
+     */
     public static final int REQUEST_BYTE_LIMIT_ON_ERROR = 1_000_000;
 
+    /**
+     * Consume request content and return an error.
+     *
+     * @param request live request
+     * @param error error
+     * @return eventual live response
+     */
     public static Eventual<LiveHttpResponse> returnEarlyWithError(LiveHttpRequest request, Throwable error) {
         return request.aggregate(REQUEST_BYTE_LIMIT_ON_ERROR).flatMap(anyRequest ->
                 Eventual.error(error));
     }
 
+    /**
+     * Consume request content and return a response.
+     *
+     * @param request live request
+     * @param response live response
+     * @return live response
+     */
     public static Eventual<LiveHttpResponse> returnEarlyWithResponse(LiveHttpRequest request, LiveHttpResponse response) {
         return request.aggregate(REQUEST_BYTE_LIMIT_ON_ERROR).map(anyRequest -> response);
     }
 
+    /**
+     * Consume request content and return a response.
+     *
+     * @param request live request
+     * @param response non-live response
+     * @return live response
+     */
     public static Eventual<LiveHttpResponse> returnEarlyWithResponse(LiveHttpRequest request, HttpResponse response) {
         return request.aggregate(REQUEST_BYTE_LIMIT_ON_ERROR).map(anyRequest -> response.stream());
     }

--- a/components/common/src/main/java/com/hotels/styx/api/EarlyReturn.java
+++ b/components/common/src/main/java/com/hotels/styx/api/EarlyReturn.java
@@ -15,9 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Mono;
-
 /**
  * Some convenience methods and values for early-return behaviour.
  * <p>
@@ -33,7 +30,7 @@ public final class EarlyReturn {
      * @return eventual live response
      */
     public static Eventual<LiveHttpResponse> returnEarlyWithError(LiveHttpRequest request, Throwable error) {
-        return dropAndReplace(request, Eventual.error(error));
+        return request.consume().flatMap(any -> Eventual.error(error));
     }
 
     /**
@@ -44,7 +41,7 @@ public final class EarlyReturn {
      * @return live response
      */
     public static Eventual<LiveHttpResponse> returnEarlyWithResponse(LiveHttpRequest request, LiveHttpResponse response) {
-        return dropAndReplace(request, Eventual.of(response));
+        return request.consume().flatMap(any -> Eventual.of(response));
     }
 
     /**
@@ -55,13 +52,7 @@ public final class EarlyReturn {
      * @return live response
      */
     public static Eventual<LiveHttpResponse> returnEarlyWithResponse(LiveHttpRequest request, HttpResponse response) {
-        return dropAndReplace(request, Eventual.of(response.stream()));
-    }
-
-    private static <T> Eventual<T> dropAndReplace(LiveHttpRequest request, Publisher<T> other) {
-        return new Eventual<>(
-                Mono.from(request.<T>consume2())
-                        .concatWith(other));
+        return request.consume().flatMap(any -> Eventual.of(response.stream()));
     }
 
     private EarlyReturn() {

--- a/components/common/src/test/java/com/hotels/styx/api/EarlyReturnTest.java
+++ b/components/common/src/test/java/com/hotels/styx/api/EarlyReturnTest.java
@@ -25,6 +25,7 @@ import static com.hotels.styx.api.LiveHttpRequest.post;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.testng.Assert.fail;
 
 public class EarlyReturnTest {
     @Test
@@ -44,6 +45,7 @@ public class EarlyReturnTest {
 
         try {
             Mono.from(eventual).block();
+            fail("Exception not thrown");
         } catch (Exception e) {
             assertThat(e, is(myException));
         }

--- a/components/common/src/test/java/com/hotels/styx/api/EarlyReturnTest.java
+++ b/components/common/src/test/java/com/hotels/styx/api/EarlyReturnTest.java
@@ -1,3 +1,18 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 package com.hotels.styx.api;
 
 import org.testng.annotations.Test;

--- a/components/common/src/test/java/com/hotels/styx/api/EarlyReturnTest.java
+++ b/components/common/src/test/java/com/hotels/styx/api/EarlyReturnTest.java
@@ -1,0 +1,84 @@
+package com.hotels.styx.api;
+
+import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static com.hotels.styx.api.LiveHttpRequest.post;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class EarlyReturnTest {
+    @Test
+    public void bodyIsConsumedWhenReturningEarlyWithError() {
+        AtomicBoolean consumed = new AtomicBoolean();
+
+        ByteStream content = ByteStream.from("foo", UTF_8)
+                .doOnEnd(oe -> consumed.set(true));
+
+        LiveHttpRequest request = post("/")
+                .body(content)
+                .build();
+
+        RuntimeException myException = new RuntimeException("This is just a test");
+
+        Eventual<LiveHttpResponse> eventual = EarlyReturn.returnEarlyWithError(request, myException);
+
+        try {
+            Mono.from(eventual).block();
+        } catch (Exception e) {
+            assertThat(e, is(myException));
+        }
+
+        assertThat(consumed.get(), is(true));
+    }
+
+    @Test
+    public void bodyIsConsumedWhenReturningEarlyWithLiveResponse() {
+        AtomicBoolean consumed = new AtomicBoolean();
+
+        ByteStream content = ByteStream.from("foo", UTF_8)
+                .doOnEnd(oe -> consumed.set(true));
+
+        LiveHttpRequest request = post("/")
+                .body(content)
+                .build();
+
+        Eventual<LiveHttpResponse> eventual = EarlyReturn.returnEarlyWithResponse(request, LiveHttpResponse.response(OK)
+                .body(ByteStream.from("Expected response content", UTF_8))
+                .build());
+
+        HttpResponse response = Mono.from(eventual.flatMap(resp ->
+                resp.aggregate(1000)))
+                .block();
+
+        assertThat(response.bodyAs(UTF_8), is("Expected response content"));
+        assertThat(consumed.get(), is(true));
+    }
+
+    @Test
+    public void bodyIsConsumedWhenReturningEarlyWithNonLiveResponse() {
+        AtomicBoolean consumed = new AtomicBoolean();
+
+        ByteStream content = ByteStream.from("foo", UTF_8)
+                .doOnEnd(oe -> consumed.set(true));
+
+        LiveHttpRequest request = post("/")
+                .body(content)
+                .build();
+
+        Eventual<LiveHttpResponse> eventual = EarlyReturn.returnEarlyWithResponse(request, HttpResponse.response(OK)
+                .body("Expected response content", UTF_8)
+                .build());
+
+        HttpResponse response = Mono.from(eventual.flatMap(resp ->
+                resp.aggregate(1000)))
+                .block();
+
+        assertThat(response.bodyAs(UTF_8), is("Expected response content"));
+        assertThat(consumed.get(), is(true));
+    }
+}

--- a/components/common/src/test/java/com/hotels/styx/api/RequestsTest.java
+++ b/components/common/src/test/java/com/hotels/styx/api/RequestsTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class RequestsTest {
     @Test
     public void requestDoFinallyActivatesWhenSuccessfullyCompleted() {
         Requests.doFinally(request, completed::set)
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -60,7 +60,7 @@ public class RequestsTest {
     @Test
     public void responseDoFinallyActivatesWhenSuccessfullyCompleted() {
         Requests.doFinally(response, completed::set)
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -74,7 +74,7 @@ public class RequestsTest {
         RuntimeException cause = new RuntimeException("help!!");
 
         Requests.doFinally(request, completed::set)
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -88,7 +88,7 @@ public class RequestsTest {
         RuntimeException cause = new RuntimeException("help!!");
 
         Requests.doFinally(response, completed::set)
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -100,7 +100,7 @@ public class RequestsTest {
     @Test
     public void requestDoOnCompleteActivatesWhenSuccessfullyCompleted() {
         Requests.doOnComplete(request, () -> completed.set(Optional.empty()))
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -112,7 +112,7 @@ public class RequestsTest {
     @Test
     public void responseDoOnCompleteActivatesWhenSuccessfullyCompleted() {
         Requests.doOnComplete(response, () -> completed.set(Optional.empty()))
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -126,7 +126,7 @@ public class RequestsTest {
         RuntimeException cause = new RuntimeException("help!!");
 
         Requests.doOnComplete(request, () -> completed.set(Optional.empty()))
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -140,7 +140,7 @@ public class RequestsTest {
         RuntimeException cause = new RuntimeException("help!!");
 
         Requests.doOnComplete(response, () -> completed.set(Optional.empty()))
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -152,7 +152,7 @@ public class RequestsTest {
     @Test
     public void requestDoOnErrorDoesNotActivatesWhenSuccessfullyCompleted() {
         Requests.doOnError(request, (cause) -> completed.set(Optional.of(cause)))
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -164,7 +164,7 @@ public class RequestsTest {
     @Test
     public void responseDoOnErrorDoesNotActivatesWhenSuccessfullyCompleted() {
         Requests.doOnError(response, (cause) -> completed.set(Optional.of(cause)))
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -178,7 +178,7 @@ public class RequestsTest {
         RuntimeException cause = new RuntimeException("help!!");
 
         Requests.doOnError(request, (it) -> completed.set(Optional.of(it)))
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));
@@ -193,7 +193,7 @@ public class RequestsTest {
         RuntimeException cause = new RuntimeException("help!!");
 
         Requests.doOnError(response, (it) -> completed.set(Optional.of(it)))
-                .consume();
+                .consumeInBackground();
 
         publisher.next(new Buffer("content", UTF_8));
         assertThat(completed.get(), is(nullValue()));

--- a/components/common/src/test/java/com/hotels/styx/api/ResponseEventListenerTest.java
+++ b/components/common/src/test/java/com/hotels/styx/api/ResponseEventListenerTest.java
@@ -62,7 +62,7 @@ public class ResponseEventListenerTest {
                 .apply();
 
         StepVerifier.create(listener)
-                .consumeNextWith(LiveHttpMessage::consume)
+                .consumeNextWith(LiveHttpMessage::consumeInBackground)
                 .then(() -> {
                     assertFalse(cancelled.get());
                     assertNull(responseError.get());
@@ -148,7 +148,7 @@ public class ResponseEventListenerTest {
                 .apply();
 
         StepVerifier.create(listener)
-                .consumeNextWith(LiveHttpMessage::consume)
+                .consumeNextWith(LiveHttpMessage::consumeInBackground)
                 .verifyError();
 
         assertFalse(cancelled.get());
@@ -170,7 +170,7 @@ public class ResponseEventListenerTest {
                 .apply();
 
         StepVerifier.create(listener)
-                .consumeNextWith(LiveHttpMessage::consume)
+                .consumeNextWith(LiveHttpMessage::consumeInBackground)
                 .verifyComplete();
 
         assertTrue(responseError.get() instanceof RuntimeException);

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/RouteHandlerAdapter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/RouteHandlerAdapter.java
@@ -24,6 +24,8 @@ import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.server.HttpRouter;
 import com.hotels.styx.server.NoServiceConfiguredException;
 
+import static com.hotels.styx.api.EarlyReturn.returnEarlyWithError;
+
 /**
  * A {@link HttpHandler} implementation.
  */
@@ -38,6 +40,6 @@ public class RouteHandlerAdapter implements RoutingObject {
     public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
         return router.route(request, context)
                 .map(handler -> handler.handle(request, context))
-                .orElseGet(() -> Eventual.error(new NoServiceConfiguredException(request.path())));
+                .orElseGet(() -> returnEarlyWithError(request, new NoServiceConfiguredException(request.path())));
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/interceptors/TcpTunnelRequestRejector.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/interceptors/TcpTunnelRequestRejector.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 
+import static com.hotels.styx.api.EarlyReturn.returnEarlyWithResponse;
 import static com.hotels.styx.api.HttpMethod.CONNECT;
 import static com.hotels.styx.api.HttpResponseStatus.METHOD_NOT_ALLOWED;
 import static com.hotels.styx.api.LiveHttpResponse.response;
@@ -29,16 +30,10 @@ import static com.hotels.styx.api.LiveHttpResponse.response;
  * (see issue #312 https://github.com/HotelsDotCom/styx/issues/312).
  */
 public class TcpTunnelRequestRejector implements HttpInterceptor {
-
     @Override
     public Eventual<LiveHttpResponse> intercept(LiveHttpRequest request, Chain chain) {
-
-        if (CONNECT.equals(request.method())) {
-            return Eventual.of(response(METHOD_NOT_ALLOWED).build());
-        } else {
-            return chain.proceed(request);
-        }
+        return CONNECT.equals(request.method())
+                ? returnEarlyWithResponse(request, response(METHOD_NOT_ALLOWED).build())
+                : chain.proceed(request);
     }
-
-
 }

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/InstrumentedPlugin.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/InstrumentedPlugin.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ import com.codahale.metrics.Meter;
 import com.hotels.styx.api.Environment;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
+import com.hotels.styx.api.HttpResponseStatus;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
-import com.hotels.styx.api.HttpResponseStatus;
 import com.hotels.styx.api.plugins.spi.Plugin;
 import com.hotels.styx.api.plugins.spi.PluginException;
 import com.hotels.styx.common.SimpleCache;
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import java.util.Map;
 
 import static com.google.common.base.Throwables.propagate;
+import static com.hotels.styx.api.EarlyReturn.returnEarlyWithError;
 import static com.hotels.styx.api.HttpResponseStatus.BAD_REQUEST;
 import static com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static java.util.Objects.requireNonNull;
@@ -93,7 +94,8 @@ public class InstrumentedPlugin implements Plugin {
                             .onErrorResumeNext(error -> error(recordAndWrapError(chain, error)))));
         } catch (Throwable e) {
             recordException(e);
-            return Eventual.error(new PluginException(e, plugin.name()));
+
+            return returnEarlyWithError(request, new PluginException(e, plugin.name()));
         }
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/Builtins.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/Builtins.java
@@ -17,7 +17,6 @@ package com.hotels.styx.routing.config;
 
 import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.Environment;
-import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.config.schema.Schema;
@@ -40,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.hotels.styx.api.EarlyReturn.returnEarlyWithResponse;
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
 import static java.lang.String.format;
@@ -58,7 +58,7 @@ public final class Builtins {
             ImmutableMap.of("HealthCheckMonitor", new HealthCheckMonitoringServiceFactory());
 
     public static final RouteRefLookup DEFAULT_REFERENCE_LOOKUP = reference -> (request, ctx) ->
-            Eventual.of(response(NOT_FOUND)
+            returnEarlyWithResponse(request, response(NOT_FOUND)
                     .body(format("Handler not found for '%s'.", reference), UTF_8)
                     .build()
                     .stream());

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ConditionRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ConditionRouter.java
@@ -17,14 +17,13 @@ package com.hotels.styx.routing.handlers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.config.schema.Schema;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 import com.hotels.styx.proxy.RouteHandlerAdapter;
-import com.hotels.styx.config.schema.Schema;
 import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.config.Builtins;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
@@ -41,14 +40,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static com.hotels.styx.api.EarlyReturn.returnEarlyWithResponse;
 import static com.hotels.styx.api.HttpResponseStatus.BAD_GATEWAY;
-import static com.hotels.styx.routing.config.RoutingConfigParser.toRoutingConfigNode;
 import static com.hotels.styx.config.schema.SchemaDsl.field;
 import static com.hotels.styx.config.schema.SchemaDsl.list;
 import static com.hotels.styx.config.schema.SchemaDsl.object;
 import static com.hotels.styx.config.schema.SchemaDsl.optional;
 import static com.hotels.styx.config.schema.SchemaDsl.routingObject;
 import static com.hotels.styx.config.schema.SchemaDsl.string;
+import static com.hotels.styx.routing.config.RoutingConfigParser.toRoutingConfigNode;
 import static com.hotels.styx.routing.config.RoutingSupport.append;
 import static com.hotels.styx.routing.config.RoutingSupport.missingAttributeError;
 import static java.lang.String.format;
@@ -97,7 +97,7 @@ public class ConditionRouter implements HttpRouter {
                 Context context,
                 ConditionRouterConfig config) {
             if (config.fallback == null) {
-                return (request, na) -> Eventual.of(LiveHttpResponse.response(BAD_GATEWAY).build());
+                return (request, na) -> returnEarlyWithResponse(request, LiveHttpResponse.response(BAD_GATEWAY).build());
             } else {
                 return Builtins.build(append(parents, "fallback"), context, config.fallback);
             }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static com.hotels.styx.api.EarlyReturn.returnEarlyWithError;
 import static com.hotels.styx.api.extension.Origin.newOriginBuilder;
 import static com.hotels.styx.api.extension.service.ConnectionPoolSettings.defaultConnectionPoolSettings;
 import static com.hotels.styx.client.HttpRequestOperationFactory.Builder.httpRequestOperationFactoryBuilder;
@@ -128,7 +129,7 @@ public class HostProxy implements RoutingObject {
                             .whenCancelled(() -> originMetrics.requestCancelled())
                             .apply());
         } else {
-            return Eventual.error(new IllegalStateException(errorMessage));
+            return returnEarlyWithError(request, new IllegalStateException(errorMessage));
         }
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/RouteRefLookup.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/RouteRefLookup.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.routing.handlers;
 
-import com.hotels.styx.api.Eventual;
 import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.RoutingObjectRecord;
 import com.hotels.styx.routing.config.StyxObjectReference;
@@ -23,6 +22,7 @@ import com.hotels.styx.routing.db.StyxObjectStore;
 
 import java.util.Optional;
 
+import static com.hotels.styx.api.EarlyReturn.returnEarlyWithResponse;
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -53,15 +53,13 @@ public interface RouteRefLookup {
 
             return routingObjectRecord
                     .map(it -> (RoutingObject) it.getRoutingObject())
-                    .orElse((liveRequest, na) -> {
-                        liveRequest.consume();
-
-                        return Eventual.of(response(NOT_FOUND)
-                                .body("Not found: " + route.name(), UTF_8)
-                                .build()
-                                .stream()
-                        );
-                    });
+                    .orElse((liveRequest, na) ->
+                            returnEarlyWithResponse(liveRequest,
+                                    response(NOT_FOUND)
+                                            .body("Not found: " + route.name(), UTF_8)
+                                            .build()
+                                            .stream()
+                            ));
         }
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StandardHttpPipeline.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StandardHttpPipeline.java
@@ -37,8 +37,6 @@ import static rx.RxReactiveStreams.toPublisher;
  * The pipeline consists of a chain of interceptors followed by a handler.
  */
 class StandardHttpPipeline implements HttpHandler {
-    private static final int REQUEST_BYTE_LIMIT_ON_ERROR = 1_000_000;
-
     private final List<HttpInterceptor> interceptors;
     private final HttpHandler handler;
     private final RequestTracker requestTracker;

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StaticResponseHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StaticResponseHandler.java
@@ -16,8 +16,6 @@
 package com.hotels.styx.routing.handlers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.hotels.styx.api.Buffer;
-import com.hotels.styx.api.ByteStream;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
@@ -27,12 +25,12 @@ import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
-import reactor.core.publisher.Flux;
 
 import java.util.List;
 
+import static com.hotels.styx.api.EarlyReturn.returnEarlyWithResponse;
+import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.statusWithCode;
-import static com.hotels.styx.api.LiveHttpResponse.response;
 import static com.hotels.styx.config.schema.SchemaDsl.field;
 import static com.hotels.styx.config.schema.SchemaDsl.integer;
 import static com.hotels.styx.config.schema.SchemaDsl.object;
@@ -59,7 +57,11 @@ public class StaticResponseHandler implements RoutingObject {
 
     @Override
     public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
-        return Eventual.of(response(statusWithCode(status)).body(new ByteStream(Flux.just(new Buffer(text, UTF_8)))).build());
+        return returnEarlyWithResponse(request,
+                response(statusWithCode(status))
+                        .body(text, UTF_8)
+                        .build()
+                        .stream());
     }
 
     private static class StaticResponseConfig {

--- a/components/proxy/src/main/java/com/hotels/styx/serviceproviders/ServiceProviderFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/serviceproviders/ServiceProviderFactory.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/main/java/com/hotels/styx/startup/extensions/DemoPlugin.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/extensions/DemoPlugin.java
@@ -20,17 +20,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
-import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.api.WebServiceHandler;
 import com.hotels.styx.api.plugins.spi.Plugin;
 import com.hotels.styx.api.plugins.spi.PluginFactory;
+import com.hotels.styx.common.http.handler.HttpAggregator;
 import org.slf4j.Logger;
 
 import java.util.Map;
 
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpResponse.response;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -68,19 +70,17 @@ public class DemoPlugin implements Plugin {
     @Override
     public Map<String, HttpHandler> adminInterfaceHandlers() {
         return ImmutableMap.of(
-                "example", adminHandler()
+                "example", new HttpAggregator(adminHandler())
         );
     }
 
-    private HttpHandler adminHandler() {
+    private WebServiceHandler adminHandler() {
         return (request, context) -> {
             LOGGER.info("Demo plugin serving admin page");
 
-            return Eventual.of(
-                    HttpResponse.response().header(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+            return Eventual.of(response().header(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
                             .body("This is an admin page provided by a demo plugin used to test Styx's plugin functionality. Text from config=" + config.adminText, UTF_8)
-                            .build()
-                            .stream());
+                            .build());
         };
     }
 

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthChecks.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthChecks.kt
@@ -47,7 +47,7 @@ fun urlProbe(probe: HttpRequest, timeout: Duration): Probe =
                             e.printStackTrace()
                         }
                         val ret = it.status().code() < 400
-                        println("Gonna return $ret")
+//                        println("Gonna return $ret")
                         ret
                     }
                     .toMono()

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthChecks.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthChecks.kt
@@ -49,7 +49,9 @@ fun urlProbe(probe: HttpRequest, timeout: Duration): Probe =
                     .timeout(timeout)
                     .onErrorResume {
                         when(it) {
-                            is IllegalReferenceCountException -> Mono.error<Boolean>(it)
+//                            is IllegalReferenceCountException -> Mono.error<Boolean>(it)
+                            // TODO why is this already down-referenced?
+                            is IllegalReferenceCountException -> Mono.just(true)
                             else -> Mono.just(false)
                         }
                     }

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthChecks.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthChecks.kt
@@ -35,8 +35,12 @@ fun urlProbe(probe: HttpRequest, timeout: Duration): Probe =
         { routingObject ->
             routingObject
                     .handle(probe.stream(), HttpInterceptorContext.create())
+                    // replacing old consume method with this causes test failure. reason currently unknown.
+//                    .flatMap {
+//                        it.consume2()
+//                    }
                     .map {
-                        it.consume()
+                        it.consumeInBackground()
                         it.status().code() < 400
                     }
                     .toMono()

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthChecks.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthChecks.kt
@@ -41,8 +41,14 @@ fun urlProbe(probe: HttpRequest, timeout: Duration): Probe =
             routingObject
                     .handle(probe.stream(), HttpInterceptorContext.create())
                     .map {
-                        it.consumeInBackground()
-                        it.status().code() < 400
+                        try {
+                            it.consumeInBackground()
+                        } catch(e : Exception) {
+                            e.printStackTrace()
+                        }
+                        val ret = it.status().code() < 400
+                        println("Gonna return $ret")
+                        ret
                     }
                     .toMono()
                     .timeout(timeout)

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/HealthCheckMonitoringServiceTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/HealthCheckMonitoringServiceTest.kt
@@ -178,8 +178,6 @@ class HealthCheckMonitoringServiceTest : FeatureSpec({
             monitor.runChecks("aaa", objectStore)
             monitor.runChecks("aaa", objectStore)
 
-//            Thread.sleep(10000)
-
             withClue(tagClue(objectStore, "aaa-01")) {
                 objectStore.get("aaa-01").get().tags shouldContain "state:active:0"
             }

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/HealthCheckMonitoringServiceTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/HealthCheckMonitoringServiceTest.kt
@@ -178,6 +178,8 @@ class HealthCheckMonitoringServiceTest : FeatureSpec({
             monitor.runChecks("aaa", objectStore)
             monitor.runChecks("aaa", objectStore)
 
+//            Thread.sleep(10000)
+
             withClue(tagClue(objectStore, "aaa-01")) {
                 objectStore.get("aaa-01").get().tags shouldContain "state:active:0"
             }

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerBuilder.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerBuilder.java
@@ -16,9 +16,7 @@
 package com.hotels.styx.server.netty;
 
 import com.hotels.styx.api.HttpHandler;
-import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.MetricRegistry;
-import com.hotels.styx.api.Eventual;
 import com.hotels.styx.server.HttpServer;
 import com.hotels.styx.server.ServerEventLoopFactory;
 import com.hotels.styx.server.netty.eventloop.PlatformAwareServerEventLoopFactory;
@@ -33,7 +31,9 @@ import java.util.function.Supplier;
 import static com.google.common.base.Objects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Lists.newCopyOnWriteArrayList;
+import static com.hotels.styx.api.EarlyReturn.returnEarlyWithResponse;
 import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
+import static com.hotels.styx.api.LiveHttpResponse.response;
 import static com.hotels.styx.server.netty.eventloop.ServerEventLoopFactories.memoize;
 import static java.util.Arrays.asList;
 
@@ -50,7 +50,8 @@ public final class NettyServerBuilder {
     private Optional<ServerConnector> httpConnector = Optional.empty();
     private Optional<ServerConnector> httpsConnector = Optional.empty();
     private final List<Runnable> startupActions = newCopyOnWriteArrayList();
-    private Supplier<HttpHandler> handlerFactory = () -> (request, context) -> Eventual.of(LiveHttpResponse.response(NOT_FOUND).build());
+    private Supplier<HttpHandler> handlerFactory = () -> (request, context) ->
+            returnEarlyWithResponse(request, response(NOT_FOUND).build());
 
     public static NettyServerBuilder newBuilder() {
         return new NettyServerBuilder();

--- a/docker/styx-env.sh
+++ b/docker/styx-env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2013-2019 Expedia Inc.
+# Copyright (C) ${license.git.copyrightYears} Expedia Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/plugin-examples/src/main/java/com/hotels/styx/EarlyReturnExamplePlugin.java
+++ b/plugin-examples/src/main/java/com/hotels/styx/EarlyReturnExamplePlugin.java
@@ -37,11 +37,12 @@ public class EarlyReturnExamplePlugin implements Plugin {
     @Override
     public Eventual<LiveHttpResponse> intercept(LiveHttpRequest request, Chain chain) {
         if (request.header("X-Respond").isPresent()) {
-            return Eventual.of(HttpResponse.response(OK)
-                    .header(CONTENT_TYPE, "text/plain; charset=utf-8")
-                    .body("Responding from plugin", UTF_8)
-                    .build()
-                    .stream());
+            return request.aggregate(1_000_000).map(anyRequest ->
+                    HttpResponse.response(OK)
+                            .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+                            .body("Responding from plugin", UTF_8)
+                            .build()
+                            .stream());
         } else {
             return chain.proceed(request);
         }

--- a/plugin-examples/src/main/java/com/hotels/styx/EarlyReturnExamplePlugin.java
+++ b/plugin-examples/src/main/java/com/hotels/styx/EarlyReturnExamplePlugin.java
@@ -31,13 +31,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * the HTTP response
  * The eventual object is returned immediately, even if the response has not yet arrived.
  */
-
 public class EarlyReturnExamplePlugin implements Plugin {
-
     @Override
     public Eventual<LiveHttpResponse> intercept(LiveHttpRequest request, Chain chain) {
         if (request.header("X-Respond").isPresent()) {
-            return request.aggregate(1_000_000).map(anyRequest ->
+            return request.consume().map(anyRequest ->
                     HttpResponse.response(OK)
                             .header(CONTENT_TYPE, "text/plain; charset=utf-8")
                             .body("Responding from plugin", UTF_8)

--- a/plugin-examples/src/main/java/com/hotels/styx/EarlyReturnExamplePlugin.java
+++ b/plugin-examples/src/main/java/com/hotels/styx/EarlyReturnExamplePlugin.java
@@ -35,7 +35,7 @@ public class EarlyReturnExamplePlugin implements Plugin {
     @Override
     public Eventual<LiveHttpResponse> intercept(LiveHttpRequest request, Chain chain) {
         if (request.header("X-Respond").isPresent()) {
-            return request.consume().map(anyRequest ->
+            return request.consume(1024).map(anyRequest ->
                     HttpResponse.response(OK)
                             .header(CONTENT_TYPE, "text/plain; charset=utf-8")
                             .body("Responding from plugin", UTF_8)

--- a/system-tests/e2e-suite/src/test/java/com/hotels/styx/http/StaticFileOnRealServerIT.java
+++ b/system-tests/e2e-suite/src/test/java/com/hotels/styx/http/StaticFileOnRealServerIT.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,13 +18,14 @@ package com.hotels.styx.http;
 import com.google.common.io.Files;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
+import com.hotels.styx.client.HttpClient;
 import com.hotels.styx.client.StyxHttpClient;
+import com.hotels.styx.common.http.handler.HttpAggregator;
 import com.hotels.styx.server.HttpServer;
 import com.hotels.styx.server.handlers.StaticFileHandler;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.hotels.styx.client.HttpClient;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -52,7 +53,7 @@ public class StaticFileOnRealServerIT {
     @BeforeClass
     public void startServer() {
         dir = Files.createTempDir();
-        webServer = createHttpServer(0, new StaticFileHandler(dir));
+        webServer = createHttpServer(0, new HttpAggregator(new StaticFileHandler(dir)));
         webServer.startAsync().awaitRunning();
         serverEndpoint = toHostAndPort(webServer.httpAddress());
     }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/TimeoutsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/TimeoutsSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/system-tests/example-backend-provider/src/main/java/testgrp/AdminHandlers.java
+++ b/system-tests/example-backend-provider/src/main/java/testgrp/AdminHandlers.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package testgrp;
 
 import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.HttpHandler;
-import com.hotels.styx.api.Eventual;
 
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
@@ -29,8 +28,12 @@ final class AdminHandlers {
     }
 
     static ImmutableMap<String, HttpHandler> adminHandlers(String endpoint, String responseContent) {
-        return ImmutableMap.of(endpoint, (request, context) -> Eventual.of(response(OK)
-                .body(responseContent, UTF_8)
-                .build().stream()));
+        return ImmutableMap.of(endpoint, (request, context) ->
+                request.aggregate(1_000_000).map(anyRequest ->
+                        response(OK)
+                                .body(responseContent, UTF_8)
+                                .build()
+                                .stream()
+                ));
     }
 }

--- a/system-tests/example-backend-provider/src/main/java/testgrp/AdminHandlers.java
+++ b/system-tests/example-backend-provider/src/main/java/testgrp/AdminHandlers.java
@@ -29,7 +29,7 @@ final class AdminHandlers {
 
     static ImmutableMap<String, HttpHandler> adminHandlers(String endpoint, String responseContent) {
         return ImmutableMap.of(endpoint, (request, context) ->
-                request.consume().map(anyRequest ->
+                request.consume(100_000).map(anyRequest ->
                         response(OK)
                                 .body(responseContent, UTF_8)
                                 .build()

--- a/system-tests/example-backend-provider/src/main/java/testgrp/AdminHandlers.java
+++ b/system-tests/example-backend-provider/src/main/java/testgrp/AdminHandlers.java
@@ -29,7 +29,7 @@ final class AdminHandlers {
 
     static ImmutableMap<String, HttpHandler> adminHandlers(String endpoint, String responseContent) {
         return ImmutableMap.of(endpoint, (request, context) ->
-                request.aggregate(1_000_000).map(anyRequest ->
+                request.consume().map(anyRequest ->
                         response(OK)
                                 .body(responseContent, UTF_8)
                                 .build()

--- a/system-tests/example-styx-plugin/src/main/java/loadtest/plugins/AdminHandlers.java
+++ b/system-tests/example-styx-plugin/src/main/java/loadtest/plugins/AdminHandlers.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package loadtest.plugins;
 
 import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.HttpHandler;
-import com.hotels.styx.api.Eventual;
 
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
@@ -29,10 +28,12 @@ final class AdminHandlers {
     }
 
     static ImmutableMap<String, HttpHandler> adminHandlers(String endpoint, String responseContent) {
-        return ImmutableMap.of(endpoint, (request, context) -> Eventual.of(response(OK)
-                .body(responseContent, UTF_8)
-                .build()
-                .stream()
-        ));
+        return ImmutableMap.of(endpoint, (request, context) ->
+                request.aggregate(1_000_000).map(anyRequest ->
+                        response(OK)
+                                .body(responseContent, UTF_8)
+                                .build()
+                                .stream()
+                ));
     }
 }

--- a/system-tests/example-styx-plugin/src/main/java/loadtest/plugins/AdminHandlers.java
+++ b/system-tests/example-styx-plugin/src/main/java/loadtest/plugins/AdminHandlers.java
@@ -29,7 +29,7 @@ final class AdminHandlers {
 
     static ImmutableMap<String, HttpHandler> adminHandlers(String endpoint, String responseContent) {
         return ImmutableMap.of(endpoint, (request, context) ->
-                request.consume().map(anyRequest ->
+                request.consume(100_000).map(anyRequest ->
                         response(OK)
                                 .body(responseContent, UTF_8)
                                 .build()

--- a/system-tests/example-styx-plugin/src/main/java/loadtest/plugins/AdminHandlers.java
+++ b/system-tests/example-styx-plugin/src/main/java/loadtest/plugins/AdminHandlers.java
@@ -29,7 +29,7 @@ final class AdminHandlers {
 
     static ImmutableMap<String, HttpHandler> adminHandlers(String endpoint, String responseContent) {
         return ImmutableMap.of(endpoint, (request, context) ->
-                request.aggregate(1_000_000).map(anyRequest ->
+                request.consume().map(anyRequest ->
                         response(OK)
                                 .body(responseContent, UTF_8)
                                 .build()

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/ConditionRoutingSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/ConditionRoutingSpec.kt
@@ -83,6 +83,7 @@ class ConditionRoutingSpec : StringSpec() {
         httpPipeline:
           type: InterceptorPipeline
           config:
+            pipeline: []
             handler:
               type: ConditionRouter
               config:
@@ -99,6 +100,8 @@ class ConditionRoutingSpec : StringSpec() {
                   config:
                     status: 200
                     content: "Hello, from http server!"
+        services: 
+          factories: {}
       """.trimIndent()
 
     val client: StyxHttpClient = StyxHttpClient.Builder().build()

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/PathPrefixRoutingSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/PathPrefixRoutingSpec.kt
@@ -89,6 +89,8 @@ class PathPrefixRoutingSpec : StringSpec() {
               content: "I'm database"
 
         httpPipeline: root
+        services: 
+          factories: {}
       """.trimIndent()
 
     val client: StyxHttpClient = StyxHttpClient.Builder().build()

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/RoutingRestApiSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/RoutingRestApiSpec.kt
@@ -53,6 +53,8 @@ class RoutingRestApiSpec : StringSpec() {
               port: 0
 
         httpPipeline: root
+        services: 
+          factories: {}
       """.trimIndent()
 
     init {

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/VersionFilesPropertySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/VersionFilesPropertySpec.kt
@@ -44,6 +44,8 @@ class VersionFilesPropertySpec : StringSpec() {
 
         userDefined:
           versionFiles: $fileLocation
+        services: 
+          factories: {}
       """.trimIndent()
 
     init {


### PR DESCRIPTION
These code changes add consumption of request upon early return to many classes.
This is done in two ways:
1. Some classes are switched from `HttpHandler` to `WebServiceHandler`
2. Some classes use convenience methods from the new `EarlyReturn` class

Option 1 is preferred (and most such conversions have already been done in previous PRs), but in some cases, such as when branching can lead to propagation of `LiveHttpRequest` instead of early-return, option 2 has been used.

You may also see some unrelated files have automatically had their copyright notices updated. I advocate just allowing these changes in, since the build process is going to keep making the changes on each build and it wastes time removing them again after every end-to-end test run.