### PR TITLE
Optimise response event listener

### DIFF
--- a/components/common/src/main/java/com/hotels/styx/api/ResponseEventListener.java
+++ b/components/common/src/main/java/com/hotels/styx/api/ResponseEventListener.java
@@ -40,7 +40,7 @@ public class ResponseEventListener {
     private Runnable cancelAction = () -> { };
     private Runnable whenFinishedAction = () -> { };
 
-    private volatile com.hotels.styx.api.ResponseEventListener.State state = com.hotels.styx.api.ResponseEventListener.State.INITIAL;
+    private volatile State state = INITIAL;
 
     private ResponseEventListener(Publisher<LiveHttpResponse> publisher) {
         this.publisher = Flux.from(requireNonNull(publisher));


### PR DESCRIPTION
## Problem 

ResponseEventListener adds unnecessary pressure on heap:

* It constructs a `StateMachine` for the response that is being monitored. The underlying `StateMachine` loads of `Map.Entry` and `Key` objects.
* It uses a separate `LiveHttpResponse` builder for each *ContentError*, *ContentEnd* and *ContentCancelled* events. 

# Fix

* Replace `StateMachine` object with nested `switch/case` and `if/else` statements. 
* Collapse *ContentError*, *ContentEnd*, and *ContentCancelled* event response body content callbacks in a single `LiveHttpResponse` builder to avoid excessive HTTP header copying.

# Impact

On routing object based application router:
* HeaderEntry: ~ 40% less objects
* HeaderEntry[]: ~ 33% less objects
* Object[]: ~ 37% less objects
And so on.

