### PR TITLE
Fix case where a Empty set-cookie headers causes NPE

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/ResponseCookie.java
+++ b/components/api/src/main/java/com/hotels/styx/api/ResponseCookie.java
@@ -86,6 +86,7 @@ public final class ResponseCookie {
     public static Set<ResponseCookie> decode(List<String> headerValues) {
         return headerValues.stream()
                 .map(ClientCookieDecoder.LAX::decode)
+                .filter(Objects::nonNull)
                 .map(ResponseCookie::convert)
                 .collect(Collectors.toSet());
     }

--- a/components/api/src/test/java/com/hotels/styx/api/LiveHttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/LiveHttpResponseTest.java
@@ -103,6 +103,11 @@ public class LiveHttpResponseTest {
         assertThat(response.headers(), is(emptyIterable()));
         assertThat(bytesToString(response.body()), is(""));
     }
+    @Test
+    public void badSetCookieHeaderDoesNotNpe() throws Exception {
+        LiveHttpResponse response = response().header("Set-cookie","").build();
+        assertThat(response.cookies().size(), is(0));
+    }
 
     @Test
     public void createsResponseWithMinimalInformation() throws Exception {


### PR DESCRIPTION
ResponseCookie.decode can NPE if reponse has an empty set-cookie header.