### PR TITLE
Improve test result reporting in Styx functional test suite

### DIFF
--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/support/TestErrorReporter.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/support/TestErrorReporter.kt
@@ -1,0 +1,65 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.support
+
+import io.kotlintest.Spec
+import io.kotlintest.TestCase
+import io.kotlintest.TestResult
+import io.kotlintest.TestStatus
+import io.kotlintest.extensions.TestListener
+import org.slf4j.LoggerFactory
+
+object TestErrorReporter: TestListener {
+    val LOGGER = LoggerFactory.getLogger("StyxFT")
+
+    override fun beforeSpec(spec: Spec) {
+        super.beforeSpec(spec)
+        LOGGER.info("Starting ${spec.description().fullName()}")
+    }
+
+    override fun afterSpec(spec: Spec) {
+        LOGGER.info("Finished ${spec.description().fullName()}")
+        super.afterSpec(spec)
+    }
+
+    override fun beforeTest(testCase: TestCase) {
+        super.beforeTest(testCase)
+
+        LOGGER.info("Running '${testCase.name}' - ${testCase.source.fileName}:${testCase.source.lineNumber}")
+    }
+
+    override fun afterTest(testCase: TestCase, result: TestResult) {
+        super.afterTest(testCase, result)
+
+        LOGGER.info("${testCase.name} - ${result.status}")
+        when (result.status) {
+            TestStatus.Success -> { }
+            TestStatus.Ignored -> { }
+            TestStatus.Error -> {
+                result.error?.let {
+                    LOGGER.info(it.message)
+                    it.printStackTrace()
+                }
+            }
+            TestStatus.Failure -> {
+                result.error?.let {
+                    LOGGER.info(it.message)
+                    it.printStackTrace()
+                }
+            }
+        }
+    }
+}

--- a/system-tests/ft-suite/src/test/kotlin/io/kotlintest/provided/ProjectConfig.kt
+++ b/system-tests/ft-suite/src/test/kotlin/io/kotlintest/provided/ProjectConfig.kt
@@ -1,0 +1,24 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package io.kotlintest.provided
+
+import com.hotels.styx.support.TestErrorReporter
+import io.kotlintest.AbstractProjectConfig
+import io.kotlintest.extensions.TestListener
+
+class ProjectConfig: AbstractProjectConfig() {
+    override fun listeners(): List<TestListener> = listOf(TestErrorReporter)
+}


### PR DESCRIPTION
This PR improves test result reporting, especially for failures. 

The new `TestErrorReporter` class listens for Kotlintest lifecycle notifications and logs the results accordingly. The `ProjectConfig` applies this listener globally for all existing test suites without having to modify existing tests.

This makes the following information available in the Travis logs. 

At the start of each spec, it logs:
```
08:57:12.335 [kotlintest-engine-0 @coroutine#1] INFO  StyxFT - Starting com.hotels.styx.routing.ConditionRoutingSpec
```

Then, at the beginning of each test:
```
08:57:12.344 [pool-3-thread-1 @coroutine#2] INFO  StyxFT - Running 'Routes HTTP protocol' - ConditionRoutingSpec.kt:35
```

And at the end of each passed test:
```
08:57:12.608 [pool-3-thread-1 @coroutine#5] INFO  StyxFT - Routes HTTP protocol - Success
```

And at the end of each failed test:

```
08:57:12.709 [pool-3-thread-1 @coroutine#9] INFO  StyxFT - Routes HTTPS protocol - Failure
08:57:12.709 [pool-3-thread-1 @coroutine#9] INFO  StyxFT - expected: 502 Bad Gateway but was: 200 OK
org.opentest4j.AssertionFailedError: expected: 502 Bad Gateway but was: 200 OK
	at com.hotels.styx.routing.ConditionRoutingSpec$2.invokeSuspend(ConditionRoutingSpec.kt:61)
	at com.hotels.styx.routing.ConditionRoutingSpec$2.invoke(ConditionRoutingSpec.kt)
	at io.kotlintest.runner.jvm.TestCaseExecutor$executeTest$supervisorJob$1$invokeSuspend$$inlined$map$lambda$1.invokeSuspend(TestCaseExecutor.kt:121)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)
	at kotlinx.coroutines.DispatchedTask.run(Dispatched.kt:233)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
```

Finally, at the end of each spec:
```
08:57:12.710 [kotlintest-engine-0 @coroutine#1] INFO  StyxFT - Finished com.hotels.styx.routing.ConditionRoutingSpec
```
