### PR TITLE
Expose styx origins config file in Admin interface (Issue #496)

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/TextHttpHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/TextHttpHandler.java
@@ -1,0 +1,57 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.admin.handlers;
+
+import com.hotels.styx.api.ByteStream;
+import com.hotels.styx.api.Eventual;
+import com.hotels.styx.api.HttpHandler;
+import com.hotels.styx.api.HttpInterceptor;
+import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.api.LiveHttpResponse;
+
+import java.util.function.Supplier;
+
+import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
+import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static com.hotels.styx.api.LiveHttpResponse.response;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Responds with UTF8 text stream.
+ */
+public class TextHttpHandler implements HttpHandler {
+
+    private final Supplier<String> text;
+
+    public TextHttpHandler(Supplier<String> text) {
+        this.text = requireNonNull(text, "text supplier cannot be null");
+    }
+
+    @Override
+    public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
+        return Eventual.of(createResponse());
+    }
+
+    protected LiveHttpResponse createResponse() {
+        return response(OK)
+                .disableCaching()
+                .addHeader(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                .body(ByteStream.from(text.get(), UTF_8))
+                .build();
+    }
+}

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
@@ -83,7 +83,7 @@ internal class YamlFileConfigurationService(
             }
 
     override fun adminInterfaceHandlers() =
-        mutableMapOf(Pair("origins", TextHttpHandler { originsConfig }))
+        mapOf("origins" to TextHttpHandler { originsConfig })
 
 
     fun reloadAction(content: String): Unit {
@@ -99,6 +99,7 @@ internal class YamlFileConfigurationService(
         }.mapCatching { (healthMonitors, routingObjectDefs) ->
             updateRoutingObjects(routingObjectDefs)
             updateHealthCheckServices(serviceDb, healthMonitors)
+        }.onSuccess {
             originsConfig = content
             initialised.countDown()
         }.onFailure {


### PR DESCRIPTION
Issue #496 
Modify the YamlFileConfigurationService to publish an endpoint to the Admin interface, that returns the current origins configuration file.