### PR TITLE
Always enable a check for empty HTTP content.

### DIFF
--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxBackendServiceClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxBackendServiceClientTest.java
@@ -331,7 +331,6 @@ public class StyxBackendServiceClientTest {
                 .loadBalancer(
                         mockLoadBalancer(Optional.of(remoteHost(SOME_ORIGIN, toHandler(hostClient), hostClient)))
                 )
-                .enableContentValidation()
                 .build();
 
         LiveHttpResponse response = Mono.from(styxHttpClient.sendRequest(SOME_REQ)).block();

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/StyxBackendServiceClientFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/StyxBackendServiceClientFactory.java
@@ -77,7 +77,6 @@ public class StyxBackendServiceClientFactory implements BackendServiceClientFact
                 .stickySessionConfig(backendService.stickySessionConfig())
                 .metricsRegistry(environment.metricRegistry())
                 .retryPolicy(retryPolicy)
-                .enableContentValidation()
                 .rewriteRules(backendService.rewrites())
                 .originStatsFactory(originStatsFactory)
                 .originsRestrictionCookieName(originRestrictionCookie)


### PR DESCRIPTION
Fixes a possibly hanging bodiless responses from new `LoadBalancingGroup` object.

Always set Content-Length to zero for bodiless responses (such as 204). The old application router code does this already, but the new load balancing group doesn't. Therefore, Netty appears to add `transfer-encoding: chunked` but no content ever follows, resulting hung responses.
