### PR TITLE
Update jackson-databind versions

### DIFF
--- a/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagatorTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagatorTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/main/java/com/hotels/styx/serviceproviders/ServiceProviderFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/serviceproviders/ServiceProviderFactory.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/plugin-examples/pom.xml
+++ b/plugin-examples/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9.1</version>
+      <version>2.9.9.3</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.9.1</version>
+        <version>2.9.9.3</version>
       </dependency>
 
       <dependency>

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/TimeoutsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/TimeoutsSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is to fix a security vulnerability GitHub informed us about.

The maven build also updated some copyright headers in files. Best to just include these changes since it will do it every time otherwise.