### PR TITLE
Add a "lbGroup" prefix to load balancing group membership tag.

### DIFF
--- a/components/proxy/src/main/kotlin/com/hotels/styx/ObjectTags.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/ObjectTags.kt
@@ -1,0 +1,18 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx
+
+fun lbGroupTag(name: String) = "lbGroup=$name"

--- a/components/proxy/src/main/kotlin/com/hotels/styx/routing/handlers/LoadBalancingGroup.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/routing/handlers/LoadBalancingGroup.kt
@@ -39,6 +39,7 @@ import com.hotels.styx.config.schema.SchemaDsl.integer
 import com.hotels.styx.config.schema.SchemaDsl.optional
 import com.hotels.styx.config.schema.SchemaDsl.string
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig
+import com.hotels.styx.lbGroupTag
 import com.hotels.styx.routing.RoutingObject
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.RoutingObjectFactory
@@ -77,7 +78,6 @@ internal class LoadBalancingGroup(val client: StyxBackendServiceClient, val chan
         )
 
         private val LOGGER = LoggerFactory.getLogger(LoadBalancingGroup::class.java)
-
     }
 
     class Factory : RoutingObjectFactory {
@@ -122,7 +122,7 @@ internal class LoadBalancingGroup(val client: StyxBackendServiceClient, val chan
 
         private fun routeDatabaseChanged(appId: String, snapshot: ObjectStore<RoutingObjectRecord>, remoteHosts: AtomicReference<Set<RemoteHost>>) {
             val newSet = snapshot.entrySet()
-                    .filter { isTaggedWith(it, appId) }
+                    .filter { isTaggedWith(it, lbGroupTag(appId)) }
                     .filterNot { isTaggedWith(it, "$INACTIVE_TAG.*".toRegex()) }
                     .map { toRemoteHost(appId, it) }
                     .toSet()

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthCheckMonitoringService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthCheckMonitoringService.kt
@@ -26,6 +26,7 @@ import com.hotels.styx.config.schema.SchemaDsl.integer
 import com.hotels.styx.config.schema.SchemaDsl.optional
 import com.hotels.styx.config.schema.SchemaDsl.string
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig
+import com.hotels.styx.lbGroupTag
 import com.hotels.styx.routing.RoutingObject
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.RoutingObjectFactory
@@ -184,16 +185,8 @@ internal fun tagIsIncomplete(tag: Set<String>) = !healthStatusTag(tag)
 
 internal fun discoverMonitoredObjects(application: String, objectStore: StyxObjectStore<RoutingObjectRecord>) =
         objectStore.entrySet()
-                .filter { it.value.tags.contains(application) }
+                .filter { it.value.tags.contains(lbGroupTag(application)) }
                 .map { Pair(it.key, it.value) }
-
-private fun removeTags(db: StyxObjectStore<RoutingObjectRecord>, name: String) {
-    db.get(name).ifPresent {
-        db.insert(name, it.copy(tags = it.tags
-                .filterNot { tag -> tag.matches("($ACTIVE_TAG|$INACTIVE_TAG).*".toRegex()) }
-                .toSet()))
-    }
-}
 
 private fun markObject(db: StyxObjectStore<RoutingObjectRecord>, name: String, newStatus: ObjectHealth) {
     db.get(name).ifPresent { db.insert(name, it.copy(tags = reTag(it.tags, newStatus))) }

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/LoadBalancingGroupTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/LoadBalancingGroupTest.kt
@@ -21,6 +21,7 @@ import com.hotels.styx.api.HttpRequest
 import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.api.configuration.ObjectStore
 import com.hotels.styx.api.exceptions.NoAvailableHostsException
+import com.hotels.styx.lbGroupTag
 import com.hotels.styx.routing.RoutingObjectFactoryContext
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.db.StyxObjectStore
@@ -53,12 +54,12 @@ class LoadBalancingGroupTest : FeatureSpec() {
             val routeDb = StyxObjectStore<RoutingObjectRecord>()
             val headers = HttpHeaders.Builder().build();
 
-            routeDb.insert("appx-01", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-01", headers)))
-            routeDb.insert("appx-02", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-02", headers)))
-            routeDb.insert("appx-03", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-03", headers)))
+            routeDb.insert("appx-01", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-01", headers)))
+            routeDb.insert("appx-02", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-02", headers)))
+            routeDb.insert("appx-03", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-03", headers)))
 
-            routeDb.insert("appy-01", RoutingObjectRecord.create("HostProxy", setOf("appY"), mockk(), StaticResponseHandler(200, "appy-01", headers)))
-            routeDb.insert("appy-02", RoutingObjectRecord.create("HostProxy", setOf("appY"), mockk(), StaticResponseHandler(200, "appy-02", headers)))
+            routeDb.insert("appy-01", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appY")), mockk(), StaticResponseHandler(200, "appy-01", headers)))
+            routeDb.insert("appy-02", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appY")), mockk(), StaticResponseHandler(200, "appy-02", headers)))
 
             routeDb.watch().waitUntil { it.entrySet().size == 5 }
 
@@ -92,9 +93,9 @@ class LoadBalancingGroupTest : FeatureSpec() {
             scenario("... and detects new origins") {
                 val frequencies = mutableMapOf<String, Int>()
 
-                routeDb.insert("appx-04", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-04", headers)))
-                routeDb.insert("appx-05", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-05", headers)))
-                routeDb.insert("appx-06", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-06", headers)))
+                routeDb.insert("appx-04", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-04", headers)))
+                routeDb.insert("appx-05", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-05", headers)))
+                routeDb.insert("appx-06", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-06", headers)))
 
                 routeDb.watch().waitUntil { it.entrySet().size == 8 }
 
@@ -121,9 +122,9 @@ class LoadBalancingGroupTest : FeatureSpec() {
             scenario("... and detects replaced origins") {
                 val frequencies = mutableMapOf<String, Int>()
 
-                routeDb.insert("appx-04", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-04-a", headers)))
-                routeDb.insert("appx-05", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-05-b", headers)))
-                routeDb.insert("appx-06", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-06-c", headers)))
+                routeDb.insert("appx-04", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-04-a", headers)))
+                routeDb.insert("appx-05", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-05-b", headers)))
+                routeDb.insert("appx-06", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-06-c", headers)))
 
                 routeDb.watch().waitUntil { it["appx-06"].isPresent }
 
@@ -158,8 +159,8 @@ class LoadBalancingGroupTest : FeatureSpec() {
             }
 
             scenario("... and exposes load balancing metric") {
-                routeDb.insert("appx-A", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-A", headers)))
-                routeDb.insert("appx-B", RoutingObjectRecord.create("HostProxy", setOf("appX"), mockk(), StaticResponseHandler(200, "appx-B", headers)))
+                routeDb.insert("appx-A", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-A", headers)))
+                routeDb.insert("appx-B", RoutingObjectRecord.create("HostProxy", setOf(lbGroupTag("appX")), mockk(), StaticResponseHandler(200, "appx-B", headers)))
 
                 routeDb.watch().waitUntil { it.entrySet().size == 4 }
 

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsConfigConverterTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsConfigConverterTest.kt
@@ -15,6 +15,7 @@
  */
 package com.hotels.styx.services
 
+import com.hotels.styx.lbGroupTag
 import com.hotels.styx.routing.RoutingObjectFactoryContext
 import com.hotels.styx.routing.config.Builtins.INTERCEPTOR_PIPELINE
 import com.hotels.styx.routing.db.StyxObjectStore
@@ -48,12 +49,12 @@ class OriginsConfigConverterTest : StringSpec({
                     it.size shouldBe 3
 
                     it[0].name() shouldBe "app.app1"
-                    it[0].tags().shouldContainAll("app", "state:active")
+                    it[0].tags().shouldContainAll(lbGroupTag("app"), "state:active")
                     it[0].type().shouldBe("HostProxy")
                     it[0].config().shouldNotBeNull()
 
                     it[1].name() shouldBe "app.app2"
-                    it[1].tags().shouldContainAll("app", "state:active")
+                    it[1].tags().shouldContainAll(lbGroupTag("app"), "state:active")
                     it[1].type().shouldBe("HostProxy")
                     it[1].config().shouldNotBeNull()
 
@@ -127,12 +128,12 @@ class OriginsConfigConverterTest : StringSpec({
                     it.size shouldBe 3
 
                     it[0].name() shouldBe "app.app1"
-                    it[0].tags().shouldContainAll("app", "state:active")
+                    it[0].tags().shouldContainAll(lbGroupTag("app"), "state:active")
                     it[0].type().shouldBe("HostProxy")
                     it[0].config().shouldNotBeNull()
 
                     it[1].name() shouldBe "app.app2"
-                    it[1].tags().shouldContainAll("app", "state:active")
+                    it[1].tags().shouldContainAll(lbGroupTag("app"), "state:active")
                     it[1].type().shouldBe("HostProxy")
                     it[1].config().shouldNotBeNull()
 
@@ -168,12 +169,12 @@ class OriginsConfigConverterTest : StringSpec({
                     it.size shouldBe 8
 
                     it[0].name() shouldBe "appA.appA-1"
-                    it[0].tags().shouldContainAll("appA", "state:active")
+                    it[0].tags().shouldContainAll(lbGroupTag("appA"), "state:active")
                     it[0].type().shouldBe("HostProxy")
                     it[0].config().shouldNotBeNull()
 
                     it[1].name() shouldBe "appA.appA-2"
-                    it[1].tags().shouldContainAll("appA", "state:active")
+                    it[1].tags().shouldContainAll(lbGroupTag("appA"), "state:active")
                     it[1].type().shouldBe("HostProxy")
                     it[1].config().shouldNotBeNull()
 
@@ -183,7 +184,7 @@ class OriginsConfigConverterTest : StringSpec({
                     it[2].config().shouldNotBeNull()
 
                     it[3].name() shouldBe "appB.appB-1"
-                    it[3].tags().shouldContainAll("appB", "state:active")
+                    it[3].tags().shouldContainAll(lbGroupTag("appB"), "state:active")
                     it[3].type().shouldBe("HostProxy")
                     it[3].config().shouldNotBeNull()
 
@@ -193,12 +194,12 @@ class OriginsConfigConverterTest : StringSpec({
                     it[4].config().shouldNotBeNull()
 
                     it[5].name() shouldBe "appC.appC-1"
-                    it[5].tags().shouldContainAll("appC", "state:active")
+                    it[5].tags().shouldContainAll(lbGroupTag("appC"), "state:active")
                     it[5].type().shouldBe("HostProxy")
                     it[5].config().shouldNotBeNull()
 
                     it[6].name() shouldBe "appC.appC-2"
-                    it[6].tags().shouldContainAll("appC", "state:active")
+                    it[6].tags().shouldContainAll(lbGroupTag("appC"), "state:active")
                     it[6].type().shouldBe("HostProxy")
                     it[6].config().shouldNotBeNull()
 
@@ -313,9 +314,9 @@ class OriginsConfigConverterTest : StringSpec({
         OriginsConfigConverter(serviceDb, RoutingObjectFactoryContext().get(), "")
                 .routingObjects(deserialiseOrigins(config))
                 .let {
-                    it[0].tags().shouldContainAll("appWithHealthCheck", "state:inactive")
-                    it[2].tags().shouldContainAll("appMissingHealthCheckUri", "state:active")
-                    it[4].tags().shouldContainAll("appWithNoHealthCheck", "state:active")
+                    it[0].tags().shouldContainAll(lbGroupTag("appWithHealthCheck"), "state:inactive")
+                    it[2].tags().shouldContainAll(lbGroupTag("appMissingHealthCheckUri"), "state:active")
+                    it[4].tags().shouldContainAll(lbGroupTag("appWithNoHealthCheck"), "state:active")
                 }
     }
 

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
@@ -23,6 +23,7 @@ import com.hotels.styx.api.extension.service.spi.StyxService
 import com.hotels.styx.api.extension.service.spi.StyxServiceStatus.RUNNING
 import com.hotels.styx.api.extension.service.spi.StyxServiceStatus.STOPPED
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig
+import com.hotels.styx.lbGroupTag
 import com.hotels.styx.routing.RoutingObjectFactoryContext
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.db.StyxObjectStore
@@ -148,8 +149,8 @@ class YamlFileConfigurationServiceTest : FunSpec() {
                     val objects = objectStore.toMap()
                     objects.size shouldBe 4
 
-                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf("app", "source=zone1")))
-                    objects["app.app-02"]!!.should(beRoutingObject("HostProxy", setOf("app", "source=zone1")))
+                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
+                    objects["app.app-02"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
                     objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
                     objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
                 }
@@ -169,7 +170,7 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 
                     objects.size shouldBe 3
 
-                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf("app", "source=zone1")))
+                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
                     objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
                     objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
                 }
@@ -189,7 +190,7 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 
                     objects.size shouldBe 3
 
-                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf("app", "source=zone1")))
+                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
                     objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
                     objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
 
@@ -215,9 +216,9 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 
                     objects.size shouldBe 5
 
-                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf("app", "source=zone1")))
+                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
                     objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
-                    objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy", setOf("appB", "source=zone1")))
+                    objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("appB"), "source=zone1")))
                     objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
                     objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
                 }
@@ -237,7 +238,7 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 
                     objects.size shouldBe 3
 
-                    objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy", setOf("appB", "source=zone1")))
+                    objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("appB"), "source=zone1")))
                     objects["appB"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
                     objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
                 }
@@ -257,7 +258,7 @@ class YamlFileConfigurationServiceTest : FunSpec() {
                     val objects = objectStore.toMap()
 
                     objects.size shouldBe 3
-                    objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy", setOf("appB", "source=zone1")))
+                    objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("appB"), "source=zone1")))
                     objects["appB"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
                     objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
                 }
@@ -284,7 +285,7 @@ class YamlFileConfigurationServiceTest : FunSpec() {
                 val objects = objectStore.toMap()
 
                 objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy",
-                        setOf(creationTimes["appB.appB-01"]!!, "appB", "source=zone1")))
+                        setOf(creationTimes["appB.appB-01"]!!, lbGroupTag("appB"), "source=zone1")))
 
                 objects["appB"]!!.should(beRoutingObject("LoadBalancingGroup",
                         setOf(creationTimes["appB"]!!, "source=zone1")))
@@ -619,7 +620,7 @@ class YamlFileConfigurationServiceTest : FunSpec() {
                 val objects = objectStore.toMap()
 
                 objects.size shouldBe 3
-                objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf("app", "source=origins-provider")))
+                objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=origins-provider")))
                 objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=origins-provider")))
                 objects["origins-provider-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=origins-provider")))
             }
@@ -633,7 +634,7 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 //                    val objects = objectStore.toMap()
 //
 //                    objects.size shouldBe 3
-//                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf("app", OBJECT_CREATOR_TAG)))
+//                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), OBJECT_CREATOR_TAG)))
 //                    objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf(OBJECT_CREATOR_TAG)))
 //                    objects["cloud-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf(OBJECT_CREATOR_TAG)))
 //                }
@@ -660,7 +661,7 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 //                        println("entry key: ${it.key}")
 //                    }
 //
-//                    objects["appC.appC-01"]!!.should(beRoutingObject("HostProxy", setOf("appC", OBJECT_CREATOR_TAG)))
+//                    objects["appC.appC-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("appC"), OBJECT_CREATOR_TAG)))
 //                    objects["appC"]!!.should(beRoutingObject("LoadBalancingGroup", setOf(OBJECT_CREATOR_TAG)))
 //                    objects["cloud-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf(OBJECT_CREATOR_TAG)))
 //                }

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/providers/HealthCheckProviderSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/providers/HealthCheckProviderSpec.kt
@@ -27,6 +27,7 @@ import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.LiveHttpRequest
 import com.hotels.styx.api.LiveHttpResponse
 import com.hotels.styx.client.StyxHttpClient
+import com.hotels.styx.lbGroupTag
 import com.hotels.styx.routing.ConditionRoutingSpec
 import com.hotels.styx.routing.RoutingObject
 import com.hotels.styx.routing.config.RoutingObjectFactory
@@ -99,9 +100,8 @@ class HealthCheckProviderSpec : FeatureSpec() {
         feature("Object monitoring") {
             styxServer.restart()
 
-            styxServer().newRoutingObject("aaa-01", hostProxy("aaa", testServer01)).shouldBe(CREATED)
-            styxServer().newRoutingObject("aaa-02", hostProxy("aaa", testServer02)).shouldBe(CREATED)
-
+            styxServer().newRoutingObject("aaa-01", hostProxy(lbGroupTag("aaa"), testServer01)).shouldBe(CREATED)
+            styxServer().newRoutingObject("aaa-02", hostProxy(lbGroupTag("aaa"), testServer02)).shouldBe(CREATED)
 
             scenario("Tags unresponsive origins with state:inactive tag") {
                 pollOrigins(styxServer, "origin-0[12]").let {
@@ -141,7 +141,7 @@ class HealthCheckProviderSpec : FeatureSpec() {
             }
 
             scenario("Detects up new origins") {
-                styxServer().newRoutingObject("aaa-03", hostProxy("aaa", testServer03)).shouldBe(CREATED)
+                styxServer().newRoutingObject("aaa-03", hostProxy(lbGroupTag("aaa"), testServer03)).shouldBe(CREATED)
 
                 eventually(2.seconds, AssertionError::class.java) {
                     styxServer().routingObject("aaa-03").get().shouldContain("state:active")

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/LoadBalancingGroupSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/LoadBalancingGroupSpec.kt
@@ -86,28 +86,28 @@ class LoadBalancingGroupSpec : FeatureSpec() {
                                   app-A-01:
                                     type: HostProxy
                                     tags:
-                                      - App-A
+                                      - lbGroup=App-A
                                     config:
                                       host: localhost:${appA01.port()}
 
                                   app-A-02:
                                     type: HostProxy
                                     tags:
-                                      - App-A
+                                      - lbGroup=App-A
                                     config:
                                       host: localhost:${appA02.port()}
 
                                   app-A-03:
                                     type: HostProxy
                                     tags:
-                                      - App-A
+                                      - lbGroup=App-A
                                     config:
                                       host: localhost:${appA03.port()}
 
                                   app-B-01:
                                     type: HostProxy
                                     tags:
-                                      - App-B
+                                      - lbGroup=App-B
                                     config:
                                       host: localhost:${appB01.port()}
 
@@ -149,7 +149,7 @@ class LoadBalancingGroupSpec : FeatureSpec() {
                                   app-A-01:
                                     type: HostProxy
                                     tags:
-                                      - App-A
+                                      - lbGroup=App-A
                                       - state:inactive
                                     config:
                                       host: localhost:${appA01.port()}
@@ -157,7 +157,7 @@ class LoadBalancingGroupSpec : FeatureSpec() {
                                   app-A-02:
                                     type: HostProxy
                                     tags:
-                                      - App-A
+                                      - lbGroup=App-A
                                       - state:inactive:3
                                     config:
                                       host: localhost:${appA02.port()}
@@ -165,14 +165,14 @@ class LoadBalancingGroupSpec : FeatureSpec() {
                                   app-A-03:
                                     type: HostProxy
                                     tags:
-                                      - App-A
+                                      - lbGroup=App-A
                                     config:
                                       host: localhost:${appA03.port()}
 
                                   app-B-01:
                                     type: HostProxy
                                     tags:
-                                      - App-B
+                                      - lbGroup=App-B
                                     config:
                                       host: localhost:${appB01.port()}
 
@@ -226,7 +226,7 @@ class LoadBalancingGroupSpec : FeatureSpec() {
                     styxServer().newRoutingObject("host-1", """
                         type: HostProxy
                         tags:
-                          - App-A
+                          - lbGroup=App-A
                         config:
                           host: localhost:${appA01.port()}
                     """.trimIndent()) shouldBe (CREATED)
@@ -285,14 +285,14 @@ class LoadBalancingGroupSpec : FeatureSpec() {
                                     app-A-01:
                                       type: HostProxy
                                       tags:
-                                        - App-A
+                                        - lbGroup=App-A
                                       config:
                                         host: localhost:${appA01.port()}
 
                                     app-A-02:
                                       type: HostProxy
                                       tags:
-                                        - App-A
+                                        - lbGroup=App-A
                                       config:
                                         host: localhost:${appA02.port()}
 
@@ -409,28 +409,28 @@ class LoadBalancingGroupSpec : FeatureSpec() {
                                     appA-01:
                                       type: HostProxy
                                       tags:
-                                        - appA
+                                        - lbGroup=appA
                                       config:
                                         host: localhost:${appA01.port()}
 
                                     appA-02:
                                       type: HostProxy
                                       tags:
-                                        - appA
+                                        - lbGroup=appA
                                       config:
                                         host: localhost:${appA02.port()}
 
                                     appA-03:
                                       type: HostProxy
                                       tags:
-                                        - appA
+                                        - lbGroup=appA
                                       config:
                                         host: localhost:${appA03.port()}
 
                                     appA-04:
                                       type: HostProxy
                                       tags:
-                                        - appA
+                                        - lbGroup=appA
                                       config:
                                         host: localhost:${appB01.port()}
 


### PR DESCRIPTION
Add `lbGroup` prefix to load balancing group membership tags. This makes them self-identifying. As a result the tag can be recognised without having to know the load balancing group configuration.

Also add a `ObjectTags.kt` to serve as a formal specification for tag names.
