### PR TITLE
YamlConfigurationService: Reject origins file if it introduces name clashes.

### DIFF
--- a/components/proxy/src/main/kotlin/com/hotels/styx/ObjectTags.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/ObjectTags.kt
@@ -23,3 +23,7 @@ fun lbGroupTagValue(tag: String): String? = "lbGroup=(.+)".toRegex()
         ?.get(1)
 
 fun sourceTag(creator: String) = "source=$creator"
+
+fun sourceTag(tags: Set<String>) = tags.firstOrNull { it.startsWith("source=") }
+
+fun sourceTagValue(tags: Set<String>) = sourceTag(tags)?.substring("source".length + 1)

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
@@ -36,7 +36,9 @@ import com.hotels.styx.server.handlers.ClassPathResourceHandler
 import com.hotels.styx.serviceproviders.ServiceProviderFactory
 import com.hotels.styx.services.OriginsConfigConverter.Companion.deserialiseOrigins
 import com.hotels.styx.sourceTag
+import com.hotels.styx.sourceTagValue
 import org.slf4j.LoggerFactory
+import java.lang.RuntimeException
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
@@ -111,8 +113,24 @@ internal class YamlFileConfigurationService(
                             converter.pathPrefixRouter(ingressObjectName, deserialised))
                     .map { StyxObjectDefinition(it.name(), it.type(), it.tags() + objectSourceTag, it.config()) }
 
+            routingObjectDefs.forEach { objectDef ->
+                routeDb.get(objectDef.name()).ifPresent {
+                    if (sourceTagValue(it.tags) != name) {
+                        throw DuplicateObjectException("Object name='${objectDef.name()}' already exists. Provider='${name}', file='${config.originsFile}'.")
+                    }
+                }
+            }
+
             val healthMonitors = converter.healthCheckServices(deserialised)
                     .map { (name, record) -> Pair(name, record.copy(tags = record.tags + objectSourceTag)) }
+
+            healthMonitors.forEach { (objectName, _) ->
+                serviceDb.get(objectName).ifPresent {
+                    if (sourceTagValue(it.tags) != name) {
+                        throw DuplicateObjectException("Health Monitor name='${objectName}' already exists. Provider='${name}', file='${config.originsFile}'.")
+                    }
+                }
+            }
 
             Pair(healthMonitors, routingObjectDefs)
         }.mapCatching { (healthMonitors, routingObjectDefs) ->
@@ -180,6 +198,8 @@ internal class YamlFileConfigurationService(
             }
         }
     }
+
+    private class DuplicateObjectException(message: String): RuntimeException(message)
 }
 
 internal data class YamlFileConfigurationServiceConfig(val originsFile: String, val ingressObject: String = "", val monitor: Boolean = true, val pollInterval: String = "")

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/LoadBalancingGroupTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/LoadBalancingGroupTest.kt
@@ -81,9 +81,9 @@ class LoadBalancingGroupTest : FeatureSpec() {
                             }
                 }
 
-                frequencies["appx-01"]!!.shouldBeGreaterThan(20)
-                frequencies["appx-02"]!!.shouldBeGreaterThan(20)
-                frequencies["appx-03"]!!.shouldBeGreaterThan(20)
+                frequencies["appx-01"]!!.shouldBeGreaterThan(15)
+                frequencies["appx-02"]!!.shouldBeGreaterThan(15)
+                frequencies["appx-03"]!!.shouldBeGreaterThan(15)
 
                 frequencies["appy-01"].shouldBeNull()
                 frequencies["appy-02"].shouldBeNull()
@@ -114,9 +114,9 @@ class LoadBalancingGroupTest : FeatureSpec() {
                             }
                 }
 
-                frequencies["appx-04"]!!.shouldBeGreaterThan(20)
-                frequencies["appx-05"]!!.shouldBeGreaterThan(20)
-                frequencies["appx-06"]!!.shouldBeGreaterThan(20)
+                frequencies["appx-04"]!!.shouldBeGreaterThan(15)
+                frequencies["appx-05"]!!.shouldBeGreaterThan(15)
+                frequencies["appx-06"]!!.shouldBeGreaterThan(15)
             }
 
             scenario("... and detects replaced origins") {
@@ -137,9 +137,9 @@ class LoadBalancingGroupTest : FeatureSpec() {
                             }
                 }
 
