### PR TITLE
Fix kotlin unit tests

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/StyxHeaderConfig.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHeaderConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/client/src/main/java/com/hotels/styx/client/StyxHostHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHostHttpClient.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/common/src/main/java/com/hotels/styx/common/Files.java
+++ b/components/common/src/main/java/com/hotels/styx/common/Files.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/common/src/main/java/com/hotels/styx/common/Logging.java
+++ b/components/common/src/main/java/com/hotels/styx/common/Logging.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -217,16 +217,18 @@
             </goals>
             <configuration>
               <junitArtifactName>none:none</junitArtifactName>
+              <junitPlatformArtifactName>none:none</junitPlatformArtifactName>
             </configuration>
           </execution>
-          <!-- Define a JUnit execution (runs JUnit and KotlinTest tests) -->
+          <!-- Define a JUnit5 execution (runs JUnit5 and KotlinTest tests) -->
           <execution>
-            <id>junit-tests</id>
+            <id>junit5-tests</id>
             <phase>test</phase>
             <goals>
               <goal>test</goal>
             </goals>
             <configuration>
+              <junitArtifactName>none:none</junitArtifactName>
               <testNGArtifactName>none:none</testNGArtifactName>
             </configuration>
           </execution>

--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -197,6 +197,42 @@
         <artifactId>kotlin-maven-plugin</artifactId>
       </plugin>
 
