### PR TITLE
Add close() method to connectionPool so connections are closed when origins are reloaded

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
@@ -211,7 +211,6 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
         active = false;
         Connection con;
         while ((con = availableConnections.poll()) != null) {
-            borrowedCount.decrementAndGet();
             if (con.isConnected()) {
                 doCloseConnection(con);
             }

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
@@ -191,6 +191,11 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
         availableConnections.remove(connection);
     }
 
+    @Override
+    public void close() {
+        availableConnections.forEach(Connection::close);
+    }
+
     public ConnectionPool.Stats stats() {
         return this.stats;
     }
@@ -236,6 +241,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
         public int connectionsInEstablishment() {
             return connectionsInEstablishment.get();
         }
+
 
         @Override
         public String toString() {

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
@@ -96,7 +96,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
                     Duration.ofMillis(poolSettings.pendingConnectionTimeoutMillis()),
                     Mono.error(() -> new MaxPendingConnectionTimeoutException(origin, connectionSettings.connectTimeoutMillis())));
         } else {
-           return Mono.error( () -> new IllegalStateException("Pool is closed"));
+           return Mono.error(() -> new IllegalStateException("Pool is closed"));
         }
     }
 

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
@@ -96,7 +96,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
                     Duration.ofMillis(poolSettings.pendingConnectionTimeoutMillis()),
                     Mono.error(() -> new MaxPendingConnectionTimeoutException(origin, connectionSettings.connectTimeoutMillis())));
         } else {
-            throw new IllegalStateException("Pool is closed");
+           return Mono.error( () -> new IllegalStateException("Pool is closed"));
         }
     }
 


### PR DESCRIPTION
We were missing a ConnectionPool.close() method that will close open connections when an origins file is reloaded.

We are just invoking Connection::close() without modifying the metrics as, in most cases (except when the origin is removed), they would be overridden by the new SimpleConnectionPool for that origin server. We can discuss this to see what's the best way to implement it.

We can also discuss what's the best meaningful test we can implement. I guess we could add a global counter for the tota number of connections opened / closed (not per origin but global!). We might also have to locate all the code paths that should trigger a pool closure  and add assertions for those in unit tests. 

Of course, this PR does not prevent us from leaving connections pool that hadn't been returned to the pool (they are not in "availableConnections") at the moment the pool was closed. 



 