### PR TITLE
Move issue template to ./github dir.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -5,23 +5,22 @@ We realise there is a lot of information requested here. We ask only that you do
 
 - Read the [contributing guidelines](https://github.com/HotelsDotCom/styx/blob/master/CONTRIBUTING.md)
 - Ensure the issue isn't already reported
-- Its helpful to use the bug or enhancement label
+- It's helpful to use the bug or enhancement label
 
 Thanks.
 -->
 
 ## The problem
-> Briefly describe the issue you are experiencing or the feature you want to see added to Styx. Tell us what you were trying to do and what happened instead.
-
-> Remember, we love features that you've contributed, so a PR with tests is amazing.
+> Briefly describe the issue you are experiencing. Tell us what you were trying to do and what happened instead.
 
 ## Detailed description
 > Please provide as much detail as possible.
-> Remember that providing sample code and or failing tests makes it much faster to understand and fix.
+
+> Remember that providing sample code and/or failing tests makes it much faster to understand and fix.
 
 ## Acceptance criteria
 > What you expect to happen in a list format.
 > e.g.
-> * A developer should be able configure option via overrides
+> * A developer should be able to configure options via overrides
 
 > Please keep it high level and try not to get into the detail of implementation

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,24 @@
+<!--
+Hey there and thank you for using issue tracker! :+1:
+
+We realise there is a lot of information requested here. We ask only that you do your best to provide as much as possible so we can better help.
+
+- Read the [contributing guidelines](https://github.com/HotelsDotCom/styx/blob/master/CONTRIBUTING.md)
+- Ensure the issue isn't already reported
+- It's helpful to use the bug or enhancement label
+
+Thanks.
+-->
+
+## The problem
+> Briefly describe the feature you want to see added to Styx.
+
+## Detailed description
+> Please provide as much detail as possible.
+
+## Acceptance criteria
+> What you expect to happen in a list format.
+> e.g.
+> * A developer should be able to configure options via overrides
+
+> Please keep it high level and try not to get into the detail of implementation


### PR DESCRIPTION
GitHub provides a new version of [issue templates](https://help.github.com/en/articles/about-issue-and-pull-request-templates#issue-templates). These are now stored in a `.github/ISSUE_TEMPLATE` directory and the best practice is to have different templates for bugs and features.

Also, [Pull Request templates](https://help.github.com/en/articles/about-issue-and-pull-request-templates#pull-request-templates) can be added to the `.github` dir.