### PR TITLE
Fix docker-compose.yml in system-tests.

### DIFF
--- a/system-tests/docker-test-env/docker-compose.yml
+++ b/system-tests/docker-test-env/docker-compose.yml
@@ -43,5 +43,3 @@ services:
     command:
      - /styx/config/styxconf.yml
 
-    entrypoint:
-      - styx/bin/startup


### PR DESCRIPTION
Updates `docker-compose.yml` to match with new image layout introduced by PR #630.

