### PR TITLE
Fix origin reactivation logic for admin interface

### DIFF
--- a/components/proxy/src/main/kotlin/com/hotels/styx/ObjectTags.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/ObjectTags.kt
@@ -31,6 +31,14 @@ val sourceTag = SafeValueTag(
         { it },
         { it })
 
+/*
+ * TAG: target
+ */
+val targetTag = SafeValueTag(
+        "target",
+        { it },
+        { it })
+
 
 /*
  * TAG: state

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthCheckMonitoringService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthCheckMonitoringService.kt
@@ -116,10 +116,7 @@ internal class HealthCheckMonitoringService(
         futureRef.get().cancel(false)
     }
 
-    fun isRunning() : Boolean {
-        val executor = futureRef.get() ?: return false
-        return !executor.isCancelled && !executor.isDone
-    }
+    fun isRunning() = futureRef.get()?.let { !it.isCancelled && !it.isDone } == true
 
     internal fun runChecks(application: String, objectStore: StyxObjectStore<RoutingObjectRecord>) {
         val monitoredObjects = objectStore.entrySet()

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthCheckMonitoringService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthCheckMonitoringService.kt
@@ -116,6 +116,11 @@ internal class HealthCheckMonitoringService(
         futureRef.get().cancel(false)
     }
 
+    fun isRunning() : Boolean {
+        val executor = futureRef.get() ?: return false
+        return !executor.isCancelled && !executor.isDone
+    }
+
     internal fun runChecks(application: String, objectStore: StyxObjectStore<RoutingObjectRecord>) {
         val monitoredObjects = objectStore.entrySet()
                 .map { Pair(it.key, it.value) }

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsAdminHandler.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsAdminHandler.kt
@@ -135,15 +135,15 @@ internal class OriginsAdminHandler(
         }
     }
 
-    private fun hasActiveHealthCheck(origin: RoutingObjectRecord) : Boolean {
-        val appId = lbGroupTag.find(origin.tags) ?: return false
-        serviceDb.entrySet().firstOrNull { (_, provider) ->
-            provider.type == HEALTH_CHECK_MONITOR
-                    && provider.tags.contains(targetTag(appId))
-                    && (provider.styxService as HealthCheckMonitoringService).isRunning()
-        } ?: return false
-        return true
-    }
+    private fun hasActiveHealthCheck(origin: RoutingObjectRecord) =
+            lbGroupTag.find(origin.tags)?.let(::findActiveHealthCheckMonitor) != null
+
+    private fun findActiveHealthCheckMonitor(appId: String) =
+            serviceDb.entrySet().firstOrNull { (_, provider) ->
+                provider.type == HEALTH_CHECK_MONITOR
+                        && provider.tags.contains(targetTag(appId))
+                        && (provider.styxService as HealthCheckMonitoringService).isRunning()
+            }
 
     private fun errorResponse(status: HttpResponseStatus, message: String) =
             response(status)

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsAdminHandler.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsAdminHandler.kt
@@ -28,8 +28,9 @@ import com.hotels.styx.api.HttpResponseStatus.*
 import com.hotels.styx.common.http.handler.HttpAggregator
 import com.hotels.styx.infrastructure.configuration.json.mixins.ErrorResponseMixin
 import com.hotels.styx.routing.RoutingObjectRecord
+import com.hotels.styx.routing.config.Builtins.HEALTH_CHECK_MONITOR
 import com.hotels.styx.routing.db.StyxObjectStore
-import io.netty.handler.codec.http.HttpObjectAggregator
+import com.hotels.styx.routing.handlers.ProviderObjectRecord
 import java.nio.charset.StandardCharsets.UTF_8
 
 /**
@@ -41,7 +42,8 @@ import java.nio.charset.StandardCharsets.UTF_8
 internal class OriginsAdminHandler(
         basePath: String,
         private val provider: String,
-        private val routeDb: StyxObjectStore<RoutingObjectRecord>) : HttpHandler {
+        private val routeDb: StyxObjectStore<RoutingObjectRecord>,
+        private val serviceDb: StyxObjectStore<ProviderObjectRecord>) : HttpHandler {
 
     companion object {
         private val MAPPER = ObjectMapper().addMixIn(
@@ -91,11 +93,14 @@ internal class OriginsAdminHandler(
         routeDb.compute(objectId) { origin ->
             if (!isValidOrigin(origin)) {
                 throw HttpStatusException(NOT_FOUND, "No origin found for ID $objectId")
-            }
-            newState = when(stateTag.find(origin!!.tags)) {
-                STATE_INACTIVE, STATE_ACTIVE -> STATE_ACTIVE
+            } else { origin!! }
+
+            val newActiveState = if (hasActiveHealthCheck(origin)) STATE_UNREACHABLE else STATE_ACTIVE
+            newState = when(stateTag.find(origin.tags)) {
+                STATE_INACTIVE -> newActiveState
+                STATE_ACTIVE -> STATE_ACTIVE
                 STATE_UNREACHABLE -> STATE_UNREACHABLE
-                else -> STATE_ACTIVE
+                else -> newActiveState
             }
             updateStateTag(origin, newState)
         }
@@ -128,6 +133,16 @@ internal class OriginsAdminHandler(
         } else {
             origin
         }
+    }
+
+    private fun hasActiveHealthCheck(origin: RoutingObjectRecord) : Boolean {
+        val appId = lbGroupTag.find(origin.tags) ?: return false
+        serviceDb.entrySet().firstOrNull { (_, provider) ->
+            provider.type == HEALTH_CHECK_MONITOR
+                    && provider.tags.contains(targetTag(appId))
+                    && (provider.styxService as HealthCheckMonitoringService).isRunning()
+        } ?: return false
+        return true
     }
 
     private fun errorResponse(status: HttpResponseStatus, message: String) =

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsConfigConverter.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsConfigConverter.kt
@@ -21,8 +21,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PRO
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.hotels.styx.STATE_ACTIVE
-import com.hotels.styx.STATE_UNREACHABLE
+import com.hotels.styx.*
 import com.hotels.styx.api.extension.Origin
 import com.hotels.styx.api.extension.service.BackendService
 import com.hotels.styx.api.extension.service.ConnectionPoolSettings
@@ -34,7 +33,6 @@ import com.hotels.styx.infrastructure.configuration.ConfigurationSource.configSo
 import com.hotels.styx.infrastructure.configuration.json.ObjectMappers
 import com.hotels.styx.infrastructure.configuration.yaml.YamlConfiguration
 import com.hotels.styx.infrastructure.configuration.yaml.YamlConfigurationFormat.YAML
-import com.hotels.styx.lbGroupTag
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.Builtins
 import com.hotels.styx.routing.config.Builtins.HEALTH_CHECK_MONITOR
@@ -49,7 +47,6 @@ import com.hotels.styx.routing.db.StyxObjectStore
 import com.hotels.styx.routing.handlers.HostProxy.HostProxyConfiguration
 import com.hotels.styx.routing.handlers.LoadBalancingGroup
 import com.hotels.styx.routing.handlers.ProviderObjectRecord
-import com.hotels.styx.stateTag
 import org.slf4j.LoggerFactory
 
 internal class OriginsConfigConverter(
@@ -114,7 +111,7 @@ internal class OriginsConfigConverter(
                 serviceDb, Builtins.BUILTIN_SERVICE_PROVIDER_FACTORIES, context)
 
         return ProviderObjectRecord(HEALTH_CHECK_MONITOR,
-                setOf("target=$appId"),
+                setOf(targetTag(appId)),
                 serviceConfig,
                 providerObject)
     }

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
@@ -102,7 +102,7 @@ internal class YamlFileConfigurationService(
             "origins" to HttpContentHandler(HTML_UTF_8.toString(), UTF_8) {
                 OriginsPageRenderer("$namespace/assets", name, routeDb).render()
             },
-            "/" to OriginsAdminHandler(namespace, name, routeDb))
+            "/" to OriginsAdminHandler(namespace, name, routeDb, serviceDb))
 
     fun reloadAction(content: String): Unit {
         LOGGER.info("New origins configuration: \n$content")

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
@@ -186,7 +186,7 @@ internal class YamlFileConfigurationService(
                 if (previous == null || changed(new.config, previous.config)) {
                     new.styxService.start()
                     previous?.styxService?.stop()
-                            ?.whenComplete({ void, throwable ->
+                            ?.whenComplete { _, throwable ->
                                 if (throwable != null) {
                                     val stack = StringWriter().let {
                                         throwable.printStackTrace(PrintWriter(it))
@@ -194,7 +194,7 @@ internal class YamlFileConfigurationService(
                                     }
                                     LOGGER.warn("Service failed to terminate cleanly. cause=$throwable stack=$stack")
                                 }
-                            })
+                            }
                     new
                 } else {
                     // No need to shout down the new one. It has yet been started.

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsAdminHandlerTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsAdminHandlerTest.kt
@@ -16,31 +16,27 @@
 package com.hotels.styx.services
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.hotels.styx.ErrorResponse
-import com.hotels.styx.HEALTHCHECK_FAILING
-import com.hotels.styx.STATE_ACTIVE
-import com.hotels.styx.STATE_INACTIVE
-import com.hotels.styx.STATE_UNREACHABLE
+import com.hotels.styx.*
 import com.hotels.styx.api.HttpRequest
 import com.hotels.styx.api.HttpResponseStatus
 import com.hotels.styx.api.HttpResponseStatus.BAD_REQUEST
 import com.hotels.styx.api.HttpResponseStatus.NOT_FOUND
 import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.LiveHttpRequest
-import com.hotels.styx.healthCheckTag
 import com.hotels.styx.infrastructure.configuration.json.mixins.ErrorResponseMixin
 import com.hotels.styx.routing.RoutingMetadataDecorator
 import com.hotels.styx.routing.RoutingObjectRecord
+import com.hotels.styx.routing.config.Builtins
+import com.hotels.styx.routing.config.Builtins.HEALTH_CHECK_MONITOR
 import com.hotels.styx.routing.db.StyxObjectStore
+import com.hotels.styx.routing.handlers.ProviderObjectRecord
 import com.hotels.styx.routing.mockObject
 import com.hotels.styx.server.HttpInterceptorContext
-import com.hotels.styx.sourceTag
-import com.hotels.styx.stateTag
-import com.hotels.styx.wait
 import io.kotlintest.matchers.collections.shouldContain
 import io.kotlintest.matchers.string.shouldStartWith
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.FeatureSpec
+import io.mockk.every
 import io.mockk.mockk
 import java.nio.charset.StandardCharsets.UTF_8
 
@@ -49,14 +45,22 @@ class OriginsAdminHandlerTest : FeatureSpec({
     val mapper = ObjectMapper().addMixIn(ErrorResponse::class.java, ErrorResponseMixin::class.java)
 
     val store = StyxObjectStore<RoutingObjectRecord>()
+    val serviceDb = StyxObjectStore<ProviderObjectRecord>()
     val mockObject = RoutingMetadataDecorator(mockObject())
-    val handler = OriginsAdminHandler("/base/path", "testProvider", store)
+    val handler = OriginsAdminHandler("/base/path", "testProvider", store, serviceDb)
+
+    fun mockHealthCheck(running: Boolean) =
+            mockk<HealthCheckMonitoringService>() {
+                every { isRunning() } returns running
+            }
 
     store.insert("app.active", RoutingObjectRecord("HostProxy", setOf(sourceTag("testProvider"), stateTag(STATE_ACTIVE)), mockk(), mockObject))
     store.insert("app.closed", RoutingObjectRecord("HostProxy", setOf(sourceTag("testProvider"), stateTag(STATE_INACTIVE)), mockk(), mockObject))
     store.insert("app.unreachable", RoutingObjectRecord("HostProxy", setOf(sourceTag("testProvider"), stateTag(STATE_UNREACHABLE)), mockk(), mockObject))
     store.insert("app.nothostproxy", RoutingObjectRecord("NotHostProxy", setOf(sourceTag("testProvider"), stateTag(STATE_UNREACHABLE)), mockk(), mockObject))
 
+    serviceDb.insert("hc.running", ProviderObjectRecord(HEALTH_CHECK_MONITOR, setOf(targetTag("app.origin.hc.running")), mockk(), mockHealthCheck(true)))
+    serviceDb.insert("hc.stopped", ProviderObjectRecord(HEALTH_CHECK_MONITOR, setOf(targetTag("app.origin.hc.stopped")), mockk(), mockHealthCheck(false)))
 
     fun getResponse(handler: OriginsAdminHandler, request: LiveHttpRequest) = handler
             .handle(request, HttpInterceptorContext.create())
@@ -124,10 +128,10 @@ class OriginsAdminHandlerTest : FeatureSpec({
 
     feature("OriginsAdminHandler updates origin state for PUT request") {
 
-        fun expectStateChange(initialState: String, requestedState: String, expectedState: String, expectHealthTagCleared: Boolean) {
-            val initialHealthTag = healthCheckTag(Pair(HEALTHCHECK_FAILING, 2))!!
+        fun expectStateChange(initialState: String, requestedState: String, expectedState: String, expectHealthTagCleared: Boolean, appId: String = "testGroup") {
             store.insert("app.origin", RoutingObjectRecord("HostProxy",
                     setOf(sourceTag("testProvider"),
+                            lbGroupTag(appId),
                             stateTag(initialState),
                             healthCheckTag(Pair(HEALTHCHECK_FAILING, 2))!!), mockk(), mockObject))
 
@@ -167,8 +171,19 @@ class OriginsAdminHandlerTest : FeatureSpec({
             expectStateChange(STATE_UNREACHABLE, STATE_ACTIVE, STATE_UNREACHABLE, false)
         }
 
-        scenario("Activating an inactive origin results in an active state") {
+        // TODO: Complete this test
+        scenario("Activating an unhealthchecked, inactive origin results in an active state") {
             expectStateChange(STATE_INACTIVE, STATE_ACTIVE, STATE_ACTIVE, false)
+        }
+
+        // TODO: Complete this test
+        scenario("Activating a healthchecked, inactive origin results in an unreachable state") {
+            expectStateChange(STATE_INACTIVE, STATE_ACTIVE, STATE_UNREACHABLE, false, "app.origin.hc.running")
+        }
+
+        // TODO: Complete this test
+        scenario("Activating a healthchecked (but the healthchecker is stopped), inactive origin results in an unreachable state") {
+            expectStateChange(STATE_INACTIVE, STATE_ACTIVE, STATE_ACTIVE, false, "app.origin.hc.stopped")
         }
 
         scenario("Returns NOT_FOUND when URL is not of the correct format") {

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsAdminHandlerTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsAdminHandlerTest.kt
@@ -171,17 +171,14 @@ class OriginsAdminHandlerTest : FeatureSpec({
             expectStateChange(STATE_UNREACHABLE, STATE_ACTIVE, STATE_UNREACHABLE, false)
         }
 
-        // TODO: Complete this test
         scenario("Activating an unhealthchecked, inactive origin results in an active state") {
             expectStateChange(STATE_INACTIVE, STATE_ACTIVE, STATE_ACTIVE, false)
         }
 
-        // TODO: Complete this test
         scenario("Activating a healthchecked, inactive origin results in an unreachable state") {
             expectStateChange(STATE_INACTIVE, STATE_ACTIVE, STATE_UNREACHABLE, false, "app.origin.hc.running")
         }
 
-        // TODO: Complete this test
         scenario("Activating a healthchecked (but the healthchecker is stopped), inactive origin results in an unreachable state") {
             expectStateChange(STATE_INACTIVE, STATE_ACTIVE, STATE_ACTIVE, false, "app.origin.hc.stopped")
         }


### PR DESCRIPTION
(See #518 )
Reactivation of an origin should follow the existing logic as described here for the Origin Toggle: https://github.com/HotelsDotCom/styx/blob/master/docs/user-guide/admin-interface.md

i.e. if health checks are enabled then a reactivated origin goes into an `unreachable` state, and it is the health check service that moves it into an `active` state.