### PR TITLE
Docker publish preparation

### DIFF
--- a/docker/styx-image/Dockerfile
+++ b/docker/styx-image/Dockerfile
@@ -1,6 +1,11 @@
 ARG TAG=11-jdk
 FROM openjdk:${TAG}
 
+RUN addgroup styx && useradd -d /home/styx -g styx -s /bin/bash styx
+
+# Remove overriding ulimits
+RUN rm -f /etc/security/limits.d/*
+
 ARG STYX_VERSION=""
 ARG STYX_IMAGE=https://github.com/HotelsDotCom/styx/releases/download/${STYX_VERSION}/${STYX_VERSION}-linux-x86_64.zip
 
@@ -21,7 +26,12 @@ ADD origins.yml /styx/default-config/origins.yml
 RUN unzip styx.zip \
     && rm styx.zip
 
+RUN mkdir -p ${STYX_LOG_OUTPUT}
+RUN chown styx:styx ${STYX_LOG_OUTPUT}
+
 EXPOSE 8080 8443 9000
+
+USER styx
 
 CMD ["/styx/default-config/default.yml"]
 

--- a/docker/styx-image/Dockerfile
+++ b/docker/styx-image/Dockerfile
@@ -1,11 +1,6 @@
 ARG TAG=11-jdk
 FROM openjdk:${TAG}
 
-RUN addgroup styx && useradd -d /home/styx -g styx -s /bin/bash styx
-
-# Remove overriding ulimits
-RUN rm -f /etc/security/limits.d/*
-
 ARG STYX_VERSION=""
 ARG STYX_IMAGE=https://github.com/HotelsDotCom/styx/releases/download/${STYX_VERSION}/${STYX_VERSION}-linux-x86_64.zip
 
@@ -15,6 +10,11 @@ ENV STYX_CONFIG=/styx/default-config/default.yml
 ENV STYX_LOG_CONFIG=/styx/conf/logback.xml
 ENV STYX_ENV_FILE=/styx/default-config/styx-env.sh
 ENV STYX_LOG_OUTPUT=/styx/logs/
+
+RUN addgroup styx && useradd -d /home/styx -g styx -s /bin/bash styx
+
+# Remove overriding ulimits
+RUN rm -f /etc/security/limits.d/*
 
 ADD ${STYX_IMAGE} /styx.zip
 RUN unzip /styx.zip \

--- a/docker/styx-image/Dockerfile
+++ b/docker/styx-image/Dockerfile
@@ -12,19 +12,19 @@ ARG STYX_IMAGE=https://github.com/HotelsDotCom/styx/releases/download/${STYX_VER
 ENV APP_HOME=/styx
 
 ENV STYX_CONFIG=/styx/default-config/default.yml
-ENV STYX_LOG_CONFIG=/styx/styx/conf/logback.xml
+ENV STYX_LOG_CONFIG=/styx/conf/logback.xml
 ENV STYX_ENV_FILE=/styx/default-config/styx-env.sh
 ENV STYX_LOG_OUTPUT=/styx/logs/
 
+ADD ${STYX_IMAGE} /styx.zip
+RUN unzip /styx.zip \
+    && rm /styx.zip
+
 WORKDIR ${APP_HOME}
 
-ADD ${STYX_IMAGE} ${APP_HOME}/styx.zip
 ADD default-docker.yml /styx/default-config/default.yml
 ADD styx-env.sh /styx/default-config/styx-env.sh
 ADD origins.yml /styx/default-config/origins.yml
-
-RUN unzip styx.zip \
-    && rm styx.zip
 
 RUN mkdir -p ${STYX_LOG_OUTPUT}
 RUN chown styx:styx ${STYX_LOG_OUTPUT}
@@ -35,4 +35,4 @@ USER styx
 
 CMD ["/styx/default-config/default.yml"]
 
-ENTRYPOINT ["styx/bin/startup"]
+ENTRYPOINT ["bin/startup"]

--- a/docker/styx-image/styx-env.sh
+++ b/docker/styx-image/styx-env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2013-2019 Expedia Inc.
+# Copyright (C) 2013-2020 Expedia Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 JVM_DIRECT_MEMORY="${JVM_DIRECT_MEMORY:=-XX:MaxDirectMemorySize=512m}"
 JVM_HEAP_OPTS="${JVM_HEAP_OPTS:=-XX:+AlwaysPreTouch}"
 
-JVM_GC_LOG="${JVM_GC_LOG:=-XX:+PrintGCDetails -Xloggc:/styx/logs/gc.log.$(/bin/date +%Y-%m-%d-%H%M%S)}"
+JVM_GC_LOG="${JVM_GC_LOG:=-XX:+PrintGCDetails -Xloggc:${APP_HOME}/logs/gc.log.$(/bin/date +%Y-%m-%d-%H%M%S)}"
 JVM_HEAP_DUMP="${JVM_HEAP_DUMP:=-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/tmp}"
 
 # Set java VM type


### PR DESCRIPTION
Prepare to publish a docker image, by:
* Creating and setting a user/group `styx:styx`
* Expanding `styx.zip` to the root of the image rather than as a subfolder of `styx`
* Ensuring the (writable) logging directory `/styx/log` is owned by the `styx` user.