### PR TITLE
Reduce exception construction

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
@@ -91,7 +91,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
             }
         }).timeout(
                 Duration.ofMillis(poolSettings.pendingConnectionTimeoutMillis()),
-                Mono.error(new MaxPendingConnectionTimeoutException(origin, connectionSettings.connectTimeoutMillis())));
+                Mono.error(() -> new MaxPendingConnectionTimeoutException(origin, connectionSettings.connectTimeoutMillis())));
     }
 
     private void newConnection() {


### PR DESCRIPTION
This was creating the exception regardless of whether it needed it or not. This uses the supplier interface to just construct it if needed