### PR TITLE
Fix a race condition in ServerObjectSpec.

### DIFF
--- a/components/proxy/src/test/kotlin/com/hotels/styx/CommonTagsTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/CommonTagsTest.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/server/ServerObjectSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/server/ServerObjectSpec.kt
@@ -82,7 +82,7 @@ class ServerObjectSpec : FeatureSpec() {
                 styxServer.restart()
 
                 // 1. Query server addresses from the admin interface
-                val httpPort = eventually(2.seconds, AssertionError::class.java) {
+                val httpPort = eventually(2.seconds) {
                     testClient.send(get("/admin/servers/myHttp/port").header(HOST, styxServer().adminHostHeader()).build())
                             .wait()
                             .bodyAs(UTF_8)
@@ -90,7 +90,7 @@ class ServerObjectSpec : FeatureSpec() {
                 }
 
 
-                val httpsPort = eventually(2.seconds, AssertionError::class.java) {
+                val httpsPort = eventually(2.seconds) {
                     testClient.send(get("/admin/servers/myHttps/port").header(HOST, styxServer().adminHostHeader()).build())
                             .wait()
                             .bodyAs(UTF_8)

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/server/ServerObjectSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/server/ServerObjectSpec.kt
@@ -24,6 +24,8 @@ import com.hotels.styx.support.adminHostHeader
 import com.hotels.styx.support.testClient
 import com.hotels.styx.support.wait
 import io.kotlintest.Spec
+import io.kotlintest.eventually
+import io.kotlintest.seconds
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.FeatureSpec
 import java.nio.charset.StandardCharsets.UTF_8
@@ -80,15 +82,20 @@ class ServerObjectSpec : FeatureSpec() {
                 styxServer.restart()
 
                 // 1. Query server addresses from the admin interface
-                val httpPort = testClient.send(get("/admin/servers/myHttp/port").header(HOST, styxServer().adminHostHeader()).build())
-                        .wait()
-                        .bodyAs(UTF_8)
-                        .toInt()
+                val httpPort = eventually(2.seconds, AssertionError::class.java) {
+                    testClient.send(get("/admin/servers/myHttp/port").header(HOST, styxServer().adminHostHeader()).build())
+                            .wait()
+                            .bodyAs(UTF_8)
+                            .toInt()
+                }
 
-                val httpsPort = testClient.send(get("/admin/servers/myHttps/port").header(HOST, styxServer().adminHostHeader()).build())
-                        .wait()
-                        .bodyAs(UTF_8)
-                        .toInt()
+
+                val httpsPort = eventually(2.seconds, AssertionError::class.java) {
+                    testClient.send(get("/admin/servers/myHttps/port").header(HOST, styxServer().adminHostHeader()).build())
+                            .wait()
+                            .bodyAs(UTF_8)
+                            .toInt()
+                }
 
                 // 2. Send a probe to both of them
                 testClient.send(get("/").header(HOST, "localhost:$httpPort").build())


### PR DESCRIPTION
There is a small race in ServerObjectSpec. The server objects have not yet been started before the test attempts to read its port number. Therefore wrap the API call in an eventually block.
