### PR TITLE
Styx server object support.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/ResponseCookie.java
+++ b/components/api/src/main/java/com/hotels/styx/api/ResponseCookie.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/main/java/com/hotels/styx/StyxServers.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServers.java
@@ -1,0 +1,58 @@
+/*
+  Copyright (C) 2013-2020 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx;
+
+import com.google.common.util.concurrent.AbstractService;
+import com.google.common.util.concurrent.Service;
+import com.hotels.styx.api.extension.service.spi.StyxService;
+
+/**
+ * A helper class to manipulate StyxServer objects.
+ */
+public final class StyxServers {
+    private StyxServers() {
+    }
+
+    /**
+     * Convert a StyxService to a Guava Service.
+     *
+     * @param styxService
+     * @return
+     */
+    public static Service toGuavaService(StyxService styxService) {
+        return new AbstractService() {
+            @Override
+            protected void doStart() {
+                styxService.start()
+                        .thenAccept(x -> notifyStarted())
+                        .exceptionally(e -> {
+                            notifyFailed(e);
+                            return null;
+                        });
+            }
+
+            @Override
+            protected void doStop() {
+                styxService.stop()
+                        .thenAccept(x -> notifyStopped())
+                        .exceptionally(e -> {
+                            notifyFailed(e);
+                            return null;
+                        });
+            }
+        };
+    }
+}

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.json.MetricsModule;
 import com.google.common.collect.ImmutableList;
 import com.hotels.styx.Environment;
 import com.hotels.styx.NettyExecutor;
+import com.hotels.styx.InetServer;
 import com.hotels.styx.StartupConfig;
 import com.hotels.styx.StyxConfig;
 import com.hotels.styx.admin.dashboard.DashboardData;
@@ -56,9 +57,8 @@ import com.hotels.styx.common.http.handler.StaticBodyHttpHandler;
 import com.hotels.styx.routing.RoutingObjectRecord;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.StyxObjectRecord;
+import com.hotels.styx.StyxObjectRecord;
 import com.hotels.styx.server.AdminHttpRouter;
-import com.hotels.styx.server.HttpServer;
 import com.hotels.styx.server.handlers.ClassPathResourceHandler;
 import com.hotels.styx.server.netty.NettyServerBuilder;
 import com.hotels.styx.server.netty.WebServerConnectorFactory;
@@ -115,7 +115,7 @@ public class AdminServerBuilder {
         return this;
     }
 
