### PR TITLE
Set the number of threads for the GlobalHttpClient to 2 in HostProxySpec

### DIFF
--- a/plugin-examples/pom.xml
+++ b/plugin-examples/pom.xml
@@ -17,8 +17,6 @@
 
     <maven.deploy.skip>true</maven.deploy.skip>
 
-    <rxjava.version>1.1.6</rxjava.version>
-    <testng.version>6.14.3</testng.version>
   </properties>
 
   <dependencyManagement>

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/HostProxySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/HostProxySpec.kt
@@ -85,7 +85,7 @@ class HostProxySpec : FeatureSpec() {
                     styxServer().removeRoutingObject("hostProxy")
                 }
 
-                threadCount("Styx-Client-Global") shouldBe 2 * Runtime.getRuntime().availableProcessors();
+                threadCount("Styx-Client-Global") shouldBe 2
             }
         }
 
@@ -385,7 +385,7 @@ class HostProxySpec : FeatureSpec() {
                                         content: "Hello - HTTP"
                               """.trimIndent())
 
-    val client: StyxHttpClient = StyxHttpClient.Builder().build()
+    val client: StyxHttpClient = System.setProperty("io.netty.eventLoopThreads", "2").let {StyxHttpClient.Builder().build()}
 
     val mockServer = MockOriginServer.create("", "", 0, HttpConnectorConfig(0))
             .start()


### PR DESCRIPTION
Set the number of threads for the GlobalHttpClient to 2 in HostProxySpec.
Unused properties in plugin-examples removed. 
