### PR TITLE
GH #636 Fix RewriteConfig ending with two consecutive placeholders

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/RewriteConfig.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/RewriteConfig.java
@@ -18,6 +18,7 @@ package com.hotels.styx.api.extension.service;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.MatchResult;
@@ -120,8 +121,11 @@ public class RewriteConfig implements RewriteRule {
         private String substitute(MatchResult matcher) {
             StringBuilder rewrittenUrl = new StringBuilder();
 
+            // There may not be enough literals to fully interleave with placeholders.
+            // This is just how String.split(REGEX) works.
+            // Any remaining literals are assumed to be empty strings.
             for (int i = 0; i < placeholderNumbers.size(); i++) {
-                if (!literals.isEmpty()) {
+                if (literals.size() > i) {
                     rewrittenUrl.append(literals.get(i));
                 }
                 rewrittenUrl.append(matcher.group(placeholderNumbers.get(i)));

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/RewriteConfig.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/RewriteConfig.java
@@ -18,7 +18,6 @@ package com.hotels.styx.api.extension.service;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.MatchResult;

--- a/components/api/src/test/java/com/hotels/styx/api/extension/service/RewriteConfigTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/extension/service/RewriteConfigTest.java
@@ -1,0 +1,37 @@
+package com.hotels.styx.api.extension.service;
+
+import org.hamcrest.CoreMatchers;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class RewriteConfigTest {
+
+    @Test
+    public void testSubstitutions() {
+        String urlPattern = "\\/foo\\/(a|b|c)(\\/.*)?";
+
+        RewriteConfig config = new RewriteConfig(urlPattern, "/bar/$1$2");
+        assertThat(config.rewrite("/foo/b/something").get(), CoreMatchers.equalTo("/bar/b/something"));
+
+        config = new RewriteConfig(urlPattern, "/bar/$1/x$2");
+        assertThat(config.rewrite("/foo/b/something").get(), CoreMatchers.equalTo("/bar/b/x/something"));
+
+        config = new RewriteConfig(urlPattern, "/bar/$1/x$2/y");
+        assertThat(config.rewrite("/foo/b/something").get(), CoreMatchers.equalTo("/bar/b/x/something/y"));
+
+        config = new RewriteConfig(urlPattern, "$1/x$2/y");
+        assertThat(config.rewrite("/foo/b/something").get(), CoreMatchers.equalTo("b/x/something/y"));
+
+        config = new RewriteConfig(urlPattern, "$1$2/y");
+        assertThat(config.rewrite("/foo/b/something").get(), CoreMatchers.equalTo("b/something/y"));
+
+        config = new RewriteConfig(urlPattern, "$1$2");
+        assertThat(config.rewrite("/foo/b/something").get(), CoreMatchers.equalTo("b/something"));
+    }
+}


### PR DESCRIPTION
Fixing #636 
Because of the way String.split(REGEX) works, a RewriteConfig might contain fewer literals than expected, and not enough to interleave fully with its placeholders. Any missing literals should just be assumed to be empty strings.