### PR TITLE
speed up kotlin integration tests by reusing the JVM fork.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -729,7 +729,8 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${maven-failsafe-plugin.version}</version>
           <configuration>
-            <forkMode>always</forkMode>
+            <forkCount>1C</forkCount>
+            <reuseForks>true</reuseForks>
             <argLine>
               -Xmx300m
               -XX:+HeapDumpOnOutOfMemoryError
@@ -1093,7 +1094,8 @@
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
-              <forkMode>always</forkMode>
+              <forkCount>1</forkCount>
+              <reuseForks>true</reuseForks>
               <argLine>
                 -Xmx300m
                 -XX:+HeapDumpOnOutOfMemoryError

--- a/pom.xml
+++ b/pom.xml
@@ -729,7 +729,7 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${maven-failsafe-plugin.version}</version>
           <configuration>
-            <forkCount>1C</forkCount>
+            <forkCount>1</forkCount>
             <reuseForks>true</reuseForks>
             <argLine>
               -Xmx300m

--- a/system-tests/e2e-suite/pom.xml
+++ b/system-tests/e2e-suite/pom.xml
@@ -194,6 +194,7 @@
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
           <filereports>WDF TestSuite.txt</filereports>
+          <stdout>T</stdout>>
           <systemProperties>
             <io.netty.leakDetectionLevel>ADVANCED</io.netty.leakDetectionLevel>
           </systemProperties>

--- a/system-tests/ft-suite/pom.xml
+++ b/system-tests/ft-suite/pom.xml
@@ -86,13 +86,6 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
 
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>${junit.platform.surefire.provider.version}</version>
-          </dependency>
-        </dependencies>
 
         <executions>
           <execution>

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/resiliency/OriginResourcesSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/resiliency/OriginResourcesSpec.kt
@@ -50,7 +50,7 @@ class OriginResourcesSpec : StringSpec() {
                     .withStatus(200)
                     .withBody("mock-server-01"))
 
-
+    val initialThreadcount = threadCount("Styx-Client-Worker")
     init {
         "Client thread pool configuration" {
             val clientThreadCount = run {
@@ -67,7 +67,7 @@ class OriginResourcesSpec : StringSpec() {
             }
 
             // From the static configuration below
-            clientThreadCount shouldBe 3
+            clientThreadCount-initialThreadcount shouldBe 3
         }
 
         "Uses the same thread pool for reloaded origins" {

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/PluginsPipelineSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/PluginsPipelineSpec.kt
@@ -21,6 +21,7 @@ import com.hotels.styx.client.StyxHttpClient
 import com.hotels.styx.support.StyxServerProvider
 import com.hotels.styx.support.proxyHttpHostHeader
 import com.hotels.styx.support.wait
+import io.kotlintest.Spec
 import io.kotlintest.matchers.collections.shouldContainInOrder
 import io.kotlintest.specs.FeatureSpec
 import org.slf4j.LoggerFactory
@@ -134,4 +135,8 @@ class PluginsPipelineSpec : FeatureSpec() {
         return Paths.get(getSystemClassLoader().getResource("")!!.getFile());
     }
 
+    override fun afterSpec(spec: Spec) {
+        styxServer.stop()
+        super.afterSpec(spec)
+    }
 }


### PR DESCRIPTION
Latest master build in Travis:  

`[INFO] Styx - System Tests - Functional Tests ............. SUCCESS [02:29 min]`

Travis build for this PR (https://travis-ci.org/HotelsDotCom/styx/builds/629635200?utm_source=github_status&utm_medium=notification) :

`[INFO] Styx - System Tests - Functional Tests ............. SUCCESS [ 32.290 s]`

