### PR TITLE
Add fragment() to Url API

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/Url.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Url.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/api/src/main/java/com/hotels/styx/api/Url.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Url.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.api;
 
 import javax.annotation.concurrent.ThreadSafe;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -32,9 +31,7 @@ import java.util.regex.Pattern;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Throwables.propagate;
-import static com.hotels.styx.api.URLEncoder.encodePathSegment;
 import static java.lang.Integer.parseInt;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -44,8 +41,6 @@ import static java.util.Collections.emptySet;
  */
 @ThreadSafe
 public final class Url implements Comparable<Url> {
-    private static final String PATH_DELIMITER = "/";
-
     private final String scheme;
     private final Optional<Authority> authority;
     private final String path;
@@ -235,14 +230,6 @@ public final class Url implements Comparable<Url> {
      */
     public String encodedUri() {
         return toString();
-    }
-
-    private static CharSequence encodePathElement(String pathElement) {
-        try {
-            return encodePathSegment(pathElement, UTF_8.toString());
-        } catch (UnsupportedEncodingException ignore) {
-            return pathElement;
-        }
     }
 
     @Override

--- a/components/api/src/main/java/com/hotels/styx/api/Url.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Url.java
@@ -16,6 +16,9 @@
 package com.hotels.styx.api;
 
 import javax.annotation.concurrent.ThreadSafe;
+
+import com.google.common.annotations.VisibleForTesting;
+
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -164,12 +167,8 @@ public final class Url implements Comparable<Url> {
         }
     }
 
-    /**
-     * The query part of the URL.
-     *
-     * @return query
-     */
-    public Optional<UrlQuery> query() {
+    @VisibleForTesting
+    Optional<UrlQuery> query() {
         return this.query;
     }
 

--- a/components/api/src/main/java/com/hotels/styx/api/Url.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Url.java
@@ -77,7 +77,7 @@ public final class Url implements Comparable<Url> {
     }
 
     /**
-     * The fragment part of the URL
+     * The fragment part of the URL.
      *
      * @return fragment, if present
      */

--- a/components/api/src/main/java/com/hotels/styx/api/Url.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Url.java
@@ -79,6 +79,15 @@ public final class Url implements Comparable<Url> {
     }
 
     /**
+     * The fragment part of the URL
+     *
+     * @return fragment, if present
+     */
+    public Optional<String> fragment() {
+        return Optional.ofNullable(fragment);
+    }
+
+    /**
      * The authority of the URL, e.g. host, host:port, user@host:port, etc.
      *
      * @return authority if present

--- a/components/api/src/main/java/com/hotels/styx/api/UrlQuery.java
+++ b/components/api/src/main/java/com/hotels/styx/api/UrlQuery.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
@@ -33,7 +33,7 @@ import static java.util.stream.StreamSupport.stream;
 /**
  * Query part of a URL.
  */
-final class UrlQuery {
+public final class UrlQuery {
     private final List<Parameter> parameters;
     private final String encodedQuery;
 
@@ -62,7 +62,7 @@ final class UrlQuery {
                 .collect(toList());
     }
 
-    List<Parameter> parameters() {
+    public List<Parameter> parameters() {
         return parameters;
     }
 
@@ -71,11 +71,11 @@ final class UrlQuery {
      *
      * @return the names of all query parameters.
      */
-    Iterable<String> parameterNames() {
+    public Iterable<String> parameterNames() {
         return parameters().stream().map(Parameter::key).distinct().collect(toList());
     }
 
-    String encodedQuery() {
+    public String encodedQuery() {
         return encodedQuery;
     }
 
@@ -108,7 +108,7 @@ final class UrlQuery {
                 .toString();
     }
 
-    static class Parameter {
+    public static class Parameter {
         private final String key;
         private final String value;
 

--- a/components/api/src/main/java/com/hotels/styx/api/UrlQuery.java
+++ b/components/api/src/main/java/com/hotels/styx/api/UrlQuery.java
@@ -33,7 +33,7 @@ import static java.util.stream.StreamSupport.stream;
 /**
  * Query part of a URL.
  */
-public final class UrlQuery {
+final class UrlQuery {
     private final List<Parameter> parameters;
     private final String encodedQuery;
 
@@ -62,7 +62,7 @@ public final class UrlQuery {
                 .collect(toList());
     }
 
-    public List<Parameter> parameters() {
+    List<Parameter> parameters() {
         return parameters;
     }
 
@@ -71,11 +71,11 @@ public final class UrlQuery {
      *
      * @return the names of all query parameters.
      */
-    public Iterable<String> parameterNames() {
+    Iterable<String> parameterNames() {
         return parameters().stream().map(Parameter::key).distinct().collect(toList());
     }
 
-    public String encodedQuery() {
+    String encodedQuery() {
         return encodedQuery;
     }
 
@@ -108,7 +108,7 @@ public final class UrlQuery {
                 .toString();
     }
 
-    public static class Parameter {
+    static class Parameter {
         private final String key;
         private final String value;
 

--- a/components/server/src/test/java/com/hotels/styx/server/netty/codec/UrlDecoderTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/codec/UrlDecoderTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.Optional;
 import static io.netty.handler.codec.http.HttpHeaders.Names.HOST;
 import static io.netty.handler.codec.http.HttpMethod.GET;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -41,7 +42,7 @@ public class UrlDecoderTest {
         assertThat(url.isAbsolute(), is(false));
         assertThat(url.isRelative(), is(true));
         assertThat(url.host(), is(Optional.empty()));
-        assertThat(url.query(), is(Optional.empty()));
+        assertThat(url.queryParams(), is(emptyMap()));
         assertThat(url.scheme(), is(""));
     }
 
@@ -59,7 +60,7 @@ public class UrlDecoderTest {
         assertThat(url.isAbsolute(), is(false));
         assertThat(url.isRelative(), is(true));
         assertThat(url.host(), is(Optional.empty()));
-        assertThat(url.query(), is(Optional.empty()));
+        assertThat(url.queryParams(), is(emptyMap()));
         assertThat(url.scheme(), is(""));
     }
 
@@ -77,7 +78,7 @@ public class UrlDecoderTest {
         assertThat(url.isAbsolute(), is(false));
         assertThat(url.isRelative(), is(true));
         assertThat(url.host(), is(Optional.empty()));
-        assertThat(url.query(), is(Optional.empty()));
+        assertThat(url.queryParams(), is(emptyMap()));
         assertThat(url.scheme(), is(""));
     }
 
@@ -94,7 +95,7 @@ public class UrlDecoderTest {
         assertThat(url.isAbsolute(), is(true));
         assertThat(url.isRelative(), is(false));
         assertThat(url.host(), is(Optional.of("example.com")));
-        assertThat(url.query(), is(Optional.empty()));
+        assertThat(url.queryParams(), is(emptyMap()));
         assertThat(url.scheme(), is("http"));
     }
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/HttpResponseSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/HttpResponseSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/OriginClosesConnectionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/OriginClosesConnectionSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AggregatingPluginContentOverflowSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AggregatingPluginContentOverflowSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AggregatingPluginSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AggregatingPluginSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AsyncRequestSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/plugins/AsyncRequestSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/LoggingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/LoggingSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds `fragment()` getter to `Url` class, and hides `Optional <UrlQuery> query()` method.

`Url.query()` returns `Optional<UrlQuery>` which is unusable at present because the class is package private. This change exposes the class and required (non-mutating) methods.