### PR TITLE
Re-enable epoll.

### DIFF
--- a/components/api/pom.xml
+++ b/components/api/pom.xml
@@ -20,10 +20,6 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-    </dependency>
 
     <!-- https://mvnrepository.com/artifact/io.projectreactor/reactor-core -->
     <dependency>

--- a/components/client/pom.xml
+++ b/components/client/pom.xml
@@ -21,6 +21,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>${netty-transport-native-epoll.classifier}</classifier>
+    </dependency>
+
+    <dependency>
       <groupId>com.hotels.styx</groupId>
       <artifactId>styx-api</artifactId>
     </dependency>


### PR DESCRIPTION
A recent change to use smaller split Netty (#508), instead of `Netty-all` deactivated e-poll support. This PR re-enables it.
