### PR TITLE
Build Styx Docker image using fabric8 docker maven plugin 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,4 +133,4 @@ changelog:
 # Default configuration file: /styx/default-config/default.yml
 #
 docker-image: clean
-	mvn clean verify -Prelease,linux,docker -Dmaven.test.skip=true
+	mvn clean install -Prelease,linux,docker -Dmaven.test.skip=true

--- a/Makefile
+++ b/Makefile
@@ -133,4 +133,4 @@ changelog:
 # Default configuration file: /styx/default-config/default.yml
 #
 docker-image: clean
-	mvn clean install -Prelease,linux,docker -Dmaven.test.skip=true
+	mvn install -Prelease,linux,docker -Dmaven.test.skip=true

--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,4 @@ changelog:
 # Default configuration file: /styx/default-config/default.yml
 #
 docker-image: clean
-	mvn install -Prelease,linux -Dmaven.test.skip=true
-	mkdir -p ${DOCKER_CONTEXT}
-	cp `find  distribution/target -maxdepth 1 -name "styx*linux-x86_64.zip"` ${DOCKER_CONTEXT}/styx.zip
-	cp docker/styx-image/* ${DOCKER_CONTEXT}
-	docker build -t styxcore:latest --build-arg STYX_IMAGE=styx.zip ${DOCKER_CONTEXT}/.
+	mvn clean verify -Prelease,linux,docker -Dmaven.test.skip=true

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -162,8 +162,8 @@
                   <alias>styxcore</alias>
                   <name>${styxcore.docker.image}</name>
                   <build>
-                    <dockerFile>${project.basedir}/../docker/styx-image/Dockerfile</dockerFile>
-                    <contextDir>${project.basedir}/../docker/styx-image/</contextDir>
+                    <dockerFile>${project.parent.basedir}/docker/styx-image/Dockerfile</dockerFile>
+                    <contextDir>${project.parent.basedir}/docker/styx-image/</contextDir>
                     <assembly>
                       <inline>
                         <files>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,6 +21,7 @@
     <main.basedir>${project.parent.basedir}</main.basedir>
     <TAG>11-jdk</TAG>
     <styxcore.docker.tag>${project.version}</styxcore.docker.tag>
+    <styxcore.docker.image>styxcore</styxcore.docker.image>
   </properties>
 
   <dependencies>
@@ -159,7 +160,7 @@
               <images>
                 <image>
                   <alias>styxcore</alias>
-                  <name>styxcore</name>
+                  <name>${styxcore.docker.image}</name>
                   <build>
                     <dockerFile>${project.basedir}/../docker/styx-image/Dockerfile</dockerFile>
                     <contextDir>${project.basedir}/../docker/styx-image/</contextDir>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>com.hotels.styx</groupId>
     <artifactId>styx-parent</artifactId>
@@ -18,6 +19,8 @@
     <main.basedir>${project.parent.basedir}</main.basedir>
     <skipCheckstyle>true</skipCheckstyle>
     <main.basedir>${project.parent.basedir}</main.basedir>
+    <TAG>11-jdk</TAG>
+    <styxcore.docker.tag>${project.version}</styxcore.docker.tag>
   </properties>
 
   <dependencies>
@@ -132,5 +135,59 @@
 
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>docker</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.31.0</version>
+
+            <executions>
+              <execution>
+                <phase>install</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+
+            <configuration>
+              <images>
+                <image>
+                  <alias>styxcore</alias>
+                  <name>styxcore</name>
+                  <build>
+                    <dockerFile>${project.basedir}/../docker/styx-image/Dockerfile</dockerFile>
+                    <contextDir>${project.basedir}/../docker/styx-image/</contextDir>
+                    <assembly>
+                      <inline>
+                        <files>
+                          <file>
+                            <source>${project.basedir}/target/styx-1.0-SNAPSHOT-linux-x86_64.zip</source>
+                          </file>
+                        </files>
+                      </inline>
+                    </assembly>
+                    <tags>
+                      <tag>${styxcore.docker.tag}</tag>
+                      <tag>${project.version}</tag>
+                    </tags>
+                    <args>
+                      <STYX_IMAGE>maven/styx-1.0-SNAPSHOT-linux-x86_64.zip</STYX_IMAGE>
+                      <TAG>11-jdk</TAG>
+                    </args>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -167,7 +167,7 @@
                       <inline>
                         <files>
                           <file>
-                            <source>${project.basedir}/target/styx-1.0-SNAPSHOT-linux-x86_64.zip</source>
+                            <source>${project.basedir}/target/${artifact.finalName}.zip</source>
                           </file>
                         </files>
                       </inline>
@@ -177,7 +177,7 @@
                       <tag>${project.version}</tag>
                     </tags>
                     <args>
-                      <STYX_IMAGE>maven/styx-1.0-SNAPSHOT-linux-x86_64.zip</STYX_IMAGE>
+                      <STYX_IMAGE>maven/${artifact.finalName}.zip</STYX_IMAGE>
                       <TAG>11-jdk</TAG>
                     </args>
                   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
       <name>libs-snapshot</name>
       <url>${libs.snapshot.url}</url>
     </snapshotRepository>
+
     <site>
       <id>Styx-Site</id>
       <url>${site.url}</url>
@@ -734,22 +735,8 @@
               -XX:+HeapDumpOnOutOfMemoryError
               -XX:HeapDumpPath=${project.build.directory}/failsafe-reports
             </argLine>
+            <skipITs>false</skipITs>
           </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>integration-test</goal>
-                <goal>verify</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>failsafe-integration-tests</id>
-              <phase>integration-test</phase>
-              <goals>
-                <goal>integration-test</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
 
         <plugin>

--- a/system-tests/e2e-suite/pom.xml
+++ b/system-tests/e2e-suite/pom.xml
@@ -212,19 +212,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <int_test_ip_address>localhost</int_test_ip_address>
-          </systemPropertyVariables>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <!-- jacoco: see http://www.eclemma.org/jacoco/trunk/doc/check-mojo.html -->


### PR DESCRIPTION
This PR adds `fabric8` docker maven plugin to build Styx Core docker image.

This is to simplify and "abstract away" the details how to build Styx Docker image automatically from other projects.

