### PR TITLE
Upload binaries compiled with JDK8 to GitHub from the Travis release pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+    jdk: openjdk8
+    repo: HotelsDotCom/styx


### PR DESCRIPTION
Our travis configuration was uploading the binaries, but not explicitly excluding artifacts generated with other jdks (although they are not been built with any other JDK right now).
