### PR TITLE
Refactor ProviderObjectRecord

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -48,13 +48,14 @@ import com.hotels.styx.api.WebServiceHandler;
 import com.hotels.styx.api.configuration.Configuration;
 import com.hotels.styx.api.extension.service.BackendService;
 import com.hotels.styx.api.extension.service.spi.Registry;
+import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.common.http.handler.HttpAggregator;
 import com.hotels.styx.common.http.handler.HttpMethodFilteringHandler;
 import com.hotels.styx.common.http.handler.StaticBodyHttpHandler;
 import com.hotels.styx.routing.RoutingObjectRecord;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.ProviderObjectRecord;
+import com.hotels.styx.routing.handlers.StyxObjectRecord;
 import com.hotels.styx.server.AdminHttpRouter;
 import com.hotels.styx.server.HttpServer;
 import com.hotels.styx.server.handlers.ClassPathResourceHandler;
@@ -94,7 +95,7 @@ public class AdminServerBuilder {
     private final Configuration configuration;
     private final RoutingObjectFactory.Context routingObjectFactoryContext;
     private final StyxObjectStore<RoutingObjectRecord> routeDatabase;
-    private final StyxObjectStore<ProviderObjectRecord> providerDatabase;
+    private final StyxObjectStore<StyxObjectRecord<StyxService>> providerDatabase;
     private final StartupConfig startupConfig;
 
     private Registry<BackendService> backendServicesRegistry;

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderListHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderListHandler.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -21,8 +21,9 @@ import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.WebServiceHandler;
+import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.api.configuration.ObjectStore;
-import com.hotels.styx.routing.handlers.ProviderObjectRecord;
+import com.hotels.styx.routing.handlers.StyxObjectRecord;
 
 import java.util.stream.Collectors;
 
@@ -54,13 +55,13 @@ public class ProviderListHandler implements WebServiceHandler {
 
     private static final String TITLE = "List of Providers";
 
-    private final ObjectStore<ProviderObjectRecord> providerDb;
+    private final ObjectStore<StyxObjectRecord<StyxService>> providerDb;
 
     /**
      * Create a new handler linked to a provider object store.
      * @param providerDb the provider store.
      */
-    public ProviderListHandler(ObjectStore<ProviderObjectRecord> providerDb) {
+    public ProviderListHandler(ObjectStore<StyxObjectRecord<StyxService>> providerDb) {
         this.providerDb = providerDb;
     }
 
@@ -76,7 +77,7 @@ public class ProviderListHandler implements WebServiceHandler {
                 .build());
     }
 
-    private static String htmlForProvider(String name, ProviderObjectRecord provider) {
+    private static String htmlForProvider(String name, StyxObjectRecord<StyxService> provider) {
         String endpointList = provider.getStyxService()
                 .adminInterfaceHandlers(adminPath("providers", name))
                 .keySet()

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderRoutingHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderRoutingHandler.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -21,9 +21,10 @@ import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.WebServiceHandler;
 import com.hotels.styx.api.configuration.ObjectStore;
+import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.common.http.handler.HttpStreamer;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.ProviderObjectRecord;
+import com.hotels.styx.routing.handlers.StyxObjectRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -47,7 +48,7 @@ public class ProviderRoutingHandler implements WebServiceHandler {
      * @param pathPrefix the path prefix added to each provider admin URL
      * @param providerDb the provider object store
      */
-    public ProviderRoutingHandler(String pathPrefix, StyxObjectStore<ProviderObjectRecord> providerDb) {
+    public ProviderRoutingHandler(String pathPrefix, StyxObjectStore<StyxObjectRecord<StyxService>> providerDb) {
         this.pathPrefix = pathPrefix;
         Flux.from(providerDb.watch()).subscribe(
                 this::refreshRoutes,
@@ -59,12 +60,12 @@ public class ProviderRoutingHandler implements WebServiceHandler {
         return router.handle(request, context);
     }
 
-    private void refreshRoutes(ObjectStore<ProviderObjectRecord> db) {
+    private void refreshRoutes(ObjectStore<StyxObjectRecord<StyxService>> db) {
         LOG.info("Refreshing provider admin endpoint routes");
         router = buildRouter(db);
     }
 
-    private UrlPatternRouter buildRouter(ObjectStore<ProviderObjectRecord> db) {
+    private UrlPatternRouter buildRouter(ObjectStore<StyxObjectRecord<StyxService>> db) {
         UrlPatternRouter.Builder routeBuilder = new UrlPatternRouter.Builder(pathPrefix)
                 .get("", new ProviderListHandler(db));
         db.entrySet().forEach(entry -> {

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ServiceProviderHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ServiceProviderHandler.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -27,9 +27,10 @@ import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.WebServiceHandler;
+import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.ProviderObjectRecord;
+import com.hotels.styx.routing.handlers.StyxObjectRecord;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -62,7 +63,7 @@ public class ServiceProviderHandler implements WebServiceHandler {
 
     private final UrlPatternRouter urlRouter;
 
-    public ServiceProviderHandler(StyxObjectStore<ProviderObjectRecord> providerDatabase) {
+    public ServiceProviderHandler(StyxObjectStore<StyxObjectRecord<StyxService>> providerDatabase) {
         urlRouter = new UrlPatternRouter.Builder()
                 .get("/admin/service/providers", (request, context) -> {
                     try {
@@ -108,7 +109,7 @@ public class ServiceProviderHandler implements WebServiceHandler {
         return YAML_MAPPER.copy();
     }
 
-    private static String serialise(String name, ProviderObjectRecord record) {
+    private static String serialise(String name, StyxObjectRecord<StyxService> record) {
         List<String> tags = ImmutableList.copyOf(record.getTags());
         StyxObjectDefinition objectDef =
                 new StyxObjectDefinition(name, record.getType(), tags, record.getConfig());

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/Builtins.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/Builtins.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ import com.hotels.styx.routing.handlers.HostProxy;
 import com.hotels.styx.routing.handlers.HttpInterceptorPipeline;
 import com.hotels.styx.routing.handlers.LoadBalancingGroup;
 import com.hotels.styx.routing.handlers.PathPrefixRouter;
-import com.hotels.styx.routing.handlers.ProviderObjectRecord;
 import com.hotels.styx.routing.handlers.ProxyToBackend;
 import com.hotels.styx.routing.handlers.RouteRefLookup;
 import com.hotels.styx.routing.handlers.StaticResponseHandler;
+import com.hotels.styx.routing.handlers.StyxObjectRecord;
 import com.hotels.styx.routing.interceptors.RewriteInterceptor;
 import com.hotels.styx.serviceproviders.ServiceProviderFactory;
 import com.hotels.styx.services.HealthCheckMonitoringService;
@@ -176,7 +176,7 @@ public final class Builtins {
     public static StyxService build(
             String name,
             StyxObjectDefinition providerDef,
-            StyxObjectStore<ProviderObjectRecord> serviceDb,
+            StyxObjectStore<StyxObjectRecord<StyxService>> serviceDb,
             Map<String, ServiceProviderFactory> factories,
             RoutingObjectFactory.Context context) {
         ServiceProviderFactory constructor = factories.get(providerDef.type());

--- a/components/proxy/src/main/java/com/hotels/styx/serviceproviders/ServiceProviderFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/serviceproviders/ServiceProviderFactory.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.ProviderObjectRecord;
+import com.hotels.styx.routing.handlers.StyxObjectRecord;
 
 /**
  * A generic factory that can be implemented to create objects whose type is not known
@@ -37,5 +37,5 @@ public interface ServiceProviderFactory {
      *
      * @return Styx service instance
      */
-    StyxService create(String name, RoutingObjectFactory.Context context, JsonNode serviceConfiguration, StyxObjectStore<ProviderObjectRecord> serviceDb);
+    StyxService create(String name, RoutingObjectFactory.Context context, JsonNode serviceConfiguration, StyxObjectStore<StyxObjectRecord<StyxService>> serviceDb);
 }

--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ import com.hotels.styx.routing.config.Builtins;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.ProviderObjectRecord;
 import com.hotels.styx.routing.handlers.RouteRefLookup.RouteDbRefLookup;
+import com.hotels.styx.routing.handlers.StyxObjectRecord;
 import com.hotels.styx.startup.extensions.ConfiguredPluginFactory;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
@@ -74,7 +74,7 @@ public class StyxServerComponents {
     private final Map<String, StyxService> services;
     private final List<NamedPlugin> plugins;
     private final StyxObjectStore<RoutingObjectRecord> routeObjectStore = new StyxObjectStore<>();
-    private final StyxObjectStore<ProviderObjectRecord> providerObjectStore = new StyxObjectStore<>();
+    private final StyxObjectStore<StyxObjectRecord<StyxService>> providerObjectStore = new StyxObjectStore<>();
     private final EventLoopGroup eventLoopGroup;
     private final Class<? extends SocketChannel> nettySocketChannelClass;
     private final RoutingObjectFactory.Context routingObjectContext;
@@ -146,7 +146,7 @@ public class StyxServerComponents {
                     StyxService provider = Builtins.build(name, definition, providerObjectStore, BUILTIN_SERVICE_PROVIDER_FACTORIES, routingObjectContext);
 
                     // Create a provider object record
-                    ProviderObjectRecord record = new ProviderObjectRecord(definition.type(), ImmutableSet.copyOf(definition.tags()), definition.config(), provider);
+                    StyxObjectRecord<StyxService> record = new StyxObjectRecord<>(definition.type(), ImmutableSet.copyOf(definition.tags()), definition.config(), provider);
 
                     // Insert provider object record into database
                     providerObjectStore.insert(name, record);
@@ -183,7 +183,7 @@ public class StyxServerComponents {
         return this.routeObjectStore;
     }
 
-    public StyxObjectStore<ProviderObjectRecord> servicesDatabase() {
+    public StyxObjectStore<StyxObjectRecord<StyxService>> servicesDatabase() {
         return this.providerObjectStore;
     }
 

--- a/components/proxy/src/main/kotlin/com/hotels/styx/routing/handlers/ProviderObjectRecord.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/routing/handlers/ProviderObjectRecord.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ import com.hotels.styx.api.extension.service.spi.StyxService
 /**
  * A routing object and its associated configuration metadata.
  */
-internal data class ProviderObjectRecord(
+internal data class StyxObjectRecord<T : StyxService>(
         val type: String,
         val tags: Set<String>,
         val config: JsonNode,
-        val styxService: StyxService)
+        val styxService: T)
+
+internal typealias ProviderObjectRecord = StyxObjectRecord<StyxService>

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ProviderListHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ProviderListHandlerTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -22,9 +22,10 @@ import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.extension.service.spi.AbstractStyxService;
+import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.common.http.handler.HttpContentHandler;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.ProviderObjectRecord;
+import com.hotels.styx.routing.handlers.StyxObjectRecord;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -46,10 +47,10 @@ public class ProviderListHandlerTest {
     public void showsEndpointsForAllConfiguredProviders() throws JsonProcessingException {
         JsonNode config = new ObjectMapper().readTree("{\"setting1\" : \"A\", \"setting2\" : \"A\"}");
 
-        StyxObjectStore<ProviderObjectRecord> store = new StyxObjectStore<>();
-        store.insert("Service-A1", new ProviderObjectRecord("ServiceA", new HashSet<>(), config, new SampleServiceA("Service-A-1")));
-        store.insert("Service-A2", new ProviderObjectRecord("ServiceA", new HashSet<>(), config, new SampleServiceA("Service-A-2")));
-        store.insert("Service-B", new ProviderObjectRecord("ServiceB", new HashSet<>(), config, new SampleServiceB("Service-B")));
+        StyxObjectStore<StyxObjectRecord<StyxService>> store = new StyxObjectStore<>();
+        store.insert("Service-A1", new StyxObjectRecord<>("ServiceA", new HashSet<>(), config, new SampleServiceA("Service-A-1")));
+        store.insert("Service-A2", new StyxObjectRecord<>("ServiceA", new HashSet<>(), config, new SampleServiceA("Service-A-2")));
+        store.insert("Service-B", new StyxObjectRecord<>("ServiceB", new HashSet<>(), config, new SampleServiceB("Service-B")));
 
         ProviderListHandler handler = new ProviderListHandler(store);
 

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ServiceProviderHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ServiceProviderHandlerTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -19,18 +19,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
-import com.hotels.styx.api.HttpResponseStatus;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.ProviderObjectRecord;
+import com.hotels.styx.routing.handlers.StyxObjectRecord;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -38,6 +36,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
+import static com.hotels.styx.api.HttpResponseStatus.NO_CONTENT;
+import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -50,18 +52,18 @@ public class ServiceProviderHandlerTest {
 
     @Test
     public void returnsAllProviders() throws IOException {
-        StyxObjectStore<ProviderObjectRecord> store = createTestStore();
+        StyxObjectStore<StyxObjectRecord<StyxService>> store = createTestStore();
         ServiceProviderHandler handler = new ServiceProviderHandler(store);
         HttpRequest request = HttpRequest.get("/admin/service/providers").build();
         HttpResponse response = Mono.from(handler.handle(request, HttpInterceptorContext.create())).block();
 
-        assertThat(response.status(), equalTo(HttpResponseStatus.OK));
+        assertThat(response.status(), equalTo(OK));
 
-        List<StyxObjectDefinition> actualProviders = extractProviders(response.bodyAs(StandardCharsets.UTF_8));
+        List<StyxObjectDefinition> actualProviders = extractProviders(response.bodyAs(UTF_8));
         assertThat(actualProviders.size(), equalTo(store.entrySet().size()));
         for (StyxObjectDefinition actual :
                 actualProviders) {
-            Optional<ProviderObjectRecord> rec = store.get(actual.name());
+            Optional<StyxObjectRecord<StyxService>> rec = store.get(actual.name());
             assertTrue(rec.isPresent());
             validateProvider(actual, rec.get());
         }
@@ -69,25 +71,25 @@ public class ServiceProviderHandlerTest {
 
     @Test
     public void returnsNoContentStatusWhenNoProvidersAvailable() {
-        StyxObjectStore<ProviderObjectRecord> empty = new StyxObjectStore<>();
+        StyxObjectStore<StyxObjectRecord<StyxService>> empty = new StyxObjectStore<>();
         ServiceProviderHandler handler = new ServiceProviderHandler(empty);
         HttpRequest request = HttpRequest.get("/admin/service/providers").build();
         HttpResponse response = Mono.from(handler.handle(request, HttpInterceptorContext.create())).block();
 
-        assertThat(response.status(), equalTo(HttpResponseStatus.NO_CONTENT));
+        assertThat(response.status(), equalTo(NO_CONTENT));
         assertFalse(response.contentLength().isPresent());
     }
 
     @Test
     public void returnsNamedProvider() throws IOException {
-        StyxObjectStore<ProviderObjectRecord> store = createTestStore();
+        StyxObjectStore<StyxObjectRecord<StyxService>> store = createTestStore();
         ServiceProviderHandler handler = new ServiceProviderHandler(store);
         HttpRequest request = HttpRequest.get("/admin/service/provider/object2").build();
         HttpResponse response = Mono.from(handler.handle(request, HttpInterceptorContext.create())).block();
 
-        assertThat(response.status(), equalTo(HttpResponseStatus.OK));
+        assertThat(response.status(), equalTo(OK));
 
-        StyxObjectDefinition actualProvider = deserialiseProvider(response.bodyAs(StandardCharsets.UTF_8));
+        StyxObjectDefinition actualProvider = deserialiseProvider(response.bodyAs(UTF_8));
         assertThat(actualProvider, notNullValue());
         assertThat(actualProvider.name(), equalTo("object2"));
         validateProvider(actualProvider, store.get("object2").get());
@@ -95,41 +97,41 @@ public class ServiceProviderHandlerTest {
 
     @Test
     public void returnsNotFoundStatusWhenNamedProviderNotFound() throws IOException {
-        StyxObjectStore<ProviderObjectRecord> store = createTestStore();
+        StyxObjectStore<StyxObjectRecord<StyxService>> store = createTestStore();
         ServiceProviderHandler handler = new ServiceProviderHandler(store);
         HttpRequest request = HttpRequest.get("/admin/service/provider/nonexistent").build();
         HttpResponse response = Mono.from(handler.handle(request, HttpInterceptorContext.create())).block();
 
-        assertThat(response.status(), equalTo(HttpResponseStatus.NOT_FOUND));
+        assertThat(response.status(), equalTo(NOT_FOUND));
     }
 
     @Test
     public void returnsNotFoundStatusWithNonHandledUrl() {
-        StyxObjectStore<ProviderObjectRecord> empty = new StyxObjectStore<>();
+        StyxObjectStore<StyxObjectRecord<StyxService>> empty = new StyxObjectStore<>();
         ServiceProviderHandler handler = new ServiceProviderHandler(empty);
         HttpRequest request = HttpRequest.get("/not/my/url").build();
         HttpResponse response = Mono.from(handler.handle(request, HttpInterceptorContext.create())).block();
 
-        assertThat(response.status(), equalTo(HttpResponseStatus.NOT_FOUND));
+        assertThat(response.status(), equalTo(NOT_FOUND));
     }
 
-    private StyxObjectStore<ProviderObjectRecord> createTestStore() throws IOException {
+    private StyxObjectStore<StyxObjectRecord<StyxService>> createTestStore() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         StyxService mockService = mock(StyxService.class);
-        StyxObjectStore<ProviderObjectRecord> store = new StyxObjectStore<>();
+        StyxObjectStore<StyxObjectRecord<StyxService>> store = new StyxObjectStore<>();
 
         JsonNode config1 = mapper.readTree("{\"setting1\" : \"A\", \"setting2\" : \"A\"}");
-        ProviderObjectRecord rec1 = new ProviderObjectRecord("Type1", new HashSet<>(Arrays.asList("this=that", "truth=false")),
+        StyxObjectRecord<StyxService> rec1 = new StyxObjectRecord<>("Type1", new HashSet<>(Arrays.asList("this=that", "truth=false")),
                 config1, mockService);
         store.insert("object1", rec1);
 
         JsonNode config2 = mapper.readTree("{\"setting1\" : \"B\", \"setting2\" : \"B\"}");
-        ProviderObjectRecord rec2 = new ProviderObjectRecord("Type2", new HashSet<>(Arrays.asList("up=down", "weakness=strength")),
+        StyxObjectRecord<StyxService> rec2 = new StyxObjectRecord<>("Type2", new HashSet<>(Arrays.asList("up=down", "weakness=strength")),
                 config2, mockService);
         store.insert("object2", rec2);
 
         JsonNode config3 = mapper.readTree("{\"setting1\" : \"C\", \"setting2\" : \"C\"}");
-        ProviderObjectRecord rec3 = new ProviderObjectRecord("Type3", new HashSet<>(Arrays.asList("black=white", "left=right")),
+        StyxObjectRecord<StyxService> rec3 = new StyxObjectRecord<>("Type3", new HashSet<>(Arrays.asList("black=white", "left=right")),
                 config3, mockService);
         store.insert("object3", rec3);
 
@@ -151,7 +153,7 @@ public class ServiceProviderHandlerTest {
                 .collect(Collectors.toList());
     }
 
-    private void validateProvider(StyxObjectDefinition actual, ProviderObjectRecord expected) {
+    private void validateProvider(StyxObjectDefinition actual, StyxObjectRecord<StyxService> expected) {
         assertThat(actual.type(), equalTo(expected.getType()));
         assertThat(actual.tags(), containsInAnyOrder(expected.getTags().toArray()));
 

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsAdminHandlerTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsAdminHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -16,22 +16,33 @@
 package com.hotels.styx.services
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.hotels.styx.*
+import com.hotels.styx.ErrorResponse
+import com.hotels.styx.HEALTHCHECK_FAILING
+import com.hotels.styx.STATE_ACTIVE
+import com.hotels.styx.STATE_INACTIVE
+import com.hotels.styx.STATE_UNREACHABLE
 import com.hotels.styx.api.HttpRequest
 import com.hotels.styx.api.HttpResponseStatus
 import com.hotels.styx.api.HttpResponseStatus.BAD_REQUEST
 import com.hotels.styx.api.HttpResponseStatus.NOT_FOUND
 import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.LiveHttpRequest
+import com.hotels.styx.api.extension.service.spi.StyxService
+import com.hotels.styx.healthCheckTag
 import com.hotels.styx.infrastructure.configuration.json.mixins.ErrorResponseMixin
+import com.hotels.styx.lbGroupTag
 import com.hotels.styx.routing.RoutingMetadataDecorator
 import com.hotels.styx.routing.RoutingObjectRecord
-import com.hotels.styx.routing.config.Builtins
 import com.hotels.styx.routing.config.Builtins.HEALTH_CHECK_MONITOR
 import com.hotels.styx.routing.db.StyxObjectStore
 import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.routing.handlers.StyxObjectRecord
 import com.hotels.styx.routing.mockObject
 import com.hotels.styx.server.HttpInterceptorContext
+import com.hotels.styx.sourceTag
+import com.hotels.styx.stateTag
+import com.hotels.styx.targetTag
+import com.hotels.styx.wait
 import io.kotlintest.matchers.collections.shouldContain
 import io.kotlintest.matchers.string.shouldStartWith
 import io.kotlintest.shouldBe
@@ -45,7 +56,7 @@ class OriginsAdminHandlerTest : FeatureSpec({
     val mapper = ObjectMapper().addMixIn(ErrorResponse::class.java, ErrorResponseMixin::class.java)
 
     val store = StyxObjectStore<RoutingObjectRecord>()
-    val serviceDb = StyxObjectStore<ProviderObjectRecord>()
+    val serviceDb = StyxObjectStore<StyxObjectRecord<StyxService>>()
     val mockObject = RoutingMetadataDecorator(mockObject())
     val handler = OriginsAdminHandler("/base/path", "testProvider", store, serviceDb)
 


### PR DESCRIPTION
Provide parametrised `StyxObjectRecord<T>` and declare `ProviderObjectRecord`
as `StyxObjectRecord<StyxService>`.

This is so that we can use common format for other styx objects, too:

* Routing object record
* Service provider record
* Styx server records (coming in subsequent pull requests)
