### PR TITLE
HttpInterceptorPipeline: accept a string as a "pipeline" argument.

### DIFF
--- a/components/common/src/main/java/com/hotels/styx/config/schema/Schema.java
+++ b/components/common/src/main/java/com/hotels/styx/config/schema/Schema.java
@@ -332,6 +332,37 @@ public class Schema {
 
     }
 
+    /**
+     * Or field type is an alternative of two possible types.
+     */
+    public static class OrField implements FieldType {
+        private final FieldType alt1;
+        private final FieldType alt2;
+
+        public OrField(FieldType alt1, FieldType alt2) {
+            this.alt1 = alt1;
+            this.alt2 = alt2;
+        }
+
+        @Override
+        public void validate(List<String> parents, JsonNode parent, JsonNode value, Function<String, FieldType> typeExtensions) {
+            try {
+                alt1.validate(parents, parent, value, typeExtensions);
+            } catch (SchemaValidationException e) {
+                try {
+                    alt2.validate(parents, parent, value, typeExtensions);
+                } catch (SchemaValidationException e2) {
+                    throw new SchemaValidationException(message(parents, describe(), value));
+                }
+            }
+        }
+
+        @Override
+        public String describe() {
+            return format("OR(%s, %s)", alt1.describe(), alt2.describe());
+        }
+    }
+
     public Builder newBuilder() {
         return new Builder(this);
     }

--- a/components/common/src/main/java/com/hotels/styx/config/schema/SchemaDsl.java
+++ b/components/common/src/main/java/com/hotels/styx/config/schema/SchemaDsl.java
@@ -145,6 +145,14 @@ public final class SchemaDsl {
         return new Schema.RoutingObjectSpec();
     }
 
+    /**
+     * An alternative of two different types.
+     *
+     * @return A FieldType instance.
+     */
+    public static Schema.FieldType or(Schema.FieldType alt1, Schema.FieldType alt2) {
+        return new Schema.OrField(alt1, alt2);
+    }
 
 
     /**

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingConfigParser.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingConfigParser.java
@@ -25,7 +25,10 @@ import static java.util.Optional.ofNullable;
 /**
  * Parses routing config objects from Yaml file.
  */
-public class RoutingConfigParser {
+public final class RoutingConfigParser {
+
+    private RoutingConfigParser() {
+    }
 
     public static StyxObjectConfiguration toRoutingConfigNode(JsonNode jsonNode) {
         if (jsonNode.getNodeType() == JsonNodeType.STRING) {

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/PluginsPipelineSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/PluginsPipelineSpec.kt
@@ -87,9 +87,7 @@ class PluginsPipelineSpec : FeatureSpec() {
                     httpPipeline:
                       type: InterceptorPipeline
                       config:
-                          pipeline:
-                            - plugin-a
-                            - plugin-c
+                          pipeline: plugin-a, plugin-c
                           handler:
                             type: StaticResponseHandler
                             config:


### PR DESCRIPTION
Accept a comma-separated string for `pipeline` attribute for `HttpInterceptorPipeline` object. This makes it easier reuse `plugins.active` value with new routing object configuration.

The pipeline still accepts Yaml lists too.

I have added a new `or` attribute to Schema DSL:

```
    public static final Schema.FieldType SCHEMA = object(
            optional("pipeline", or(string(), list(string()))),
            field("handler", routingObject())
    );
```
