### PR TITLE
Fixes for Docker/Toxiproxy environment

### DIFF
--- a/docker/default-docker.yml
+++ b/docker/default-docker.yml
@@ -69,4 +69,4 @@ loadBalancing:
 
 url:
   encoding:
-    unwiseCharactersToEncode:
+    unwiseCharactersToEncode: ""

--- a/system-tests/docker-toxiproxy/README.md
+++ b/system-tests/docker-toxiproxy/README.md
@@ -21,6 +21,7 @@ $ brew install toxiproxy
 First, build a development Docker image for Styx:
 
 ```bash
+$ mvn install -Prelease,linux -Dmaven.test.skip=true
 $ make docker
 ``` 
 
@@ -83,3 +84,7 @@ Removing toxics:
 ```bash
 $ toxiproxy-cli toxic r -n latency_downstream httpd-01
 ```
+
+To enable/disable origins:
+
+$ toxiproxy-cli toggle httpd-01

--- a/system-tests/docker-toxiproxy/styx-config/origins.yml
+++ b/system-tests/docker-toxiproxy/styx-config/origins.yml
@@ -6,6 +6,8 @@
 ---
 - id: "httpd"
   path: "/"
+  healthCheck:
+    uri: /info.txt
   connectionPool:
     maxConnectionsPerHost: 45
     maxPendingConnectionsPerHost: 15


### PR DESCRIPTION
- Update default config as per server config schema

Styx would have been unable to start in ToxiProxy test environment because `unwiseCharactersToEncode` was not initialised and therefore didn't pass the validation. 

- Build instructions

- Enable origins health check