-                frequencies["appx-04-a"]!!.shouldBeGreaterThan(20)
-                frequencies["appx-05-b"]!!.shouldBeGreaterThan(20)
-                frequencies["appx-06-c"]!!.shouldBeGreaterThan(20)
+                frequencies["appx-04-a"]!!.shouldBeGreaterThan(15)
+                frequencies["appx-05-b"]!!.shouldBeGreaterThan(15)
+                frequencies["appx-06-c"]!!.shouldBeGreaterThan(15)
             }
 
             scenario("... and emits NoAvailableHostsException when load balancing group is empty") {

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceDuplicateIdentifiersTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceDuplicateIdentifiersTest.kt
@@ -1,0 +1,139 @@
+/*
+  Copyright (C) 2013-2019 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.services
+
+import com.hotels.styx.routing.RoutingObjectRecord
+import com.hotels.styx.routing.db.StyxObjectStore
+import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.services.YamlFileConfigurationServiceTest.OriginsServiceConfiguration
+import com.hotels.styx.support.matchers.LoggingTestSupport
+import io.kotlintest.Spec
+import io.kotlintest.matchers.string.shouldMatch
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FunSpec
+import io.mockk.mockk
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.time.Duration
+
+private val LOGGER = LoggerFactory.getLogger(YamlFileConfigurationServiceDuplicateIdentifiersTest::class.java)
+
+class YamlFileConfigurationServiceDuplicateIdentifiersTest : FunSpec() {
+    val logger = LoggingTestSupport(YamlFileConfigurationService::class.java);
+
+    private val tempDir = createTempDir(suffix = "-${this.javaClass.simpleName}")
+    private val originsFile = File("${tempDir.absolutePath}/config.yml")
+
+    private val objectStore = StyxObjectStore<RoutingObjectRecord>()
+    private val serviceDb = StyxObjectStore<ProviderObjectRecord>()
+    private val service = OriginsServiceConfiguration(objectStore, serviceDb, originsFile,
+            config = """
+                        ---
+                        - id: "app"
+                          path: "/"
+                          origins:
+                          - { id: "app-01", host: "localhost:9090" }
+                    """.trimIndent())
+            .createService(name = "zone1")
+            .start()
+            .waitForObjects(count = 3)
+
+    override fun beforeSpec(spec: Spec) {
+        LOGGER.info("Temp directory: " + tempDir.absolutePath)
+        LOGGER.info("Origins file: " + originsFile.absolutePath)
+        LOGGER.info("Duration: '{}'", Duration.ofMillis(100).toString())
+    }
+
+    override fun afterSpec(spec: Spec) {
+        tempDir.deleteRecursively()
+        service.stop()
+    }
+
+    init {
+        context("Duplicate object detection") {
+            test("Rejects origin file if it would introduce duplicate routing object keys") {
+                objectStore.insert("app.app-02", RoutingObjectRecord("HostProxy", setOf("abc"), mockk(), mockk()))
+                objectStore.entrySet().size.shouldBe(4)
+
+                writeOrigins(originsFile, """
+                        ---
+                        - id: "app"
+                          path: "/"
+                          origins:
+                          - { id: "app-01", host: "localhost:9091" } 
+                          - { id: "app-02", host: "localhost:9092" } 
+                          - { id: "app-03", host: "localhost:9093" } 
+                """.trimIndent())
+
+                Thread.sleep(500)
+
+                objectStore.entrySet().forEach {
+                    println("entry: ${it.key} -> ${it.value.type} - ${it.value.tags}")
+                }
+
+                objectStore.entrySet().size.shouldBe(4)
+            }
+
+            test("Logs an error message for duplicate routing object key") {
+
+                logger.lastMessage()
+                        .getFormattedMessage()
+                        .shouldMatch(".*Failed to reload new configuration. cause='Object name='app.app-02' already exists. Provider='zone1', file='.*config.yml'.*")
+            }
+
+            test("Rejects origin file if it would introduce duplicate health check monitor names") {
+                serviceDb.insert("app-monitor", ProviderObjectRecord("HealthCheckMonitor", setOf("abc"), mockk(), mockk()))
+
+                objectStore.entrySet().size.shouldBe(4)
+                serviceDb.entrySet().size.shouldBe(1)
+
+                writeOrigins(originsFile, """
+                        ---
+                        - id: "app"
+                          path: "/"
+                          healthCheck:
+                             uri: /endpoint.txt
+                          origins:
+                          - { id: "app-01", host: "localhost:9091" } 
+                          - { id: "app-03", host: "localhost:9093" } 
+                """.trimIndent())
+
+                Thread.sleep(500)
+
+                objectStore.entrySet().forEach {
+                    println("routing entry: ${it.key} -> ${it.value.type} - ${it.value.tags}")
+                }
+                serviceDb.entrySet().forEach {
+                    println("service entry: ${it.key} -> ${it.value.type} - ${it.value.tags}")
+                }
+
+                serviceDb.entrySet().size.shouldBe(1)
+
+                // The above configuration would introduce 5th object unless it is rejected:
+                objectStore.entrySet().size.shouldBe(4)
+            }
+
+
+            test("Logs an error message for duplicate health check monitor name") {
+                logger.lastMessage()
+                        .getFormattedMessage()
+                        .shouldMatch(".*Failed to reload new configuration. cause='Health Monitor name='app-monitor' already exists. Provider='zone1', file='.*config.yml'.*")
+            }
+        }
+    }
+}
+
+

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
@@ -765,8 +765,8 @@ class YamlFileConfigurationServiceTest : FunSpec() {
             return CreatedService(ServiceConfiguration(routeDb, serviceDb, providerName, serviceConfig), service)
         }
     }
-
 }
+
 
 internal fun writeOrigins(originsConfig: File, text: String, debug: Boolean = false) {
     originsConfig.writeText(text)

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
@@ -149,10 +149,10 @@ class YamlFileConfigurationServiceTest : FunSpec() {
                     val objects = objectStore.toMap()
                     objects.size shouldBe 4
 
-                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
-                    objects["app.app-02"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
-                    objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
-                    objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
+                    objects["app.app-01"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
+                    objects["app.app-02"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
+                    objects["app"].should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
+                    objects["zone1-router"].should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
                 }
             }
 
@@ -170,9 +170,9 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 
                     objects.size shouldBe 3
 
-                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
-                    objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
-                    objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
+                    objects["app.app-01"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
+                    objects["app"].should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
+                    objects["zone1-router"].should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
                 }
             }
 
@@ -190,9 +190,9 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 
                     objects.size shouldBe 3
 
-                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
-                    objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
-                    objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
+                    objects["app.app-01"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
+                    objects["app"].should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
+                    objects["zone1-router"].should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
 
                     JsonNodeConfig(objectStore["app.app-01"].get().config).get("host") shouldBe Optional.of("localhost:9999")
                 }
@@ -216,11 +216,11 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 
                     objects.size shouldBe 5
 
-                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
-                    objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
-                    objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("appB"), "source=zone1")))
-                    objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
-                    objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
+                    objects["app.app-01"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=zone1")))
+                    objects["app"].should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
+                    objects["appB.appB-01"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("appB"), "source=zone1")))
+                    objects["app"].should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
+                    objects["zone1-router"].should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
                 }
             }
 
@@ -238,9 +238,9 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 
                     objects.size shouldBe 3
 
-                    objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("appB"), "source=zone1")))
-                    objects["appB"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
-                    objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
+                    objects["appB.appB-01"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("appB"), "source=zone1")))
+                    objects["appB"].should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
+                    objects["zone1-router"].should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
                 }
 
             }
@@ -258,9 +258,9 @@ class YamlFileConfigurationServiceTest : FunSpec() {
                     val objects = objectStore.toMap()
 
                     objects.size shouldBe 3
-                    objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("appB"), "source=zone1")))
-                    objects["appB"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
-                    objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
+                    objects["appB.appB-01"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("appB"), "source=zone1")))
+                    objects["appB"].should(beRoutingObject("LoadBalancingGroup", setOf("source=zone1")))
+                    objects["zone1-router"].should(beRoutingObject("PathPrefixRouter", setOf("source=zone1")))
                 }
             }
 
@@ -284,13 +284,13 @@ class YamlFileConfigurationServiceTest : FunSpec() {
 
                 val objects = objectStore.toMap()
 
-                objects["appB.appB-01"]!!.should(beRoutingObject("HostProxy",
+                objects["appB.appB-01"].should(beRoutingObject("HostProxy",
                         setOf(creationTimes["appB.appB-01"]!!, lbGroupTag("appB"), "source=zone1")))
 
-                objects["appB"]!!.should(beRoutingObject("LoadBalancingGroup",
+                objects["appB"].should(beRoutingObject("LoadBalancingGroup",
                         setOf(creationTimes["appB"]!!, "source=zone1")))
 
-                objects["zone1-router"]!!.should(beRoutingObject("PathPrefixRouter",
+                objects["zone1-router"].should(beRoutingObject("PathPrefixRouter",
                         setOf(creationTimes["zone1-router"]!!, "source=zone1")))
             }
 
@@ -620,52 +620,51 @@ class YamlFileConfigurationServiceTest : FunSpec() {
                 val objects = objectStore.toMap()
 
                 objects.size shouldBe 3
-                objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=origins-provider")))
-                objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf("source=origins-provider")))
-                objects["origins-provider-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf("source=origins-provider")))
+                objects["app.app-01"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=origins-provider")))
+                objects["app"].should(beRoutingObject("LoadBalancingGroup", setOf("source=origins-provider")))
+                objects["origins-provider-router"].should(beRoutingObject("PathPrefixRouter", setOf("source=origins-provider")))
             }
 
-            // TODO: Fix these tests:
-//            test("Keeps the original configuration when origins file is removed") {
-//                originsConfig.delete()
-//                originsConfig.exists() shouldBe false
-//
-//                eventually(2.seconds, AssertionError::class.java) {
-//                    val objects = objectStore.toMap()
-//
-//                    objects.size shouldBe 3
-//                    objects["app.app-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), OBJECT_CREATOR_TAG)))
-//                    objects["app"]!!.should(beRoutingObject("LoadBalancingGroup", setOf(OBJECT_CREATOR_TAG)))
-//                    objects["cloud-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf(OBJECT_CREATOR_TAG)))
-//                }
-//            }
-//
-//            test("Recovers when the file becomes availabe again") {
-//
-//                println("Writing origins file now")
-//                writeOrigins("""
-//                    ---
-//                    - id: "appC"
-//                      path: "/"
-//                      origins:
-//                        - { id: "appC-01", host: "localhost:9999" }
-//                        - { id: "appC-02", host: "localhost:9999" }
-//                    """.trimIndent())
-//
-//                eventually(2.seconds, AssertionError::class.java) {
-//                    val objects = objectStore.toMap()
-//
-//                    objects.size shouldBe 4
-//
-//                    objects.entries.forEach {
-//                        println("entry key: ${it.key}")
-//                    }
-//
-//                    objects["appC.appC-01"]!!.should(beRoutingObject("HostProxy", setOf(lbGroupTag("appC"), OBJECT_CREATOR_TAG)))
-//                    objects["appC"]!!.should(beRoutingObject("LoadBalancingGroup", setOf(OBJECT_CREATOR_TAG)))
-//                    objects["cloud-router"]!!.should(beRoutingObject("PathPrefixRouter", setOf(OBJECT_CREATOR_TAG)))
-//                }
-//            }
+            test("Keeps the original configuration when origins file is removed") {
+                originsConfig.delete()
+                originsConfig.exists() shouldBe false
+
+                eventually(2.seconds, AssertionError::class.java) {
+                    val objects = objectStore.toMap()
+
+                    objects.size shouldBe 3
+                    objects["app.app-01"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("app"), "source=origins-provider")))
+                    objects["app"].should(beRoutingObject("LoadBalancingGroup", setOf("source=origins-provider")))
+                    objects["origins-provider-router"].should(beRoutingObject("PathPrefixRouter", setOf("source=origins-provider")))
+                }
+            }
+
+            test("Recovers when the file becomes availabe again") {
+
+                println("Writing origins file now")
+                writeOrigins("""
+                    ---
+                    - id: "appC"
+                      path: "/"
+                      origins:
+                        - { id: "appC-01", host: "localhost:9001" }
+                        - { id: "appC-02", host: "localhost:9002" }
+                    """.trimIndent())
+
+                eventually(2.seconds, AssertionError::class.java) {
+                    val objects = objectStore.toMap()
+
+                    objects.size shouldBe 4
+
+                    objects.entries.forEach {
+                        println("entry key: ${it.key}")
+                    }
+
+                    objects["appC.appC-01"].should(beRoutingObject("HostProxy", setOf(lbGroupTag("appC"), "source=origins-provider")))
+                    objects["appC"].should(beRoutingObject("LoadBalancingGroup", setOf("source=origins-provider")))
+                    objects["origins-provider-router"].should(beRoutingObject("PathPrefixRouter", setOf("source=origins-provider")))
+                }
+            }
 
             service.stop()
         }
@@ -675,14 +674,19 @@ class YamlFileConfigurationServiceTest : FunSpec() {
             .map { (k, v) -> Pair(k, v) }
             .toMap()
 
-    internal fun beRoutingObject(type: String, mandatoryTags: Collection<String>) = object : Matcher<RoutingObjectRecord> {
-        override fun test(value: RoutingObjectRecord): MatcherResult {
-            val message = "Error matching ${value}"
+    internal fun beRoutingObject(type: String, mandatoryTags: Collection<String>) = object : Matcher<RoutingObjectRecord?> {
+        override fun test(value: RoutingObjectRecord?): MatcherResult {
+            val message = "Object mismatch"
+
+            if (value == null) {
+                return MatcherResult(false, "{$message}.\nExcpected ${type} but was null",
+                        "${message}.\nObject is null")
+            }
 
             if (value.type != type) {
                 return MatcherResult(false,
                         "{$message}.\nExcpected ${type} but was ${value.type}",
-                        "${message}.\nObject type should not be LoadBalancingGroup")
+                        "${message}.\nObject type should not be ${type}")
             }
             if (!value.tags.containsAll(mandatoryTags)) {
                 return MatcherResult(false,


### PR DESCRIPTION
Reject origins file reload if it would result in name clashes between routing objects, and
log a meaningful error message.
