### PR TITLE
YamlFileConfigurationService fails to start health check monitors

### DIFF
--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthCheckMonitoringService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/HealthCheckMonitoringService.kt
@@ -55,7 +55,7 @@ internal class HealthCheckMonitoringService(
         activeThreshold: Int,
         inactiveThreshold: Int,
         private val executor: ScheduledExecutorService,
-        workerExecutor: NettyExecutor = healthCheckExecutor) : AbstractStyxService("HealthCheckMonitoringService") {
+        workerExecutor: NettyExecutor = healthCheckExecutor) : AbstractStyxService("HealthCheckMonitoringService-$application") {
 
     companion object {
         @JvmField

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
@@ -622,7 +622,7 @@ class OriginsFileCompatibilitySpec : FunSpec() {
                             it!!.status() shouldBe OK
                             it.header(CONTENT_TYPE).get().toLowerCase() shouldBe APPLICATION_JSON.toString().toLowerCase()
                             // TODO: This name should probably change.
-                            it.bodyAs(UTF_8) shouldBe "{ name: \"HealthCheckMonitoringService\" status: \"RUNNING\" }"
+                            it.bodyAs(UTF_8) shouldBe "{ name: \"HealthCheckMonitoringService-appB\" status: \"RUNNING\" }"
                         }
             }
 

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/ProviderAdminInterfaceSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/ProviderAdminInterfaceSpec.kt
@@ -106,11 +106,11 @@ class ProviderAdminInterfaceSpec : FeatureSpec() {
             scenario("Exposes endpoints for each provider") {
                 styxServer.adminRequest("/admin/providers/myMonitor/status")
                         .bodyAs(UTF_8)
-                        .shouldBe("""{ name: "HealthCheckMonitoringService" status: "RUNNING" }""")
+                        .shouldBe("""{ name: "HealthCheckMonitoringService-aaa" status: "RUNNING" }""")
 
                 styxServer.adminRequest("/admin/providers/mySecondMonitor/status")
                         .bodyAs(UTF_8)
-                        .shouldBe("""{ name: "HealthCheckMonitoringService" status: "RUNNING" }""")
+                        .shouldBe("""{ name: "HealthCheckMonitoringService-bbb" status: "RUNNING" }""")
             }
 
             scenario ("Provider list page contains links for each provider endpoint") {
@@ -143,7 +143,7 @@ class ProviderAdminInterfaceSpec : FeatureSpec() {
                 val responseB = styxServer.adminRequest("/admin/providers/appB-monitor/status")
                 responseB.status() shouldBe OK
                 responseB.header(CONTENT_TYPE).get().toLowerCase() shouldBe APPLICATION_JSON.toString().toLowerCase()
-                responseB.bodyAs(UTF_8) shouldBe "{ name: \"HealthCheckMonitoringService\" status: \"RUNNING\" }"
+                responseB.bodyAs(UTF_8) shouldBe "{ name: \"HealthCheckMonitoringService-appB\" status: \"RUNNING\" }"
             }
 
             scenario("Endpoints for dynamically removed Styx services are not listed in the Admin interface") {


### PR DESCRIPTION
## Summary

This PR fixes a race condition in `YamlFileConfigurationService` that sometimes prevents it from being able to start health check monitoring services. 

Also, yaml file configuration service now adds a backend service app name in the health check monitoring service name. This is useful as the application name will show up in possible error messages in case other bugs will surface in future.

## User impact

Especially, this bug affects deployments several `YamlFileConfigurationService` providers (more than one). When the health check monitoring service is not started, the relevant `HostProxy` objects for the origin are not added to the load balancing group, and therefore they are always unreachable.

The issue doesn't affect, or is highly unlikely to affect deployments with only one `YamlFileConfigurationService` provider.

## Root cause

Styx object database is a lockless concurrent in-memory database for storing routing/provider/etc objects. Its `compute` method takes a lambda that provides a new styx object that is stored in the database. The `compute` lambda action must idempotent because the database will call it again if it detects a concurrent modification to the database.

But YamlFileConfigurationService was not idempotent. It attempted to start the health check monitoring service in this lambda callback. Therefore, a retry during the concurrent modification caused the health check monitoring service to be started again, thus resulting in an IllegalStateException.

Fixed this by caching the return value from the lambda callback. Consider this as a work around until I figure out something better.
