### PR TITLE
Move backendServiceFactory from default configuration into styx config.

### DIFF
--- a/docker/default-docker.yml
+++ b/docker/default-docker.yml
@@ -38,12 +38,6 @@ admin:
 
 services:
   factories:
-    backendServiceRegistry:
-      class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry$Factory"
-      config:
-        originsFile: "/styx/default-config/origins.yml"
-        monitor:
-          enabled: true
     jmx:
       class: "com.hotels.styx.metrics.reporting.jmx.JmxReporterServiceFactory"
       config:

--- a/system-tests/docker-test-env/styx-config/styxconf.yml
+++ b/system-tests/docker-test-env/styx-config/styxconf.yml
@@ -4,5 +4,8 @@ include: /styx/default-config/default.yml
 services:
   factories:
     backendServiceRegistry:
+      class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry$Factory"
       config:
-        originsFile: "/styx/config/origins.yml"
+        originsFile: "/styx/default-config/origins.yml"
+        monitor:
+          enabled: true

--- a/system-tests/docker-test-env/styx-config/styxconf.yml
+++ b/system-tests/docker-test-env/styx-config/styxconf.yml
@@ -6,6 +6,6 @@ services:
     backendServiceRegistry:
       class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry$Factory"
       config:
-        originsFile: "/styx/default-config/origins.yml"
+        originsFile: "/styx/config/origins.yml"
         monitor:
           enabled: true


### PR DESCRIPTION
The old backend services factory is backed in the `default.yaml` in Styx Docker base image. 

This PR moves it down to `docker-test-env/styx-config/styxconf.yml` that is mapped from the host, making it easier to swap between the old application router and the new routing object engine.