-    public HttpServer build() {
+    public InetServer build() {
         LOG.info("event bus that will be used is {}", environment.eventBus());
         StyxConfig styxConfig = environment.configuration();
         AdminServerConfig adminServerConfig = styxConfig.adminServerConfig();

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderListHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderListHandler.java
@@ -16,14 +16,14 @@
 package com.hotels.styx.admin.handlers;
 
 
+import com.hotels.styx.StyxObjectRecord;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.WebServiceHandler;
-import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.api.configuration.ObjectStore;
-import com.hotels.styx.routing.handlers.StyxObjectRecord;
+import com.hotels.styx.api.extension.service.spi.StyxService;
 
 import java.util.stream.Collectors;
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderRoutingHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderRoutingHandler.java
@@ -15,6 +15,7 @@
  */
 package com.hotels.styx.admin.handlers;
 
+import com.hotels.styx.StyxObjectRecord;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
@@ -24,7 +25,6 @@ import com.hotels.styx.api.configuration.ObjectStore;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.common.http.handler.HttpStreamer;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.StyxObjectRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ServiceProviderHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ServiceProviderHandler.java
@@ -30,7 +30,7 @@ import com.hotels.styx.api.WebServiceHandler;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.StyxObjectRecord;
+import com.hotels.styx.StyxObjectRecord;
 import org.slf4j.Logger;
 
 import java.util.List;

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/Builtins.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/Builtins.java
@@ -16,6 +16,7 @@
 package com.hotels.styx.routing.config;
 
 import com.google.common.collect.ImmutableMap;
+import com.hotels.styx.InetServer;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.extension.service.spi.StyxService;
@@ -30,9 +31,10 @@ import com.hotels.styx.routing.handlers.PathPrefixRouter;
 import com.hotels.styx.routing.handlers.ProxyToBackend;
 import com.hotels.styx.routing.handlers.RouteRefLookup;
 import com.hotels.styx.routing.handlers.StaticResponseHandler;
-import com.hotels.styx.routing.handlers.StyxObjectRecord;
+import com.hotels.styx.StyxObjectRecord;
 import com.hotels.styx.routing.interceptors.RewriteInterceptor;
 import com.hotels.styx.serviceproviders.ServiceProviderFactory;
+import com.hotels.styx.serviceproviders.StyxServerFactory;
 import com.hotels.styx.services.HealthCheckMonitoringService;
 import com.hotels.styx.services.HealthCheckMonitoringServiceFactory;
 import com.hotels.styx.services.YamlFileConfigurationService;
@@ -81,6 +83,9 @@ public final class Builtins {
     public static final ImmutableMap<String, Schema.FieldType> BUILTIN_SERVICE_PROVIDER_SCHEMAS =
             ImmutableMap.of(HEALTH_CHECK_MONITOR, HealthCheckMonitoringService.SCHEMA,
                     YAML_FILE_CONFIGURATION_SERVICE, YamlFileConfigurationService.SCHEMA);
+
+    public static final ImmutableMap<String, StyxServerFactory> BUILTIN_SERVER_FACTORIES = ImmutableMap.of();
+    public static final ImmutableMap<String, Schema.FieldType> BUILTIN_SERVER_SCHEMAS = ImmutableMap.of();
 
     public static final RouteRefLookup DEFAULT_REFERENCE_LOOKUP = reference -> (request, ctx) ->
             Eventual.of(response(NOT_FOUND)
@@ -183,5 +188,29 @@ public final class Builtins {
         checkArgument(constructor != null, format("Unknown service provider type '%s' for '%s' provider", providerDef.type(), providerDef.name()));
 
         return constructor.create(name, context, providerDef.config(), serviceDb);
+    }
+
+    /**
+     * Builds a Styx server.
+     *
+     * Styx server is a service that can accept incoming traffic from the client hosts.
+     *
+     * @param name Styx service name
+     * @param serverDef Styx service object configuration
+     * @param factories Service provider factories by name
+     * @param context Routing object factory context
+     *
+     * @return a Styx service
+     */
+    public static InetServer buildServer(
+            String name,
+            StyxObjectDefinition serverDef,
+            StyxObjectStore<StyxObjectRecord<InetServer>> serverDb,
+            Map<String, StyxServerFactory> factories,
+            RoutingObjectFactory.Context context) {
+        StyxServerFactory constructor = factories.get(serverDef.type());
+        checkArgument(constructor != null, format("Unknown server type '%s' for '%s' provider", serverDef.type(), serverDef.name()));
+
+        return constructor.create(name, context, serverDef.config(), serverDb);
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/main/java/com/hotels/styx/serviceproviders/StyxServerFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/serviceproviders/StyxServerFactory.java
@@ -16,7 +16,7 @@
 package com.hotels.styx.serviceproviders;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.hotels.styx.api.extension.service.spi.StyxService;
+import com.hotels.styx.InetServer;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
 import com.hotels.styx.routing.db.StyxObjectStore;
 import com.hotels.styx.StyxObjectRecord;
@@ -26,7 +26,7 @@ import com.hotels.styx.StyxObjectRecord;
  * until read from configuration.
  *
  */
-public interface ServiceProviderFactory {
+public interface StyxServerFactory {
     /**
      * Create a service provider instance.
      *
@@ -37,5 +37,5 @@ public interface ServiceProviderFactory {
      *
      * @return Styx service instance
      */
-    StyxService create(String name, RoutingObjectFactory.Context context, JsonNode serviceConfiguration, StyxObjectStore<StyxObjectRecord<StyxService>> serviceDb);
+    InetServer create(String name, RoutingObjectFactory.Context context, JsonNode serviceConfiguration, StyxObjectStore<StyxObjectRecord<InetServer>> serviceDb);
 }

--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.AsyncEventBus;
 import com.hotels.styx.Environment;
 import com.hotels.styx.NettyExecutor;
+import com.hotels.styx.InetServer;
 import com.hotels.styx.StartupConfig;
 import com.hotels.styx.StyxConfig;
 import com.hotels.styx.Version;
@@ -41,7 +42,7 @@ import com.hotels.styx.routing.config.RoutingObjectFactory;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
 import com.hotels.styx.routing.db.StyxObjectStore;
 import com.hotels.styx.routing.handlers.RouteRefLookup.RouteDbRefLookup;
-import com.hotels.styx.routing.handlers.StyxObjectRecord;
+import com.hotels.styx.StyxObjectRecord;
 import com.hotels.styx.startup.extensions.ConfiguredPluginFactory;
 import org.slf4j.Logger;
 
@@ -53,6 +54,7 @@ import static com.hotels.styx.StartupConfig.newStartupConfigBuilder;
 import static com.hotels.styx.Version.readVersionFrom;
 import static com.hotels.styx.infrastructure.logging.LOGBackConfigurer.initLogging;
 import static com.hotels.styx.routing.config.Builtins.BUILTIN_HANDLER_FACTORIES;
+import static com.hotels.styx.routing.config.Builtins.BUILTIN_SERVER_FACTORIES;
 import static com.hotels.styx.routing.config.Builtins.BUILTIN_SERVICE_PROVIDER_FACTORIES;
 import static com.hotels.styx.routing.config.Builtins.INTERCEPTOR_FACTORIES;
 import static com.hotels.styx.startup.ServicesLoader.SERVICES_FROM_CONFIG;
@@ -73,9 +75,9 @@ public class StyxServerComponents {
     private final List<NamedPlugin> plugins;
     private final StyxObjectStore<RoutingObjectRecord> routeObjectStore = new StyxObjectStore<>();
     private final StyxObjectStore<StyxObjectRecord<StyxService>> providerObjectStore = new StyxObjectStore<>();
+    private final StyxObjectStore<StyxObjectRecord<InetServer>> serverObjectStore = new StyxObjectStore<>();
     private final RoutingObjectFactory.Context routingObjectContext;
     private final StartupConfig startupConfig;
-    private final Map<String, RoutingObjectFactory> routingObjectFactories;
 
     private static final Logger LOGGER = getLogger(StyxServerComponents.class);
     private final NettyExecutor executor;
@@ -84,7 +86,7 @@ public class StyxServerComponents {
         StyxConfig styxConfig = requireNonNull(builder.styxConfig);
 
         this.startupConfig = builder.startupConfig == null ? newStartupConfigBuilder().build() : builder.startupConfig;
-        this.routingObjectFactories = new ImmutableMap.Builder<String, RoutingObjectFactory>()
+        Map<String, RoutingObjectFactory> routingObjectFactories = new ImmutableMap.Builder<String, RoutingObjectFactory>()
                 .putAll(BUILTIN_HANDLER_FACTORIES)
                 .putAll(builder.additionalRoutingObjectFactories)
                 .build();
@@ -104,7 +106,7 @@ public class StyxServerComponents {
                 new RouteDbRefLookup(this.routeObjectStore),
                 environment,
                 routeObjectStore,
-                this.routingObjectFactories,
+                routingObjectFactories,
                 plugins,
                 INTERCEPTOR_FACTORIES,
                 false);
@@ -132,16 +134,20 @@ public class StyxServerComponents {
                 .map(StyxServerComponents::readComponents)
                 .orElse(ImmutableMap.of())
                 .forEach((name, definition) -> {
-                    LOGGER.warn("Starting provider: " + name + ": " + definition);
-
-                    // Build provider object
+                    LOGGER.warn("Loading provider: " + name + ": " + definition);
                     StyxService provider = Builtins.build(name, definition, providerObjectStore, BUILTIN_SERVICE_PROVIDER_FACTORIES, routingObjectContext);
-
-                    // Create a provider object record
                     StyxObjectRecord<StyxService> record = new StyxObjectRecord<>(definition.type(), ImmutableSet.copyOf(definition.tags()), definition.config(), provider);
-
-                    // Insert provider object record into database
                     providerObjectStore.insert(name, record);
+                });
+
+        this.environment.configuration().get("servers", JsonNode.class)
+                .map(StyxServerComponents::readComponents)
+                .orElse(ImmutableMap.of())
+                .forEach((name, definition) -> {
+                    LOGGER.warn("Loading styx server: " + name + ": " + definition);
+                    InetServer provider = Builtins.buildServer(name, definition, serverObjectStore, BUILTIN_SERVER_FACTORIES, routingObjectContext);
+                    StyxObjectRecord<InetServer> record = new StyxObjectRecord<>(definition.type(), ImmutableSet.copyOf(definition.tags()), definition.config(), provider);
+                    serverObjectStore.insert(name, record);
                 });
     }
 
@@ -177,6 +183,10 @@ public class StyxServerComponents {
 
     public StyxObjectStore<StyxObjectRecord<StyxService>> servicesDatabase() {
         return this.providerObjectStore;
+    }
+
+    public StyxObjectStore<StyxObjectRecord<InetServer>> serversDatabase() {
+        return this.serverObjectStore;
     }
 
     public RoutingObjectFactory.Context routingObjectFactoryContext() {

--- a/components/proxy/src/main/kotlin/com/hotels/styx/ServiceProviderMonitor.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/ServiceProviderMonitor.kt
@@ -18,7 +18,6 @@ package com.hotels.styx;
 import com.hotels.styx.api.extension.service.spi.AbstractStyxService
 import com.hotels.styx.api.extension.service.spi.StyxService
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.routing.handlers.StyxObjectRecord
 import org.slf4j.LoggerFactory.getLogger
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicReference

--- a/components/proxy/src/main/kotlin/com/hotels/styx/StyxObjectRecord.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/StyxObjectRecord.kt
@@ -27,6 +27,6 @@ data class StyxObjectRecord<T: StyxService>(
         val config: JsonNode,
         val styxService: T)
 
-typealias ProviderObjectRecord = StyxObjectRecord<StyxService>
+internal typealias ProviderObjectRecord = StyxObjectRecord<StyxService>
 
-typealias ServerObjectRecord = StyxObjectRecord<InetServer>
+internal typealias ServerObjectRecord = StyxObjectRecord<InetServer>

--- a/components/proxy/src/main/kotlin/com/hotels/styx/StyxObjectRecord.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/StyxObjectRecord.kt
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-package com.hotels.styx.routing.handlers
+package com.hotels.styx
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.hotels.styx.api.extension.service.spi.StyxService
@@ -21,10 +21,12 @@ import com.hotels.styx.api.extension.service.spi.StyxService
 /**
  * A routing object and its associated configuration metadata.
  */
-internal data class StyxObjectRecord<T : StyxService>(
+data class StyxObjectRecord<T: StyxService>(
         val type: String,
         val tags: Set<String>,
         val config: JsonNode,
         val styxService: T)
 
-internal typealias ProviderObjectRecord = StyxObjectRecord<StyxService>
+typealias ProviderObjectRecord = StyxObjectRecord<StyxService>
+
+typealias ServerObjectRecord = StyxObjectRecord<InetServer>

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthCheckMonitoringService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthCheckMonitoringService.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import com.hotels.styx.routing.RoutingObject
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.RoutingObjectFactory
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.ProviderObjectRecord
 import com.hotels.styx.serviceproviders.ServiceProviderFactory
 import com.hotels.styx.services.HealthCheckMonitoringService.Companion.EXECUTOR
 import org.slf4j.LoggerFactory

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsAdminHandler.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsAdminHandler.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import com.hotels.styx.infrastructure.configuration.json.mixins.ErrorResponseMix
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.Builtins.HEALTH_CHECK_MONITOR
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.ProviderObjectRecord
 import java.nio.charset.StandardCharsets.UTF_8
 
 /**

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsConfigConverter.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsConfigConverter.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import com.hotels.styx.routing.config.StyxObjectDefinition
 import com.hotels.styx.routing.db.StyxObjectStore
 import com.hotels.styx.routing.handlers.HostProxy.HostProxyConfiguration
 import com.hotels.styx.routing.handlers.LoadBalancingGroup
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.ProviderObjectRecord
 import org.slf4j.LoggerFactory
 
 internal class OriginsConfigConverter(

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.RoutingObjectFactory
 import com.hotels.styx.routing.config.StyxObjectDefinition
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.ProviderObjectRecord
 import com.hotels.styx.server.handlers.ClassPathResourceHandler
 import com.hotels.styx.serviceproviders.ServiceProviderFactory
 import com.hotels.styx.services.OriginsConfigConverter.Companion.deserialiseOrigins

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ProviderListHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ProviderListHandlerTest.java
@@ -25,7 +25,7 @@ import com.hotels.styx.api.extension.service.spi.AbstractStyxService;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.common.http.handler.HttpContentHandler;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.StyxObjectRecord;
+import com.hotels.styx.StyxObjectRecord;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ServiceProviderHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ServiceProviderHandlerTest.java
@@ -22,7 +22,7 @@ import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.routing.handlers.StyxObjectRecord;
+import com.hotels.styx.StyxObjectRecord;
 import com.hotels.styx.server.HttpInterceptorContext;
 import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;

--- a/components/proxy/src/test/java/com/hotels/styx/startup/CoreMetricsTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/startup/CoreMetricsTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/test/kotlin/com/hotels/styx/ServiceProviderMonitorTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/ServiceProviderMonitorTest.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.hotels.styx
 
 import com.hotels.styx.api.extension.service.spi.StyxService
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
 import com.hotels.styx.services.record
 import io.kotlintest.specs.FeatureSpec
 import io.mockk.mockk

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/RoutingObjectRecordTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/RoutingObjectRecordTest.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/config/BuiltinsTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/config/BuiltinsTest.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import com.hotels.styx.routing.RoutingObject
 import com.hotels.styx.routing.RoutingObjectFactoryContext
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.ProviderObjectRecord
 import com.hotels.styx.routing.handlers.RouteRefLookup
 import com.hotels.styx.server.HttpInterceptorContext
 import com.hotels.styx.serviceproviders.ServiceProviderFactory

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/HealthChecksTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/HealthChecksTest.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import com.hotels.styx.api.extension.service.spi.StyxService
 import com.hotels.styx.routing.RoutingObject
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.ProviderObjectRecord
 import com.hotels.styx.routing.handlers.StaticResponseHandler
 import io.kotlintest.matchers.boolean.shouldBeFalse
 import io.kotlintest.matchers.boolean.shouldBeTrue

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsAdminHandlerTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsAdminHandlerTest.kt
@@ -35,8 +35,8 @@ import com.hotels.styx.routing.RoutingMetadataDecorator
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.Builtins.HEALTH_CHECK_MONITOR
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
-import com.hotels.styx.routing.handlers.StyxObjectRecord
+import com.hotels.styx.ProviderObjectRecord
+import com.hotels.styx.StyxObjectRecord
 import com.hotels.styx.routing.mockObject
 import com.hotels.styx.server.HttpInterceptorContext
 import com.hotels.styx.sourceTag

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsConfigConverterTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsConfigConverterTest.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.hotels.styx.lbGroupTag
 import com.hotels.styx.routing.RoutingObjectFactoryContext
 import com.hotels.styx.routing.config.Builtins.INTERCEPTOR_PIPELINE
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.ProviderObjectRecord
 import com.hotels.styx.services.OriginsConfigConverter.Companion.deserialiseOrigins
 import com.hotels.styx.services.OriginsConfigConverter.Companion.loadBalancingGroup
 import com.hotels.styx.stateTag

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceDuplicateIdentifiersTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceDuplicateIdentifiersTest.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package com.hotels.styx.services
 
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.ProviderObjectRecord
 import com.hotels.styx.services.YamlFileConfigurationServiceTest.OriginsServiceConfiguration
 import com.hotels.styx.support.matchers.LoggingTestSupport
 import io.kotlintest.Spec

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import com.hotels.styx.routing.RoutingObjectFactoryContext
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.db.StyxObjectStore
 import com.hotels.styx.routing.handlers.PathPrefixRouter
-import com.hotels.styx.routing.handlers.ProviderObjectRecord
+import com.hotels.styx.ProviderObjectRecord
 import io.kotlintest.Matcher
 import io.kotlintest.MatcherResult
 import io.kotlintest.Spec

--- a/components/server/src/main/java/com/hotels/styx/InetServer.java
+++ b/components/server/src/main/java/com/hotels/styx/InetServer.java
@@ -1,0 +1,33 @@
+/*
+  Copyright (C) 2013-2020 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx;
+
+import com.hotels.styx.api.extension.service.spi.StyxService;
+
+import java.net.InetSocketAddress;
+
+/**
+ * A Styx Server is a StyxService with a server socket.
+ */
+public interface InetServer extends StyxService {
+
+    /**
+     * Return an associated server address.
+     *
+     * @return a server Inet address and port.
+     */
+    InetSocketAddress inetAddress();
+}

--- a/components/server/src/main/java/com/hotels/styx/server/HttpServers.java
+++ b/components/server/src/main/java/com/hotels/styx/server/HttpServers.java
@@ -16,6 +16,7 @@
 package com.hotels.styx.server;
 
 import com.hotels.styx.NettyExecutor;
+import com.hotels.styx.InetServer;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.server.netty.NettyServerBuilder;
 import com.hotels.styx.server.netty.WebServerConnectorFactory;
@@ -30,7 +31,7 @@ public class HttpServers {
      * @param port
      * @return {@link com.hotels.styx.server.HttpServer} object
      */
-    public static HttpServer createHttpServer(int port, HttpHandler handler) {
+    public static InetServer createHttpServer(int port, HttpHandler handler) {
         return NettyServerBuilder.newBuilder()
                 .setProtocolConnector(new WebServerConnectorFactory().create(new HttpConnectorConfig(port)))
                 .handler(handler)
@@ -47,7 +48,7 @@ public class HttpServers {
      *
      * @return {@link com.hotels.styx.server.HttpServer} object
      */
-    public static HttpServer createHttpServer(String name, HttpConnectorConfig httpConnectorConfig, HttpHandler handler) {
+    public static InetServer createHttpServer(String name, HttpConnectorConfig httpConnectorConfig, HttpHandler handler) {
         return NettyServerBuilder.newBuilder()
                 .setProtocolConnector(new WebServerConnectorFactory().create(httpConnectorConfig))
                 .handler(handler)
@@ -64,7 +65,7 @@ public class HttpServers {
      *
      * @return {@link com.hotels.styx.server.HttpServer} object
      */
-    public static HttpServer createHttpsServer(String name, HttpsConnectorConfig httpsConnectorConfig, HttpHandler handler) {
+    public static InetServer createHttpsServer(String name, HttpsConnectorConfig httpsConnectorConfig, HttpHandler handler) {
         return NettyServerBuilder.newBuilder()
                 .setProtocolConnector(new WebServerConnectorFactory().create(httpsConnectorConfig))
                 .handler(handler)

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
@@ -63,7 +63,6 @@ final class NettyServer extends AbstractStyxService implements InetServer {
     private volatile InetSocketAddress address;
 
     NettyServer(NettyServerBuilder nettyServerBuilder) {
-        // Ideally host:port as a service name:
         super("");
         this.host = nettyServerBuilder.host();
         this.channelGroup = requireNonNull(nettyServerBuilder.channelGroup());
@@ -163,7 +162,8 @@ final class NettyServer extends AbstractStyxService implements InetServer {
         @Override
         public Void call() {
             channelGroup.close().awaitUninterruptibly();
-            // TODO: Mikko: check why the return value is never used:
+            // Note: The return values from the shutdown methods is ignored.
+            //       Not sure why.
             shutdownEventExecutorGroup(bossGroup);
             shutdownEventExecutorGroup(workerGroup);
             return null;

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
@@ -15,10 +15,10 @@
  */
 package com.hotels.styx.server.netty;
 
-import com.google.common.util.concurrent.AbstractService;
 import com.hotels.styx.NettyExecutor;
+import com.hotels.styx.InetServer;
 import com.hotels.styx.api.HttpHandler;
-import com.hotels.styx.server.HttpServer;
+import com.hotels.styx.api.extension.service.spi.AbstractStyxService;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
@@ -32,6 +32,7 @@ import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.base.Throwables.propagate;
 import static io.netty.channel.ChannelOption.ALLOCATOR;
@@ -47,7 +48,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 /**
  * NettyServer.
  */
-final class NettyServer extends AbstractService implements HttpServer {
+final class NettyServer extends AbstractStyxService implements InetServer {
     private static final Logger LOGGER = getLogger(NettyServer.class);
 
     private final ChannelGroup channelGroup;
@@ -62,6 +63,8 @@ final class NettyServer extends AbstractService implements HttpServer {
     private volatile InetSocketAddress address;
 
     NettyServer(NettyServerBuilder nettyServerBuilder) {
+        // Ideally host:port as a service name:
+        super("");
         this.host = nettyServerBuilder.host();
         this.channelGroup = requireNonNull(nettyServerBuilder.channelGroup());
         this.handler = requireNonNull(nettyServerBuilder.handler());
@@ -84,8 +87,10 @@ final class NettyServer extends AbstractService implements HttpServer {
     }
 
     @Override
-    protected void doStart() {
+    protected CompletableFuture<Void> startService() {
         LOGGER.info("starting services");
+
+        CompletableFuture<Void> serviceFuture = new CompletableFuture<>();
 
         ServerBootstrap b = new ServerBootstrap();
 
@@ -115,24 +120,28 @@ final class NettyServer extends AbstractService implements HttpServer {
                         address = (InetSocketAddress) channel.localAddress();
                         LOGGER.info("server connector {} bound successfully on port {} socket port {}", new Object[]{serverConnector.getClass(), port, address});
                         stopper = new Stopper(bossExecutor, workerExecutor);
-                        notifyStarted();
+                        serviceFuture.complete(null);
                     } else {
                         LOGGER.warn("Failed to start service={} cause={}", this, future.cause());
-                        notifyFailed(mapToBetterException(future.cause(), port));
+                        serviceFuture.completeExceptionally(mapToBetterException(future.cause(), port));
                     }
                 });
+
+        return serviceFuture;
     }
 
     @Override
-    protected void doStop() {
-        try {
-            if (stopper != null) {
-                stopper.call();
-                address = null;
+    protected CompletableFuture<Void> stopService() {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                if (stopper != null) {
+                    stopper.call();
+                    address = null;
+                }
+            } catch (Exception e) {
+                throw propagate(e);
             }
-        } catch (Exception e) {
-            throw propagate(e);
-        }
+        });
     }
 
     private Throwable mapToBetterException(Throwable cause, int port) {
@@ -154,9 +163,9 @@ final class NettyServer extends AbstractService implements HttpServer {
         @Override
         public Void call() {
             channelGroup.close().awaitUninterruptibly();
+            // TODO: Mikko: check why the return value is never used:
             shutdownEventExecutorGroup(bossGroup);
             shutdownEventExecutorGroup(workerGroup);
-            notifyStopped();
             return null;
         }
 

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerBuilder.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServerBuilder.java
@@ -16,10 +16,10 @@
 package com.hotels.styx.server.netty;
 
 import com.hotels.styx.NettyExecutor;
+import com.hotels.styx.InetServer;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.MetricRegistry;
-import com.hotels.styx.server.HttpServer;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -105,7 +105,7 @@ public final class NettyServerBuilder {
         return httpConnector;
     }
 
-    public HttpServer build() {
+    public InetServer build() {
         checkArgument(httpConnector != null, "Must configure a protocol connector");
         checkArgument(workerExecutor != null, "Must configure a worker executor");
 

--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpResponseWriter.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpResponseWriter.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/system-tests/e2e-suite/src/test/java/com/hotels/styx/http/StaticFileOnRealServerIT.java
+++ b/system-tests/e2e-suite/src/test/java/com/hotels/styx/http/StaticFileOnRealServerIT.java
@@ -16,11 +16,13 @@
 package com.hotels.styx.http;
 
 import com.google.common.io.Files;
+import com.google.common.util.concurrent.Service;
+import com.hotels.styx.InetServer;
+import com.hotels.styx.StyxServers;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.client.HttpClient;
 import com.hotels.styx.client.StyxHttpClient;
-import com.hotels.styx.server.HttpServer;
 import com.hotels.styx.server.handlers.StaticFileHandler;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -44,7 +46,8 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 public class StaticFileOnRealServerIT {
     private final HttpClient client = new StyxHttpClient.Builder().build();
 
-    private HttpServer webServer;
+    private InetServer webServer;
+    private Service guavaService;
     private File dir;
     private String serverEndpoint;
 
@@ -56,7 +59,8 @@ public class StaticFileOnRealServerIT {
     public void startServer() {
         dir = Files.createTempDir();
         webServer = createHttpServer(0, new StaticFileHandler(dir));
-        webServer.startAsync().awaitRunning();
+        guavaService = StyxServers.toGuavaService(webServer);
+        guavaService.startAsync().awaitRunning();
         serverEndpoint = toHostAndPort(webServer.inetAddress());
     }
 
@@ -64,7 +68,7 @@ public class StaticFileOnRealServerIT {
     @AfterAll
     public void stopServer() {
         dir.delete();
-        webServer.stopAsync().awaitTerminated();
+        guavaService.stopAsync().awaitTerminated();
     }
 
     @Test

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/MockServer.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/MockServer.scala
@@ -60,6 +60,7 @@ class MockServer(id: String, val port: Int) extends AbstractIdleService with Htt
       .workerExecutor(NettyExecutor.create("MockServer", 1))
       .handler(router)
     .build()
+  val guavaService = StyxServers.toGuavaService(server)
 
   def takeRequest(): LiveHttpRequest = {
     requestQueue.poll
@@ -79,13 +80,13 @@ class MockServer(id: String, val port: Int) extends AbstractIdleService with Htt
   }
 
   override def startUp(): Unit = {
-    server.startAsync().awaitRunning()
+    guavaService.startAsync().awaitRunning()
     logger.info("mock server started on port " + server.inetAddress().getPort)
   }
 
   override def shutDown(): Unit = {
     logger.info(s"mock server running on port ${server.inetAddress().getPort} stopping")
-    server.stopAsync().awaitTerminated()
+    guavaService.stopAsync().awaitTerminated()
   }
 
   override def inetAddress(): InetSocketAddress = {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedUploadSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedUploadSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -322,12 +322,4 @@ class ChunkedUploadSpec extends FunSpec
       })
   }
 
-  def originAndWebServer(appId: String, originId: String) = {
-    val serverPort = freePort()
-    val origin = newOriginBuilder("localhost", serverPort).applicationId("app").id("app1").build()
-    val server = createHttpServer(serverPort, new HttpAggregator(new ContentDigestHandler(origin)))
-    server.startAsync().awaitRunning()
-
-    origin -> server
-  }
 }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/TlsErrorSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/https/TlsErrorSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/NettyOrigins.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/NettyOrigins.scala
@@ -15,9 +15,13 @@
  */
 package com.hotels.styx.support
 
+import java.net.InetSocketAddress
+import java.util.concurrent.{Executor, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
 
 import com.hotels.styx.NettyExecutor
+import com.google.common.util.concurrent.Service
+import com.hotels.styx.{InetServer, StyxServers}
 import com.hotels.styx.api.HttpHandler
 import com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH
 import com.hotels.styx.api.Id._
@@ -52,11 +56,40 @@ trait NettyOrigins {
   val customResponseHandler = new CustomResponseHandler()
 
   def customResponseWebServer(port: Int, responseHandler: CustomResponseHandler): HttpServer = {
-    val server: HttpServer = new NettyServerBuilder()
+    val server: InetServer = new NettyServerBuilder()
       .setProtocolConnector(new NettyHttpServerConnector(port, responseHandler))
       .workerExecutor(NettyExecutor.create("Netty Test Origin", 1))
       .build()
-    server
+
+    new HttpServer {
+      /**
+       * Return http endpoint
+       */
+
+      val guavaService = StyxServers.toGuavaService(server)
+
+      override def inetAddress(): InetSocketAddress = server.inetAddress()
+
+      override def startAsync(): Service = guavaService.startAsync()
+
+      override def isRunning: Boolean = guavaService.isRunning
+
+      override def state(): Service.State = guavaService.state()
+
+      override def stopAsync(): Service = guavaService.stopAsync()
+
+      override def awaitRunning(): Unit = guavaService.awaitRunning()
+
+      override def awaitRunning(timeout: Long, unit: TimeUnit): Unit = guavaService.awaitRunning(timeout, unit)
+
+      override def awaitTerminated(): Unit = guavaService.awaitTerminated()
+
+      override def awaitTerminated(timeout: Long, unit: TimeUnit): Unit = guavaService.awaitTerminated(timeout, unit)
+
+      override def failureCause(): Throwable = guavaService.failureCause()
+
+      override def addListener(listener: Service.Listener, executor: Executor): Unit = guavaService.addListener(listener, executor)
+    }
 
   }
 

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/MockOriginServer.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/servers/MockOriginServer.java
@@ -32,10 +32,11 @@ import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.http.StubResponseRenderer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ServiceManager;
+import com.hotels.styx.InetServer;
+import com.hotels.styx.StyxServers;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.server.HttpConnectorConfig;
-import com.hotels.styx.server.HttpServer;
 import com.hotels.styx.server.HttpServers;
 import com.hotels.styx.server.HttpsConnectorConfig;
 import io.netty.buffer.ByteBuf;
@@ -60,8 +61,8 @@ public final class MockOriginServer {
     private final int adminPort;
 
     private int serverPort;
-    private final HttpServer adminServer;
-    private final HttpServer mockServer;
+    private final InetServer adminServer;
+    private final InetServer mockServer;
 
     static {
         System.setProperty("org.mortbay.log.class", "com.github.tomakehurst.wiremock.jetty.LoggerAdapter");
@@ -69,7 +70,7 @@ public final class MockOriginServer {
 
     private ServiceManager services;
 
-    private MockOriginServer(String appId, String originId, int adminPort, int serverPort, HttpServer adminServer, HttpServer mockServer) {
+    private MockOriginServer(String appId, String originId, int adminPort, int serverPort, InetServer adminServer, InetServer mockServer) {
         this.appId = appId;
         this.originId = originId;
         this.adminPort = adminPort;
@@ -80,8 +81,8 @@ public final class MockOriginServer {
 
     public static MockOriginServer create(String appId, String originId, int adminPort, HttpConnectorConfig httpConfig) {
         WireMockApp wireMockApp = wireMockApp();
-        HttpServer adminServer = createAdminServer(originId, adminPort, wireMockApp);
-        HttpServer mockServer = HttpServers.createHttpServer(
+        InetServer adminServer = createAdminServer(originId, adminPort, wireMockApp);
+        InetServer mockServer = HttpServers.createHttpServer(
                 "mock-stub-" + originId,
                 httpConfig,
                 mockHandler(originId, wireMockApp, new WireMockConfiguration()));
@@ -92,8 +93,8 @@ public final class MockOriginServer {
 
     public static MockOriginServer create(String appId, String originId, int adminPort, HttpsConnectorConfig httpsConfig) {
         WireMockApp wireMockApp = wireMockApp();
-        HttpServer adminServer = createAdminServer(originId, adminPort, wireMockApp);
-        HttpServer mockServer = HttpServers.createHttpsServer(
+        InetServer adminServer = createAdminServer(originId, adminPort, wireMockApp);
+        InetServer mockServer = HttpServers.createHttpsServer(
                 "mock-stub-" + originId,
                 httpsConfig,
                 mockHandler(originId, wireMockApp, new WireMockConfiguration()));
@@ -138,7 +139,7 @@ public final class MockOriginServer {
     }
 
     public MockOriginServer start() {
-        services = new ServiceManager(ImmutableList.of(adminServer, mockServer));
+        services = new ServiceManager(ImmutableList.of(StyxServers.toGuavaService(adminServer), StyxServers.toGuavaService(mockServer)));
         services.startAsync().awaitHealthy();
         return this;
     }
@@ -214,7 +215,7 @@ public final class MockOriginServer {
         );
     }
 
-    private static HttpServer createAdminServer(String originId, int adminPort, WireMockApp wireMockApp) {
+    private static InetServer createAdminServer(String originId, int adminPort, WireMockApp wireMockApp) {
         return HttpServers.createHttpServer(
                 "mock-admin-" + originId,
                 new HttpConnectorConfig(adminPort),


### PR DESCRIPTION
## Description

Introduces a new `InetServer` interface that is a `StyxService` with a server `InetAddress`. It is an Internet server that accepts incoming connections on a specified port. The interface is not limited to HTTP. It can be anything as long as it opens a server port. 

Because `InetServer` is a `StyxService`, it can be started and stopped with the usual Styx service framework.

Extend the Styx configuration object model to accommodate these new `InetSerever` objects. This allows used to configure styx server objects like so:

```
servers:
  myHttpServer:
    type: HttpServer
    config:
      port: 8080
      tlsSettings:
       ...
```

This PR doesn't yet provide any server implementations. Therefore the above configuration wouldn't work against this PR. This PR just extends the configuration framework into which new server implementations can be added.

## Open Issues

- The `InetServer` interface should really be called `StyxServer`. But this name is already taken, and changing it would break some existing consumers. 

- Styx services must be converted to Guava Services before they can be started. This is really inconvenient at times (in tests only), as you need two separate objects. One for the styx service to read the port number, another for starting/stopping the service.

- NettyServer service name.
