### PR TITLE
Expose styx logs in system test env as docker volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dependency-reduced-pom.xml
 .vagrant/
 result/
 logs/
+styx-logs/
 **/*.pyc
 load-test-latest
 wrk2/

--- a/system-tests/docker-test-env/docker-compose.yml
+++ b/system-tests/docker-test-env/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - "8000:8000"
     volumes:
       - ./styx-config:/styx/config
+      - ./styx-logs:/styx/logs
     links:
       - httpd-01
       - toxiproxy


### PR DESCRIPTION
Exposes all logs via mounted `styx-logs/` directory.
