### PR TITLE
Remove obsolete animal sniffer maven plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,6 @@
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
 
     <!-- non apache plugin versions and configurations, please sort alphabetically -->
-    <animal-sniffer-maven-plugin.version>1.0</animal-sniffer-maven-plugin.version>
     <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
     <jacoco-maven-plugin.version>0.7.5.201505241946</jacoco-maven-plugin.version>
 
@@ -839,18 +838,6 @@
               </configuration>
             </execution>
           </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <configuration>
-            <signature>
-              <groupId>org.codehaus.mojo.signature</groupId>
-              <artifactId>java17</artifactId>
-              <version>${animal-sniffer-maven-plugin.version}</version>
-            </signature>
-          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Plugin is unavailable in some maven repositories. It turns out that it was not being used and the signature file for the JDK is also unavailable. 