+      <!-- This project has both TestNG tests, and JUnit5-executed KotlinTest tests. So
+           Surefire needs some fancy config to handle this. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <!-- Turn off default surefire execution -->
+          <execution>
+            <id>default-test</id>
+            <phase>none</phase>
+          </execution>
+          <!-- Define a TestNG execution (runs the TestNG tests) -->
+          <execution>
+            <id>testng-tests</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <junitArtifactName>none:none</junitArtifactName>
+            </configuration>
+          </execution>
+          <!-- Define a JUnit execution (runs JUnit and KotlinTest tests) -->
+          <execution>
+            <id>junit-tests</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <testNGArtifactName>none:none</testNGArtifactName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/RoutingObjectRecordTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/RoutingObjectRecordTest.kt
@@ -18,8 +18,6 @@ package com.hotels.styx.routing
 import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.specs.StringSpec
 import io.mockk.mockk
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 class RoutingObjectRecordTest : StringSpec({
     "Creates with timestamp" {

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/RoutingObjectRecordTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/RoutingObjectRecordTest.kt
@@ -18,6 +18,8 @@ package com.hotels.styx.routing
 import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.specs.StringSpec
 import io.mockk.mockk
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class RoutingObjectRecordTest : StringSpec({
     "Creates with timestamp" {
@@ -26,6 +28,11 @@ class RoutingObjectRecordTest : StringSpec({
                 .filter { it.startsWith("created") }
                 .first()
 
-        createdTag.shouldContain("created:20[0-9]{2}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}.[0-9]{3}".toRegex())
+        if (createdTag.contains(".")) { // just to keep the regexes clear
+            createdTag.shouldContain("created:20[0-9]{2}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}.[0-9]{1,3}$".toRegex())
+        } else {
+            createdTag.shouldContain("created:20[0-9]{2}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}$".toRegex())
+
+        }
     }
 })

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/config/BuiltinsTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/config/BuiltinsTest.kt
@@ -48,7 +48,7 @@ class BuiltinsTest : StringSpec({
     }
 
     val routeObjectStore = mockk<StyxObjectStore<RoutingObjectRecord>>()
-    every { routeObjectStore.get("aHandler") } returns Optional.of(RoutingObjectRecord.create("type", mockk(), mockk(), mockHandler))
+    every { routeObjectStore.get("aHandler") } returns Optional.of(RoutingObjectRecord.create("type", setOf(), mockk(), mockHandler))
 
     "Builds a new handler as per StyxObjectDefinition" {
         val routeDef = StyxObjectDefinition("handler-def", "SomeRoutingObject", mockk())

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/HostProxyTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/HostProxyTest.kt
@@ -122,7 +122,7 @@ class HostProxyTest : FeatureSpec() {
             scenario("Uses configured host and port number") {
                 val factory = HostProxy.Factory()
 
-                val hostProxy = factory.build(listOf(), context.get(), routingObjectDef("""
+                val hostProxy = factory.build(listOf("hostproxyname"), context.get(), routingObjectDef("""
                           type: HostProxy
                           config:
                             host: ahost.server.com:1234
@@ -135,7 +135,7 @@ class HostProxyTest : FeatureSpec() {
             scenario("Port defaults to 80") {
                 val factory = HostProxy.Factory()
 
-                val hostProxy = factory.build(listOf(), context.get(), routingObjectDef("""
+                val hostProxy = factory.build(listOf("hostproxyname"), context.get(), routingObjectDef("""
                           type: HostProxy
                           config:
                             host: localhost
@@ -148,7 +148,7 @@ class HostProxyTest : FeatureSpec() {
             scenario("Port defaults to 443 when TLS settings are present") {
                 val factory = HostProxy.Factory()
 
-                val hostProxy = factory.build(listOf(), context.get(), routingObjectDef("""
+                val hostProxy = factory.build(listOf("hostproxyname"), context.get(), routingObjectDef("""
                           type: HostProxy
                           config:
                             host: localhost

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/HealthCheckMonitoringServiceTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/HealthCheckMonitoringServiceTest.kt
@@ -26,6 +26,7 @@ import io.kotlintest.matchers.boolean.shouldBeTrue
 import io.kotlintest.matchers.collections.shouldContain
 import io.kotlintest.matchers.collections.shouldContainAll
 import io.kotlintest.matchers.collections.shouldContainExactly
+import io.kotlintest.matchers.string.shouldNotStartWith
 import io.kotlintest.matchers.withClue
 import io.kotlintest.milliseconds
 import io.kotlintest.shouldBe
@@ -75,10 +76,12 @@ class HealthCheckMonitoringServiceTest : FeatureSpec({
 
             verify { scheduledFuture.cancel(false) }
 
-            objectStore["aaa-01"].get().tags.shouldContainExactly("aaa", "state:disabled")
-            objectStore["aaa-02"].get().tags.shouldContainExactly("aaa")
-            objectStore["aaa-03"].get().tags.shouldContainExactly("aaa")
-            objectStore["aaa-04"].get().tags.shouldContainExactly("aaa", "state:enabled")
+            objectStore["aaa-01"].get().tags.shouldContainAll("aaa", "state:disabled")
+            objectStore["aaa-02"].get().tags.shouldContain("aaa")
+            objectStore["aaa-02"].get().tags.forEach{ it shouldNotStartWith "state" }
+            objectStore["aaa-03"].get().tags.shouldContain("aaa")
+            objectStore["aaa-03"].get().tags.forEach{ it shouldNotStartWith "state" }
+            objectStore["aaa-04"].get().tags.shouldContainAll("aaa", "state:enabled")
         }
     }
 

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
@@ -29,7 +29,7 @@ import com.hotels.styx.routing.handlers.PathPrefixRouter
 import com.hotels.styx.routing.handlers.ProviderObjectRecord
 import com.hotels.styx.services.OriginsConfigConverter.Companion.OBJECT_CREATOR_TAG
 import io.kotlintest.Matcher
-import io.kotlintest.Result
+import io.kotlintest.MatcherResult
 import io.kotlintest.Spec
 import io.kotlintest.eventually
 import io.kotlintest.seconds
@@ -585,21 +585,21 @@ class YamlFileConfigurationServiceTest : FunSpec() {
             .toMap()
 
     internal fun beRoutingObject(type: String, mandatoryTags: Collection<String>) = object : Matcher<RoutingObjectRecord> {
-        override fun test(value: RoutingObjectRecord): Result {
+        override fun test(value: RoutingObjectRecord): MatcherResult {
             val message = "Error matching ${value}"
 
             if (value.type != type) {
-                return Result(false,
+                return MatcherResult(false,
                         "{$message}.\nExcpected ${type} but was ${value.type}",
                         "${message}.\nObject type should not be LoadBalancingGroup")
             }
             if (!value.tags.containsAll(mandatoryTags)) {
-                return Result(false,
+                return MatcherResult(false,
                         "${message}.\nShould contain all tags ${mandatoryTags}, but contains ${value.tags}",
                         "${message}.\nShould not contain tags ${value.tags}")
             }
 
-            return Result(true, "test passed", "test passed")
+            return MatcherResult(true, "test passed", "test passed")
         }
     }
 

--- a/components/server/src/main/java/com/hotels/styx/server/ServerEnvironment.java
+++ b/components/server/src/main/java/com/hotels/styx/server/ServerEnvironment.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/server/src/main/java/com/hotels/styx/server/routing/antlr/DslFunctionResolutionError.java
+++ b/components/server/src/main/java/com/hotels/styx/server/routing/antlr/DslFunctionResolutionError.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 
     <!--Kotlin -->
     <kotlin.version>1.3.21</kotlin.version>
-    <kotlintest.version>3.3.2</kotlintest.version>
+    <kotlintest.version>3.4.2</kotlintest.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 
     <java-uuid-generator.version>3.1.5</java-uuid-generator.version>
@@ -706,6 +706,12 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
         </plugin>
 
         <plugin>

--- a/support/test-api/src/main/java/com/hotels/styx/testapi/BackendService.java
+++ b/support/test-api/src/main/java/com/hotels/styx/testapi/BackendService.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/system-tests/docker-test-env/origin-data/index.html
+++ b/system-tests/docker-test-env/origin-data/index.html
@@ -1,2 +1,17 @@
+<!--
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <h1>Hello, world!</h1>
 <h1>ABC</h1>


### PR DESCRIPTION
Kotlin tests are run by a JUnit 5 test runner. The styx-proxy component has Kotlin unit tests as well as TestNG unit tests, but the Maven Surefire plugin does not, by default, run both JUnit and TestNG tests in the same project.

The surefire plugin needs to be configured with two executions - one each for JUnit5 and TestNG - and the default execution disabled. 

Surefire determines which test framework to use by examining the test classpath. If it finds the appropriate dependency ("junit:junit", "org.junit.platform:junit-platform-engine" or "org.testng:testng" for JUnit4, JUnit5 and TestNG respectively) it executes that framework.

The two custom executions defined here disable the unwanted frameworks for each case, leaving only one that will run. It does this by changing the name of the dependency artifacts that the surefire plugin is looking for. (i.e. by setting the TestNG artifact name to "none:none", surefire will not find that on the test classpath and so will not try to run TestNG tests in that execution.)

The config parameters used are `testNgArtifactName`, `junitArtifactName` and `junitPlatformArtifactName` - as listed here: http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html

The original inspiration for this approach came from here: https://issues.apache.org/jira/browse/SUREFIRE-377