### PR TITLE
Hardening of e2e tests

### DIFF
--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
@@ -749,24 +749,28 @@ class OriginsFileCompatibilitySpec : FunSpec() {
             .start()
             .stub(WireMock.get(WireMock.urlMatching("/.*")), WireMock.aResponse()
                     .withStatus(200)
+                    .withHeader("X-Origin", "Server-A01-server")
                     .withBody("appA-01"))
 
     val mockServerA02 = MockOriginServer.create("appA", "appA-02", 0, HttpConnectorConfig(0))
             .start()
             .stub(WireMock.get(WireMock.urlMatching("/.*")), WireMock.aResponse()
                     .withStatus(200)
+                    .withHeader("X-Origin", "Server-A02-server")
                     .withBody("appA-02"))
 
     val mockServerB01 = MockOriginServer.create("appB", "appB-01", 0, HttpConnectorConfig(0))
             .start()
             .stub(WireMock.get(WireMock.urlMatching("/.*")), WireMock.aResponse()
                     .withStatus(200)
+                    .withHeader("X-Origin", "Server-B01-server")
                     .withBody("appB-01"))
 
     val mockServerC01 = MockOriginServer.create("appC", "appC-01", 0, HttpConnectorConfig(0))
             .start()
             .stub(WireMock.get(WireMock.urlMatching("/.*")), WireMock.aResponse()
                     .withStatus(200)
+                    .withHeader("X-Origin", "Server-C01-server")
                     .withBody("appC-01"))
 
     val mockTlsv12Server = MockOriginServer.create("appTls", "appTls-01", 0,
@@ -778,6 +782,7 @@ class OriginsFileCompatibilitySpec : FunSpec() {
             .start()
             .stub(WireMock.get(WireMock.urlMatching("/.*")), WireMock.aResponse()
                     .withStatus(200)
+                    .withHeader("X-Origin", "TlsV2-server")
                     .withBody("appTls-01"))
 
     override fun afterSpec(spec: Spec) {

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/HostProxySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/HostProxySpec.kt
@@ -18,7 +18,9 @@ package com.hotels.styx.routing
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
+import com.hotels.styx.api.HttpHeaderNames.CHUNKED
 import com.hotels.styx.api.HttpHeaderNames.HOST
+import com.hotels.styx.api.HttpHeaderNames.TRANSFER_ENCODING
 import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.api.HttpResponseStatus.BAD_GATEWAY
 import com.hotels.styx.api.HttpResponseStatus.CREATED
@@ -225,8 +227,16 @@ class HostProxySpec : FeatureSpec() {
                                connectionExpirationSeconds: $connectinExpiryInSeconds
                            """.trimIndent()) shouldBe CREATED
 
+                // NOTE: Connection priming will fail when it encounters "Origin Responded Too Quickly" scenario.
+                //       This may happen when the request is sent with empty body and `Content-Length: 0`.
+                //       This is okay in production. The pooled connection is closed, instead of
+                //       returned back to the pool. But in this test we do need a pooled connection.
+                //
+                //       To avoid this scenario, we will set `Transfer-Encoding: Chunked`, enforcing the origin
+                //       receiver to wait for an additional TCP segment before responding.
                 client.send(get("/")
                         .header(HOST, styxServer().proxyHttpHostHeader())
+                        .header(TRANSFER_ENCODING, CHUNKED)
                         .build())
                         .wait()!!
                         .status() shouldBe OK

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/HostProxySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/routing/HostProxySpec.kt
@@ -401,9 +401,6 @@ class HostProxySpec : FeatureSpec() {
                                     http:
                                       port: 0
                                       
-                                services:
-                                  factories: {}                                     
-
                                 httpPipeline: hostProxy
                               """.trimIndent())
 
@@ -420,9 +417,6 @@ class HostProxySpec : FeatureSpec() {
                                     http:
                                       port: 0
                                       
-                                services:
-                                  factories: {}
-
                                 httpPipeline:
                                   type: ConditionRouter
                                   config:


### PR DESCRIPTION
Improves e2e tests:
- Improve connection pool priming in HostProxySpec.
- Improve instrumentation and test visibility.
