### PR TITLE
Remove Guava ServiceManager from NettyServer

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -192,14 +192,13 @@ public final class StyxServer extends AbstractService {
         StyxConfig styxConfig = components.environment().configuration();
         httpServer = styxConfig.proxyServerConfig()
                 .httpConnectorConfig()
-                .map(it -> httpServer(components, it, httpHandler))
+                .map(it -> httpServer(components.environment(), it, httpHandler))
                 .orElse(null);
 
         httpsServer = styxConfig.proxyServerConfig()
                 .httpsConnectorConfig()
-                .map(it -> httpServer(components, it, httpHandler))
+                .map(it -> httpServer(components.environment(), it, httpHandler))
                 .orElse(null);
-
 
         ArrayList<Service> services2 = new ArrayList<>();
 
@@ -211,22 +210,22 @@ public final class StyxServer extends AbstractService {
 
     public InetSocketAddress proxyHttpAddress() {
         return Optional.ofNullable(httpServer)
-                .map(HttpServer::httpAddress)
+                .map(HttpServer::inetAddress)
                 .orElse(null);
     }
 
     public InetSocketAddress proxyHttpsAddress() {
         return Optional.ofNullable(httpsServer)
-                .map(HttpServer::httpAddress)
+                .map(HttpServer::inetAddress)
                 .orElse(null);
     }
 
     public InetSocketAddress adminHttpAddress() {
-        return adminServer.httpAddress();
+        return adminServer.inetAddress();
     }
 
-    private static HttpServer httpServer(StyxServerComponents config, ConnectorConfig connectorConfig, HttpHandler styxDataPlane) {
-        return new ProxyServerBuilder(config.environment())
+    private static HttpServer httpServer(Environment environment, ConnectorConfig connectorConfig, HttpHandler styxDataPlane) {
+        return new ProxyServerBuilder(environment)
                 .handler(styxDataPlane)
                 .connectorConfig(connectorConfig)
                 .build();

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/StyxProxyTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/StyxProxyTest.java
@@ -92,7 +92,7 @@ public class StyxProxyTest extends SSLSetup {
         server.startAsync().awaitRunning();
         assertThat("Server should be running", server.isRunning());
 
-        HttpResponse secureResponse = get("http://localhost:" + server.httpAddress().getPort());
+        HttpResponse secureResponse = get("http://localhost:" + server.inetAddress().getPort());
         assertThat(secureResponse.bodyAs(UTF_8), containsString("Response from http connector"));
 
         server.stopAsync().awaitTerminated();

--- a/components/server/src/main/java/com/hotels/styx/server/HttpServer.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpServer.java
@@ -27,6 +27,6 @@ public interface HttpServer extends Service {
     /**
      * Return http endpoint.
      */
-    InetSocketAddress httpAddress();
+    InetSocketAddress inetAddress();
 
 }

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
@@ -16,8 +16,6 @@
 package com.hotels.styx.server.netty;
 
 import com.google.common.util.concurrent.AbstractService;
-import com.google.common.util.concurrent.Service;
-import com.google.common.util.concurrent.ServiceManager;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.server.HttpServer;
 import com.hotels.styx.server.ServerEventLoopFactory;
@@ -37,8 +35,6 @@ import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.google.common.base.Throwables.propagate;
 import static io.netty.channel.ChannelOption.ALLOCATOR;
@@ -57,35 +53,30 @@ import static org.slf4j.LoggerFactory.getLogger;
 final class NettyServer extends AbstractService implements HttpServer {
     private static final Logger LOGGER = getLogger(NettyServer.class);
 
-    private final String host;
     private final ChannelGroup channelGroup;
     private final ServerEventLoopFactory serverEventLoopFactory;
 
-    private final ServerConnector protocolConnector;
-
     private final HttpHandler handler;
-    private final ServerSocketBinder protocolSocketBinder;
+    private final ServerConnector serverConnector;
+    private final String host;
 
     private volatile Callable<?> stopper;
-    private volatile HttpHandler httpHandler;
+    private volatile InetSocketAddress address;
 
     NettyServer(NettyServerBuilder nettyServerBuilder) {
         this.host = nettyServerBuilder.host();
         this.channelGroup = requireNonNull(nettyServerBuilder.channelGroup());
         this.serverEventLoopFactory = requireNonNull(nettyServerBuilder.serverEventLoopFactory(), "serverEventLoopFactory cannot be null");
         this.handler = requireNonNull(nettyServerBuilder.handler());
-
-        this.protocolConnector = nettyServerBuilder.protocolConnector();
-
-        this.protocolSocketBinder = new ServerSocketBinder(protocolConnector);
+        this.serverConnector = nettyServerBuilder.protocolConnector();
     }
 
     @Override
-    public InetSocketAddress httpAddress() {
-        return Optional.ofNullable(protocolSocketBinder)
+    public InetSocketAddress inetAddress() {
+        return Optional.ofNullable(address)
                 .map(it -> {
                     try {
-                        return new InetSocketAddress(host, it.port());
+                        return new InetSocketAddress(host, it.getPort());
                     } catch (IllegalArgumentException e) {
                         return null;
                     }
@@ -97,150 +88,84 @@ final class NettyServer extends AbstractService implements HttpServer {
     protected void doStart() {
         LOGGER.info("starting services");
 
-        httpHandler = NettyServer.this.handler;
+        ServerBootstrap b = new ServerBootstrap();
+        EventLoopGroup bossGroup = serverEventLoopFactory.newBossEventLoopGroup();
+        EventLoopGroup workerGroup = serverEventLoopFactory.newWorkerEventLoopGroup();
+        Class<? extends ServerChannel> channelType = serverEventLoopFactory.serverChannelClass();
 
-        ServiceManager serviceManager = new ServiceManager(
-                Stream.of(protocolSocketBinder)
-                .collect(Collectors.toList())
-        );
+        b.group(bossGroup, workerGroup)
+                .channel(channelType)
+                .option(SO_BACKLOG, 1024)
+                .option(SO_REUSEADDR, true)
+                .childOption(SO_REUSEADDR, true)
+                .childOption(SO_KEEPALIVE, true)
+                .childOption(TCP_NODELAY, true)
+                .childOption(ALLOCATOR, PooledByteBufAllocator.DEFAULT)
+                .childHandler(new ChannelInitializer() {
+                    @Override
+                    protected void initChannel(Channel ch) throws Exception {
+                        serverConnector.configure(ch, handler);
+                    }
+                });
 
-        serviceManager.addListener(new ServerListener(this));
+        // Bind and start to accept incoming connections.
+        int port = serverConnector.port();
 
-        this.stopper = () -> {
-            serviceManager.stopAsync();
-            return null;
-        };
-
-        serviceManager.startAsync();
+        b.bind(new InetSocketAddress(port))
+                .addListener((ChannelFutureListener) future -> {
+                    if (future.isSuccess()) {
+                        Channel channel = future.channel();
+                        channelGroup.add(channel);
+                        address = (InetSocketAddress) channel.localAddress();
+                        LOGGER.info("server connector {} bound successfully on port {} socket port {}", new Object[]{serverConnector.getClass(), port, address});
+                        stopper = new Stopper(bossGroup, workerGroup);
+                        notifyStarted();
+                    } else {
+                        LOGGER.warn("Failed to start service={} cause={}", this, future.cause());
+                        notifyFailed(mapToBetterException(future.cause(), port));
+                    }
+                });
     }
 
     @Override
     protected void doStop() {
         try {
-            LOGGER.info("stopping server");
-            this.stopper.call();
+            if (stopper != null) {
+                stopper.call();
+                address = null;
+            }
         } catch (Exception e) {
-            notifyFailed(e);
+            throw propagate(e);
         }
     }
 
-    private static final class ServerListener extends ServiceManager.Listener {
-        private final NettyServer server;
-
-        public ServerListener(NettyServer server) {
-            this.server = server;
+    private Throwable mapToBetterException(Throwable cause, int port) {
+        if (cause instanceof BindException) {
+            return new BindException(format("Address [%s] already is use.", port));
         }
-
-        @Override
-        public void healthy() {
-            server.notifyStarted();
-        }
-
-        @Override
-        public void stopped() {
-            LOGGER.info("stopped");
-            server.notifyStopped();
-        }
-
-        @Override
-        public void failure(Service service) {
-            LOGGER.warn("Failed to start service={} cause={}", service, service.failureCause());
-            server.notifyFailed(service.failureCause());
-        }
+        return cause;
     }
 
-    private final class ServerSocketBinder extends AbstractService {
-        private final ServerConnector serverConnector;
-        private volatile Callable<?> connectorStopper;
-        private volatile InetSocketAddress address;
+    private class Stopper implements Callable<Void> {
+        private final EventLoopGroup bossGroup;
+        private final EventLoopGroup workerGroup;
 
-        private ServerSocketBinder(ServerConnector serverConnector) {
-            this.serverConnector = serverConnector;
+        public Stopper(EventLoopGroup bossGroup, EventLoopGroup workerGroup) {
+            this.bossGroup = bossGroup;
+            this.workerGroup = workerGroup;
         }
 
         @Override
-        protected void doStart() {
-            ServerBootstrap b = new ServerBootstrap();
-            EventLoopGroup bossGroup = serverEventLoopFactory.newBossEventLoopGroup();
-            EventLoopGroup workerGroup = serverEventLoopFactory.newWorkerEventLoopGroup();
-            Class<? extends ServerChannel> channelType = serverEventLoopFactory.serverChannelClass();
-
-            b.group(bossGroup, workerGroup)
-                    .channel(channelType)
-                    .option(SO_BACKLOG, 1024)
-                    .option(SO_REUSEADDR, true)
-                    .childOption(SO_REUSEADDR, true)
-                    .childOption(SO_KEEPALIVE, true)
-                    .childOption(TCP_NODELAY, true)
-                    .childOption(ALLOCATOR, PooledByteBufAllocator.DEFAULT)
-                    .childHandler(new ChannelInitializer() {
-                        @Override
-                        protected void initChannel(Channel ch) throws Exception {
-                            serverConnector.configure(ch, httpHandler);
-                        }
-                    });
-
-            // Bind and start to accept incoming connections.
-            int port = serverConnector.port();
-
-            b.bind(new InetSocketAddress(port))
-                    .addListener((ChannelFutureListener) future -> {
-                        if (future.isSuccess()) {
-                            Channel channel = future.channel();
-                            channelGroup.add(channel);
-                            address = (InetSocketAddress) channel.localAddress();
-                            LOGGER.info("server connector {} bound successfully on port {} socket port {}", new Object[] {serverConnector.getClass(), port, address});
-                            connectorStopper = new Stopper(bossGroup, workerGroup);
-                            notifyStarted();
-                        } else {
-                            notifyFailed(mapToBetterException(future.cause(), port));
-                        }
-                    });
+        public Void call() {
+            channelGroup.close().awaitUninterruptibly();
+            shutdownEventExecutorGroup(bossGroup);
+            shutdownEventExecutorGroup(workerGroup);
+            notifyStopped();
+            return null;
         }
 
-        public int port() {
-            return (address != null) ? address.getPort() : -1;
-        }
-
-        private Throwable mapToBetterException(Throwable cause, int port) {
-            if (cause instanceof BindException) {
-                return new BindException(format("Address [%s] already is use.", port));
-            }
-            return cause;
-        }
-
-        @Override
-        protected void doStop() {
-            try {
-                if (connectorStopper != null) {
-                    connectorStopper.call();
-                }
-            } catch (Exception e) {
-                throw propagate(e);
-            }
-        }
-
-        private class Stopper implements Callable<Void> {
-            private final EventLoopGroup bossGroup;
-            private final EventLoopGroup workerGroup;
-
-            public Stopper(EventLoopGroup bossGroup, EventLoopGroup workerGroup) {
-                this.bossGroup = bossGroup;
-                this.workerGroup = workerGroup;
-            }
-
-            @Override
-            public Void call() {
-                channelGroup.close().awaitUninterruptibly();
-                shutdownEventExecutorGroup(bossGroup);
-                shutdownEventExecutorGroup(workerGroup);
-                notifyStopped();
-                return null;
-            }
-
-            private Future<?> shutdownEventExecutorGroup(EventExecutorGroup eventExecutorGroup) {
-                return eventExecutorGroup.shutdownGracefully(10, 1000, MILLISECONDS);
-            }
+        private Future<?> shutdownEventExecutorGroup(EventExecutorGroup eventExecutorGroup) {
+            return eventExecutorGroup.shutdownGracefully(10, 1000, MILLISECONDS);
         }
     }
 }

--- a/system-tests/e2e-suite/src/test/java/com/hotels/styx/http/StaticFileOnRealServerIT.java
+++ b/system-tests/e2e-suite/src/test/java/com/hotels/styx/http/StaticFileOnRealServerIT.java
@@ -57,7 +57,7 @@ public class StaticFileOnRealServerIT {
         dir = Files.createTempDir();
         webServer = createHttpServer(0, new StaticFileHandler(dir));
         webServer.startAsync().awaitRunning();
-        serverEndpoint = toHostAndPort(webServer.httpAddress());
+        serverEndpoint = toHostAndPort(webServer.inetAddress());
     }
 
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/MockServer.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/MockServer.scala
@@ -79,23 +79,23 @@ class MockServer(id: String, val port: Int) extends AbstractIdleService with Htt
 
   override def startUp(): Unit = {
     server.startAsync().awaitRunning()
-    logger.info("mock server started on port " + server.httpAddress().getPort)
+    logger.info("mock server started on port " + server.inetAddress().getPort)
   }
 
   override def shutDown(): Unit = {
+    logger.info(s"mock server running on port ${server.inetAddress().getPort} stopping")
     server.stopAsync().awaitTerminated()
-    logger.info(s"mock server running on port ${server.httpAddress().getPort} stopped")
   }
 
-  override def httpAddress(): InetSocketAddress = {
-    server.httpAddress()
+  override def inetAddress(): InetSocketAddress = {
+    server.inetAddress()
   }
 
   private def connectorOnFreePort: ServerConnector = {
     new WebServerConnectorFactory().create(new HttpConnectorConfig(0))
   }
 
-  def httpPort() = Option(server.httpAddress()).map(_.getPort).getOrElse(0)
+  def httpPort() = Option(server.inetAddress()).map(_.getPort).getOrElse(0)
 
   def origin = newOriginBuilder("localhost", httpPort()).id(id).build()
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/StyxBackend.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/configuration/StyxBackend.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2019 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ trait ImplicitOriginConversions {
     port = server.port())
 
   implicit def httpServer2Origin(httpServer: HttpServer): Origin = Origin(
-    host = "localhost", port = httpServer.httpAddress().getPort
+    host = "localhost", port = httpServer.inetAddress().getPort
   )
 
   implicit def java2ScalaOrigin(origin: com.hotels.styx.api.extension.Origin): Origin = Origin.fromJava(origin)

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/MockOriginServer.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/MockOriginServer.java
@@ -185,11 +185,11 @@ public final class MockOriginServer {
     }
 
     public int port() {
-        return mockServer.httpAddress().getPort();
+        return mockServer.inetAddress().getPort();
     }
 
     public int adminPort() {
-        return adminServer.httpAddress().getPort();
+        return adminServer.inetAddress().getPort();
     }
 
     public boolean isRunning() {


### PR DESCRIPTION
`NettyServer` doesn't have to use service manager. Therefore we can simplify this class by removing the `ServiceListener` from it.

Also rename meaningless `HttpServer/httpAddress` method to `inetAddress`.
