### PR TITLE
Dependabot/maven/jackson.version 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,10 +95,10 @@
     <!-- General Versions -->
     <guava.version>18.0</guava.version>
     <guice.version>3.0</guice.version>
-    <jackson.version>2.10.0</jackson.version>
-    <jackson.dataformat.version>2.9.10</jackson.dataformat.version>
-    <jackson.module.scala.version>2.9.10</jackson.module.scala.version>
-    <jackson-module-kotlin.version>2.9.10</jackson-module-kotlin.version>
+    <jackson.version>2.10.1</jackson.version>
+    <jackson.dataformat.version>2.10.1</jackson.dataformat.version>
+    <jackson.module.scala.version>2.10.1</jackson.module.scala.version>
+    <jackson-module-kotlin.version>2.10.1</jackson-module-kotlin.version>
     <metrics.version>4.0.5</metrics.version>
     <antlr.version>4.5.1-1</antlr.version>
     <netty.version>4.1.42.Final</netty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <!-- General Versions -->
     <guava.version>18.0</guava.version>
     <guice.version>3.0</guice.version>
-    <jackson.version>2.9.10</jackson.version>
+    <jackson.version>2.10.0</jackson.version>
     <jackson.dataformat.version>2.9.10</jackson.dataformat.version>
     <jackson.module.scala.version>2.9.10</jackson.module.scala.version>
     <jackson-module-kotlin.version>2.9.10</jackson-module-kotlin.version>


### PR DESCRIPTION
Update Jackson/Fasterxml dependencies. See PR #524 for details.


