### PR TITLE
Configure Travis CI to compile the project and run the tests using Trusty 'Java' (specifying the JDK version was failing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+dist: xenial
 language: java
 script: mvn verify -Pquality,linux
 jdk:
- - oraclejdk9
+ - oraclejdk8
 cache:
   directories:
   - ~/.m2/repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-language: generic
+language: java
 script: mvn verify -Pquality,linux
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 script: mvn verify -Pquality,linux
 jdk:
- - oraclejdk11
+ - oraclejdk9
 cache:
   directories:
   - ~/.m2/repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-dist: xenial
-language: java
+dist: trusty
+language: generic
 script: mvn verify -Pquality,linux
-jdk:
- - oraclejdk8
 cache:
   directories:
   - ~/.m2/repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 script: mvn verify -Pquality,linux
 jdk:
- - oraclejdk8
+ - oraclejdk11
 cache:
   directories:
   - ~/.m2/repository


### PR DESCRIPTION
Our Travis CI build has started failing recently when trying to  install Java 8. Since the default JDK in Trusty 'Java' is JDK 8 and we shouldn't need to install it,  we have removed the jdk: entry from the travis config file. 
 Additionally, just in case, we are now specifying we want to use the Ubuntu Trusty image (it should be the default). 