### PR TITLE
Block server start until origins file is loaded.

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ public abstract class AbstractStyxService implements StyxService {
     public CompletableFuture<Void> stop() {
         boolean changed = status.compareAndSet(RUNNING, STOPPING);
 
-        LOGGER.info("Stopping {} failed", name);
+        LOGGER.info("Stopping {}", name);
         if (changed) {
             return stopService()
                     .exceptionally(failWithMessage("Service failed to stop."))

--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -187,7 +187,7 @@ public final class StyxServer extends AbstractService {
         ArrayList<Service> services = new ArrayList<>();
         adminServer = createAdminServer(components);
         services.add(toGuavaService(adminServer));
-        services.add(toGuavaService(new PluginsManager("Sty§x-Plugins-Manager", components)));
+        services.add(toGuavaService(new PluginsManager("Styx-Plugins-Manager", components)));
         services.add(toGuavaService(new ServiceProviderMonitor<>("Styx-Service-Monitor", components.servicesDatabase())));
         components.services().values().forEach(it -> services.add(toGuavaService(it)));
         this.phase1Services = new ServiceManager(services);

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileChangeMonitorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileChangeMonitorTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/test/kotlin/com/hotels/styx/ServiceProviderMonitorTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/ServiceProviderMonitorTest.kt
@@ -24,7 +24,7 @@ import io.mockk.verify
 
 class ServiceProviderMonitorTest : FeatureSpec({
 
-    feature("Service provider lifecycle management") {
+    feature("!Service provider lifecycle management") {
 
         val serviceAaa = mockk<StyxService>(relaxed = true)
         val serviceBbb = mockk<StyxService>(relaxed = true)

--- a/components/proxy/src/test/kotlin/com/hotels/styx/ServiceProviderMonitorTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/ServiceProviderMonitorTest.kt
@@ -15,21 +15,22 @@
  */
 package com.hotels.styx
 
-import com.hotels.styx.api.extension.service.spi.StyxService
+import com.hotels.styx.api.extension.service.spi.AbstractStyxService
+import com.hotels.styx.api.extension.service.spi.StyxServiceStatus.RUNNING
+import com.hotels.styx.api.extension.service.spi.StyxServiceStatus.STOPPED
 import com.hotels.styx.routing.db.StyxObjectStore
 import com.hotels.styx.services.record
+import io.kotlintest.shouldBe
 import io.kotlintest.specs.FeatureSpec
 import io.mockk.mockk
-import io.mockk.verify
 
 class ServiceProviderMonitorTest : FeatureSpec({
 
-    feature("!Service provider lifecycle management") {
+    feature("Service provider lifecycle management") {
 
-        val serviceAaa = mockk<StyxService>(relaxed = true)
-        val serviceBbb = mockk<StyxService>(relaxed = true)
-        val serviceCcc = mockk<StyxService>(relaxed = true)
-
+        val serviceAaa = MockService("aaa")
+        val serviceBbb = MockService("bbb")
+        val serviceCcc = MockService("ccc")
 
         val monitor = ServiceProviderMonitor(
                 "Styx-Service-Monitor",
@@ -43,22 +44,21 @@ class ServiceProviderMonitorTest : FeatureSpec({
         scenario("Starts configured services when styx starts up") {
             monitor.start().get()
 
-            verify {
-                serviceAaa.start()
-                serviceBbb.start()
-                serviceCcc.start()
-            }
+            serviceAaa.status().shouldBe(RUNNING)
+            serviceBbb.status().shouldBe(RUNNING)
+            serviceCcc.status().shouldBe(RUNNING)
         }
 
         scenario("Shuts services when Styx server shuts down") {
             monitor.stop().get()
 
-            verify {
-                serviceAaa.stop()
-                serviceBbb.stop()
-                serviceCcc.stop()
-            }
+            serviceAaa.status().shouldBe(STOPPED)
+            serviceBbb.status().shouldBe(STOPPED)
+            serviceCcc.status().shouldBe(STOPPED)
+
         }
     }
 
 })
+
+private class MockService(val name: String): AbstractStyxService(name)

--- a/system-tests/docker-test-env/styx-config/styxconf.yml
+++ b/system-tests/docker-test-env/styx-config/styxconf.yml
@@ -14,8 +14,15 @@ routingObjects:
       status: 200
       content: "hello-2"
 
+providers:
+  originsFileLoader:
+    type: YamlFileConfigurationService
+    config:
+      originsFile: /styx/config/origins.yml
+      ingressObject: pathPrefixRouter
+      monitor: True
 
-httpPipeline: hello1
+httpPipeline: pathPrefixRouter
 
 servers:
   http:

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
@@ -129,7 +129,6 @@ class OriginsFileCompatibilitySpec : FunSpec() {
             }
         }
 
-        // Test hangs:
         context("Failing to load an initial configuration blocks Styx HTTP server from starting.") {
             writeOrigins("""
                     - id: appA

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
@@ -130,24 +130,18 @@ class OriginsFileCompatibilitySpec : FunSpec() {
         }
 
         // Test hangs:
-        context("!Error scenarios") {
+        context("Failing to load an initial configuration blocks Styx HTTP server from starting.") {
             writeOrigins("""
                     - id: appA
                     - this file has somehow corrupted
                       .. bl;ah blah" 
                     """.trimIndent())
 
-            styxServer.restart()
+            styxServer.restartAsync()
 
             delay(1.seconds.toMillis())
 
-            client.send(get("/20")
-                            .header(HOST, styxServer().proxyHttpHostHeader())
-                            .build())
-                    .wait().let {
-                        it!!.status() shouldBe NOT_FOUND
-                    }
-
+            styxServer().proxyHttpAddress() shouldBe null
             styxServer.stop()
         }
 

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
@@ -129,6 +129,28 @@ class OriginsFileCompatibilitySpec : FunSpec() {
             }
         }
 
+        // Test hangs:
+        context("!Error scenarios") {
+            writeOrigins("""
+                    - id: appA
+                    - this file has somehow corrupted
+                      .. bl;ah blah" 
+                    """.trimIndent())
+
+            styxServer.restart()
+
+            delay(1.seconds.toMillis())
+
+            client.send(get("/20")
+                            .header(HOST, styxServer().proxyHttpHostHeader())
+                            .build())
+                    .wait().let {
+                        it!!.status() shouldBe NOT_FOUND
+                    }
+
+            styxServer.stop()
+        }
+
         context("Origins configuration changes") {
             writeOrigins("""
                 - id: appA


### PR DESCRIPTION
## Problem Description:

`YamlFileConfigurationService` doesn't prevent Styx HTTP server from starting if it doesn't successfully load an initial origins configuration file.

Therefore, Styx server starts without sensible origins configuration. All requests to its HTTP port will return `404 NOT FOUND`, with message `Not found: pathPrefixRouter` in response body.

This affects only the new `YamlFileConfigurationService`. The old monolithic application router is unaffected.

## Root Cause & The Fix

Problem was caused by `ServiceProviderMonitor` which loads all service providers from Yaml `providers` block. It didn't wait for the underlying service providers to be started correctly.

I fixed this by modifying the `ServiceProviderMonitor` class so that it waits for all underlying services to successfully start up before declaring itself as healthy to `phase1` service manager.

