### PR TITLE
Add X-Styx-Origin-Id header to 5xx responses originated from styx.

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/BadHttpResponseException.java
+++ b/components/client/src/main/java/com/hotels/styx/client/BadHttpResponseException.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,7 +15,11 @@
  */
 package com.hotels.styx.client;
 
+import com.hotels.styx.api.Id;
+import com.hotels.styx.api.exceptions.StyxException;
 import com.hotels.styx.api.extension.Origin;
+
+import java.util.Optional;
 
 import static java.lang.String.format;
 
@@ -23,7 +27,7 @@ import static java.lang.String.format;
  * An exception to throw when a bad HTTP response was received. For
  * example, when the decoding of the message failed.
  */
-public class BadHttpResponseException extends RuntimeException {
+public class BadHttpResponseException extends RuntimeException implements StyxException {
     private static final String MESSAGE_FORMAT = "Bad HTTP Response received from origin. origin=%s.";
     private final Origin origin;
 
@@ -32,7 +36,13 @@ public class BadHttpResponseException extends RuntimeException {
         this.origin = origin;
     }
 
-    public Origin origin() {
-        return origin;
+    @Override
+    public Optional<Id> origin() {
+        return Optional.of(origin.id());
+    }
+
+    @Override
+    public Id application() {
+        return origin.applicationId();
     }
 }

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/MaxPendingConnectionTimeoutException.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/MaxPendingConnectionTimeoutException.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,14 +15,18 @@
  */
 package com.hotels.styx.client.connectionpool;
 
+import com.hotels.styx.api.Id;
+import com.hotels.styx.api.exceptions.StyxException;
 import com.hotels.styx.api.extension.Origin;
+
+import java.util.Optional;
 
 import static java.lang.String.format;
 
 /**
  * The consumer has been pending for connection for too long time.
  */
-public class MaxPendingConnectionTimeoutException extends ResourceExhaustedException {
+public class MaxPendingConnectionTimeoutException extends ResourceExhaustedException implements StyxException {
     private final Origin origin;
     private final int pendingConnectionTimeoutMillis;
 
@@ -36,7 +40,13 @@ public class MaxPendingConnectionTimeoutException extends ResourceExhaustedExcep
         return pendingConnectionTimeoutMillis;
     }
 
-    public Origin origin() {
-        return origin;
+    @Override
+    public Optional<Id> origin() {
+        return Optional.of(origin.id());
+    }
+
+    @Override
+    public Id application() {
+        return origin.applicationId();
     }
 }

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/MaxPendingConnectionsExceededException.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/MaxPendingConnectionsExceededException.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,14 +15,18 @@
  */
 package com.hotels.styx.client.connectionpool;
 
+import com.hotels.styx.api.Id;
+import com.hotels.styx.api.exceptions.StyxException;
 import com.hotels.styx.api.extension.Origin;
+
+import java.util.Optional;
 
 import static java.lang.String.format;
 
 /**
  * Launched when a connection pool is unable to establish new TCP connections.
  */
-public class MaxPendingConnectionsExceededException extends ResourceExhaustedException {
+public class MaxPendingConnectionsExceededException extends ResourceExhaustedException implements StyxException {
     private final Origin origin;
     private final int pendingConnectionsCount;
     private final int maxPendingConnectionsPerHost;
@@ -44,7 +48,13 @@ public class MaxPendingConnectionsExceededException extends ResourceExhaustedExc
         return maxPendingConnectionsPerHost;
     }
 
-    public Origin origin() {
-        return origin;
+    @Override
+    public Optional<Id> origin() {
+        return Optional.of(origin.id());
+    }
+
+    @Override
+    public Id application() {
+        return origin.applicationId();
     }
 }

--- a/components/common/src/main/java/com/hotels/styx/api/exceptions/NoAvailableHostsException.java
+++ b/components/common/src/main/java/com/hotels/styx/api/exceptions/NoAvailableHostsException.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,16 +17,33 @@ package com.hotels.styx.api.exceptions;
 
 import com.hotels.styx.api.Id;
 
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
 /**
  * An exception to be thrown when there are no hosts available.
  */
-public class NoAvailableHostsException extends RuntimeException {
+public class NoAvailableHostsException extends RuntimeException implements StyxException {
+    private final Id applicationId;
+
     /**
      * Constructor.
      *
      * @param applicationId ID of the application for which there are no hosts
      */
     public NoAvailableHostsException(Id applicationId) {
-        super(String.format("No hosts available for application %s", applicationId));
+        super(String.format("No hosts available for application %s", requireNonNull(applicationId)));
+        this.applicationId = applicationId;
+    }
+
+    @Override
+    public Optional<Id> origin() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Id application() {
+        return applicationId;
     }
 }

--- a/components/common/src/main/java/com/hotels/styx/api/exceptions/OriginUnreachableException.java
+++ b/components/common/src/main/java/com/hotels/styx/api/exceptions/OriginUnreachableException.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -16,14 +16,17 @@
 package com.hotels.styx.api.exceptions;
 
 
+import com.hotels.styx.api.Id;
 import com.hotels.styx.api.extension.Origin;
+
+import java.util.Optional;
 
 import static java.lang.String.format;
 
 /**
  * Exception for when a host is down.
  */
-public class OriginUnreachableException extends TransportException implements IsRetryableException {
+public class OriginUnreachableException extends TransportException implements StyxException, IsRetryableException {
     private static final String MESSAGE_FORMAT = "Origin server is unreachable. Could not connect to origin=%s";
     private final Origin origin;
 
@@ -43,7 +46,13 @@ public class OriginUnreachableException extends TransportException implements Is
      *
      * @return origin
      */
-    public Origin origin() {
-        return origin;
+    @Override
+    public Optional<Id> origin() {
+        return Optional.of(origin.id());
+    }
+
+    @Override
+    public Id application() {
+        return origin.applicationId();
     }
 }

--- a/components/common/src/main/java/com/hotels/styx/api/exceptions/ResponseTimeoutException.java
+++ b/components/common/src/main/java/com/hotels/styx/api/exceptions/ResponseTimeoutException.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,14 +15,17 @@
  */
 package com.hotels.styx.api.exceptions;
 
+import com.hotels.styx.api.Id;
 import com.hotels.styx.api.extension.Origin;
+
+import java.util.Optional;
 
 import static java.lang.String.format;
 
 /**
  * An exception due to a response timeout.
  */
-public class ResponseTimeoutException extends TransportException implements IsDeadConnectionException, IsTimeoutException {
+public class ResponseTimeoutException extends TransportException implements IsDeadConnectionException, IsTimeoutException, StyxException {
     private final Origin origin;
 
     /**
@@ -56,8 +59,14 @@ public class ResponseTimeoutException extends TransportException implements IsDe
      *
      * @return origin
      */
-    public Origin origin() {
-        return origin;
+    @Override
+    public Optional<Id> origin() {
+        return Optional.of(origin.id());
+    }
+
+    @Override
+    public Id application() {
+        return origin.applicationId();
     }
 
     private static String message(Origin origin) {

--- a/components/common/src/main/java/com/hotels/styx/api/exceptions/StyxException.java
+++ b/components/common/src/main/java/com/hotels/styx/api/exceptions/StyxException.java
@@ -15,36 +15,12 @@
  */
 package com.hotels.styx.api.exceptions;
 
-/**
- * An exception that causes a connection to fail.
- */
-public abstract class TransportException extends RuntimeException {
-    /**
-     * Constructor.
-     *
-     * @param message message
-     */
-    public TransportException(String message) {
-        super(message);
-    }
+import com.hotels.styx.api.Id;
 
-    /**
-     * Constructor.
-     *
-     * @param cause cause
-     */
-    public TransportException(Throwable cause) {
-        super(cause);
-    }
+import java.util.Optional;
 
-    /**
-     * Constructor.
-     *
-     * @param message message
-     * @param cause   cause
-     */
-    public TransportException(String message, Throwable cause) {
-        super(message, cause);
-    }
+public interface StyxException {
+    Optional<Id> origin();
 
+    Id application();
 }

--- a/components/common/src/main/java/com/hotels/styx/api/exceptions/TransportLostException.java
+++ b/components/common/src/main/java/com/hotels/styx/api/exceptions/TransportLostException.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,17 +15,19 @@
  */
 package com.hotels.styx.api.exceptions;
 
+import com.hotels.styx.api.Id;
 import com.hotels.styx.api.extension.Origin;
 import io.netty.channel.Channel;
 
 import java.net.SocketAddress;
+import java.util.Optional;
 
 import static java.lang.String.format;
 
 /**
  * Exception thrown when the connection between styx and origin is lost.
  */
-public class TransportLostException extends TransportException {
+public class TransportLostException extends TransportException implements StyxException {
     private static final String MESSAGE_FORMAT = "Connection to origin lost. origin=\"%s\", remoteAddress=\"%s\".";
     private final SocketAddress address;
     private final Origin origin;
@@ -62,7 +64,12 @@ public class TransportLostException extends TransportException {
      *
      * @return origin
      */
-    public Origin origin() {
-        return origin;
+    public Optional<Id> origin() {
+        return Optional.of(origin.id());
+    }
+
+    @Override
+    public Id application() {
+        return origin.applicationId();
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/ProxyConnectorFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/ProxyConnectorFactory.java
@@ -71,14 +71,17 @@ public class ProxyConnectorFactory implements ServerConnectorFactory {
     private final ResponseEnhancer responseEnhancer;
     private final boolean requestTracking;
     private final HttpMessageFormatter httpMessageFormatter;
+    private final CharSequence originsHeader;
 
+    // CHECKSTYLE:OFF
     public ProxyConnectorFactory(NettyServerConfig serverConfig,
-                          MetricRegistry metrics,
-                          HttpErrorStatusListener errorStatusListener,
-                          String unwiseCharacters,
-                          ResponseEnhancer responseEnhancer,
-                          boolean requestTracking,
-                          HttpMessageFormatter httpMessageFormatter) {
+                                 MetricRegistry metrics,
+                                 HttpErrorStatusListener errorStatusListener,
+                                 String unwiseCharacters,
+                                 ResponseEnhancer responseEnhancer,
+                                 boolean requestTracking,
+                                 HttpMessageFormatter httpMessageFormatter,
+                                 CharSequence originsHeader) {
         this.serverConfig = requireNonNull(serverConfig);
         this.metrics = requireNonNull(metrics);
         this.errorStatusListener = requireNonNull(errorStatusListener);
@@ -86,7 +89,9 @@ public class ProxyConnectorFactory implements ServerConnectorFactory {
         this.responseEnhancer = requireNonNull(responseEnhancer);
         this.requestTracking = requestTracking;
         this.httpMessageFormatter = httpMessageFormatter;
+        this.originsHeader = originsHeader;
     }
+    // CHECKSTYLE:ON
 
     @Override
     public ServerConnector create(ConnectorConfig config) {
@@ -106,6 +111,7 @@ public class ProxyConnectorFactory implements ServerConnectorFactory {
         private final ResponseEnhancer responseEnhancer;
         private final RequestTracker requestTracker;
         private final HttpMessageFormatter httpMessageFormatter;
+        private final CharSequence originsHeader;
 
         private ProxyConnector(ConnectorConfig config, ProxyConnectorFactory factory) {
             this.config = requireNonNull(config);
@@ -124,6 +130,7 @@ public class ProxyConnectorFactory implements ServerConnectorFactory {
             }
             this.requestTracker = factory.requestTracking ? CurrentRequestTracker.INSTANCE : RequestTracker.NO_OP;
             this.httpMessageFormatter = factory.httpMessageFormatter;
+            this.originsHeader = factory.originsHeader;
         }
 
         @Override
@@ -169,6 +176,7 @@ public class ProxyConnectorFactory implements ServerConnectorFactory {
                             .metricRegistry(metrics)
                             .secure(sslContext.isPresent())
                             .requestTracker(requestTracker)
+                            .xOriginsHeader(originsHeader)
                             .build());
 
             if (serverConfig.compressResponses()) {

--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -253,7 +253,8 @@ public final class StyxServer extends AbstractService {
                 environment.configuration().get(ENCODE_UNWISECHARS).orElse(""),
                 (builder, request) -> builder.header(styxInfoHeaderName, responseInfoFormat.format(request)),
                 environment.configuration().get("requestTracking", Boolean.class).orElse(false),
-                environment.httpMessageFormatter())
+                environment.httpMessageFormatter(),
+                environment.configuration().styxHeaderConfig().originIdHeaderName())
                 .create(connectorConfig);
 
         return NettyServerBuilder.newBuilder()

--- a/components/proxy/src/main/kotlin/com/hotels/styx/servers/StyxHttpServer.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/servers/StyxHttpServer.kt
@@ -137,7 +137,9 @@ internal class StyxHttpServerFactory : StyxServerFactory {
                                             ResponseInfoFormat(environment).format(request))
                                 },
                                 false,
-                                environment.httpMessageFormatter())
+                                environment.httpMessageFormatter(),
+                                // TODO: Add styx header configuration
+                                null)
                                 .create(
                                         if (config.tlsSettings == null) {
                                             HttpConnectorConfig(config.port)

--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -23,12 +23,14 @@ import com.hotels.styx.api.ContentOverflowException;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpResponseStatus;
+import com.hotels.styx.api.Id;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.MetricRegistry;
 import com.hotels.styx.api.exceptions.NoAvailableHostsException;
 import com.hotels.styx.api.exceptions.OriginUnreachableException;
 import com.hotels.styx.api.exceptions.ResponseTimeoutException;
+import com.hotels.styx.api.exceptions.StyxException;
 import com.hotels.styx.api.exceptions.TransportLostException;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.api.plugins.spi.PluginException;
@@ -59,6 +61,7 @@ import reactor.core.publisher.Flux;
 import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
@@ -120,6 +123,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
     private final StateMachine<State> stateMachine;
     private final ResponseEnhancer responseEnhancer;
     private final boolean secure;
+    private final CharSequence originsHeaderName;
 
     private volatile Subscription subscription;
     private volatile LiveHttpRequest ongoingRequest;
@@ -141,6 +145,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
         this.metrics = builder.metricRegistry.get();
         this.secure = builder.secure;
         this.tracker = tracker;
+        this.originsHeaderName = builder.originsHeaderName;
     }
 
     private StateMachine<State> createStateMachine() {
@@ -276,23 +281,23 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
 
                 @Override
                 public void hookOnComplete() {
-                   eventProcessor.submit(new ResponseObservableCompletedEvent(ctx, request.id()));
+                    eventProcessor.submit(new ResponseObservableCompletedEvent(ctx, request.id()));
                 }
 
                 @Override
                 public void hookOnError(Throwable cause) {
-                   eventProcessor.submit(new ResponseObservableErrorEvent(ctx, cause, request.id()));
+                    eventProcessor.submit(new ResponseObservableErrorEvent(ctx, cause, request.id()));
                 }
 
                 @Override
                 public void hookOnNext(LiveHttpResponse response) {
-                   eventProcessor.submit(new ResponseReceivedEvent(response, ctx));
+                    eventProcessor.submit(new ResponseReceivedEvent(response, ctx));
                 }
             });
 
             return WAITING_FOR_RESPONSE;
         } catch (Throwable cause) {
-            LiveHttpResponse response = exceptionToResponse(cause, request);
+            LiveHttpResponse response = exceptionToResponse(cause, request, originsHeaderName);
             httpErrorStatusListener.proxyErrorOccurred(request, remoteAddress(ctx), response.status(), cause);
             statsSink.onTerminate(request.id());
             tracker.endTrack(ongoingRequest);
@@ -416,7 +421,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
         }
 
         if (!isIoException(cause)) {
-            LiveHttpResponse response = exceptionToResponse(cause, ongoingRequest);
+            LiveHttpResponse response = exceptionToResponse(cause, ongoingRequest, originsHeaderName);
             httpErrorStatusListener.proxyErrorOccurred(response.status(), cause);
             if (ctx.channel().isActive()) {
                 respondAndClose(ctx, response);
@@ -459,7 +464,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
             return TERMINATED;
         }
 
-        LiveHttpResponse response = exceptionToResponse(cause, ongoingRequest);
+        LiveHttpResponse response = exceptionToResponse(cause, ongoingRequest, originsHeaderName);
         responseWriterFactory.create(ctx)
                 .write(response)
                 .handle((ignore, exception) -> {
@@ -505,21 +510,41 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
         return throwable instanceof IOException;
     }
 
-    private LiveHttpResponse exceptionToResponse(Throwable exception, LiveHttpRequest request) {
-        HttpResponseStatus status = status(exception instanceof PluginException
-                ? exception.getCause()
-                : exception);
+    private LiveHttpResponse exceptionToResponse(Throwable cause, LiveHttpRequest request, CharSequence originsHeaderName) {
+        HttpResponseStatus status = status(cause instanceof PluginException
+                ? cause.getCause()
+                : cause);
 
         String message = status.code() >= 500 ? "Site temporarily unavailable." : status.description();
 
-        return responseEnhancer.enhance(
+        LiveHttpResponse.Transformer builder = responseEnhancer.enhance(
                 response(status)
                         .body(new ByteStream(Flux.just(new Buffer(message, UTF_8))))
                         .build()
                         .newBuilder(), request)
                 .header(CONTENT_LENGTH, message.getBytes(UTF_8).length)
-                .header(CONNECTION, "close")
-                .build();
+                .header(CONNECTION, "close");
+
+        if (originsHeaderName != null && originFromException(cause) != null) {
+            return builder.header(originsHeaderName, originFromException(cause))
+                    .build();
+        } else {
+            return builder.build();
+        }
+    }
+
+    private String originFromException(Throwable cause) {
+        if (cause instanceof StyxException) {
+            StyxException c = (StyxException) cause;
+            return c.origin()
+                    .map(Id::toString)
+                    .orElse(Optional.ofNullable(c.application())
+                            .map(Id::toString)
+                            .orElse(null));
+
+        } else {
+            return null;
+        }
     }
 
     private static HttpResponseStatus status(Throwable exception) {
@@ -645,6 +670,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
         private Supplier<MetricRegistry> metricRegistry = CodaHaleMetricRegistry::new;
         private RequestTracker tracker = RequestTracker.NO_OP;
         private boolean secure;
+        private CharSequence originsHeaderName;
 
         /**
          * Constructs a new builder.
@@ -718,6 +744,11 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
 
         public Builder requestTracker(RequestTracker tracker) {
             this.tracker = requireNonNull(tracker);
+            return this;
+        }
+
+        public Builder xOriginsHeader(CharSequence originsHeaderName) {
+            this.originsHeaderName = originsHeaderName;
             return this;
         }
 

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/OriginsFileCompatibilitySpec.kt
@@ -305,10 +305,20 @@ class OriginsFileCompatibilitySpec : FunSpec() {
                     client.send(get("/11")
                             .header(HOST, styxServer().proxyHttpHostHeader())
                             .build())
-                            .wait().let {
-                                it!!.status() shouldBe BAD_GATEWAY
+                            .wait()!!
+                            .let {
+                                it.status() shouldBe BAD_GATEWAY
                             }
                 }
+
+                client.send(get("/11")
+                        .header(HOST, styxServer().proxyHttpHostHeader())
+                        .build())
+                        .wait()!!
+                        .let {
+                            it.status() shouldBe BAD_GATEWAY
+                            it.header("X-Styx-Origin-Id").get() shouldBe "appTls.appTls-01"
+                        }
 
                 writeOrigins("""
                     - id: appTls
@@ -588,8 +598,10 @@ class OriginsFileCompatibilitySpec : FunSpec() {
                 client.send(get("/16")
                         .header(HOST, styxServer().proxyHttpHostHeader())
                         .build())
-                        .wait().let {
-                            it!!.status() shouldBe BAD_GATEWAY
+                        .wait()!!
+                        .let {
+                            it.status() shouldBe BAD_GATEWAY
+                            it.header("X-Styx-Origin-Id").get() shouldBe "appB"
                             it.bodyAs(UTF_8) shouldBe "Site temporarily unavailable."
                         }
             }

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/proxy/NoAvailableHostsSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/proxy/NoAvailableHostsSpec.kt
@@ -1,0 +1,99 @@
+/*
+  Copyright (C) 2013-2020 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.proxy
+
+import com.hotels.styx.api.HttpHeaderNames.HOST
+import com.hotels.styx.api.HttpRequest.get
+import com.hotels.styx.api.HttpResponseStatus.BAD_GATEWAY
+import com.hotels.styx.client.StyxHttpClient
+import com.hotels.styx.support.StyxServerProvider
+import com.hotels.styx.support.proxyHttpHostHeader
+import com.hotels.styx.support.testClient
+import com.hotels.styx.support.wait
+import io.kotlintest.Spec
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FeatureSpec
+
+class NoAvailableHostsSpec : FeatureSpec() {
+    val client: StyxHttpClient = StyxHttpClient.Builder().build()
+
+    val styxServer = StyxServerProvider()
+
+    override fun afterSpec(spec: Spec) {
+        styxServer.stop()
+    }
+
+    init {
+        feature("Responds with 502 with application ID in X-Styx-Origin-Id header") {
+            scenario("Load balancing group in httpPipeline") {
+                styxServer.restart("""
+                    proxy:
+                      connectors:
+                        http:
+                          port: 0
+                      
+                    admin:
+                      connectors:
+                        http:
+                          port: 0
+            
+                    httpPipeline:
+                      type: LoadBalancingGroup
+                      config:
+                        origins: remoteHosts
+                  """.trimIndent())
+
+                testClient.send(get("/").header(HOST, styxServer().proxyHttpHostHeader()).build())
+                        .wait()!!
+                        .let {
+                            it.status() shouldBe (BAD_GATEWAY)
+                            it.header("X-Styx-Origin-Id").get() shouldBe "httpPipeline"
+                        }
+            }
+
+            scenario("Load balancing group name routing object") {
+                styxServer.restart("""
+                    proxy:
+                      connectors:
+                        http:
+                          port: 0
+                      
+                    admin:
+                      connectors:
+                        http:
+                          port: 0
+            
+                    routingObjects:
+                      zone1Lb:
+                        type: LoadBalancingGroup
+                        config:
+                          origins: remoteHosts
+
+                    httpPipeline: zone1Lb
+                  """.trimIndent())
+
+                testClient.send(get("/").header(HOST, styxServer().proxyHttpHostHeader()).build())
+                        .wait()!!
+                        .let {
+                            it.status() shouldBe (BAD_GATEWAY)
+                            it.header("X-Styx-Origin-Id").get() shouldBe "zone1Lb"
+                        }
+            }
+        }
+    }
+}
+
+

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/proxy/OriginUnreachableSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/proxy/OriginUnreachableSpec.kt
@@ -1,0 +1,90 @@
+/*
+  Copyright (C) 2013-2020 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.proxy
+
+import com.hotels.styx.api.HttpHeaderNames.HOST
+import com.hotels.styx.api.HttpRequest.get
+import com.hotels.styx.api.HttpResponseStatus.SERVICE_UNAVAILABLE
+import com.hotels.styx.client.StyxHttpClient
+import com.hotels.styx.support.StyxServerProvider
+import com.hotels.styx.support.proxyHttpHostHeader
+import com.hotels.styx.support.testClient
+import com.hotels.styx.support.wait
+import io.kotlintest.Spec
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FeatureSpec
+
+class OriginUnreachableSpec : FeatureSpec() {
+    val client: StyxHttpClient = StyxHttpClient.Builder().build()
+
+    val styxServer = StyxServerProvider()
+
+    override fun afterSpec(spec: Spec) {
+        styxServer.stop()
+    }
+
+    init {
+        feature("Responds with 502 with application ID in X-Styx-Origin-Id header") {
+            scenario("HostProxy is unable to connect to an origin") {
+                styxServer.restart("""
+                    proxy:
+                      connectors:
+                        http:
+                          port: 0
+                      
+                    admin:
+                      connectors:
+                        http:
+                          port: 0
+            
+                    routingObjects:
+                      remoteHost:
+                        type: HostProxy
+                        tags:
+                          - lbGroup=zone1
+                        config:
+                          host: "localhost:27341"
+                    
+                      zone1Lb:
+                        type: LoadBalancingGroup
+                        config:
+                          origins: zone1
+
+                    httpPipeline: zone1Lb
+                  """.trimIndent())
+
+                // Note: Since https://github.com/HotelsDotCom/styx/pull/337, the connection pool
+                // handles OriginUnreachableException internally, and it no longer propagates to
+                // Styx proxy server.
+                //
+                // Therefore, Styx proxy server now sees flavour of ResourceExhaustedException which
+                // maps to a 503 SERVICE UNAVAILABLE response.
+
+                testClient.send(get("/").header(HOST, styxServer().proxyHttpHostHeader()).build())
+                        .wait()!!
+                        .let {
+                            it.status() shouldBe (SERVICE_UNAVAILABLE)
+                            it.header("X-Styx-Origin-Id").get() shouldBe "remoteHost"
+                        }
+            }
+        }
+
+
+    }
+
+}
+
+


### PR DESCRIPTION
Adds an `X-Styx-Origin-Id` header to 5xx responses originating from Styx.
In this case, the `X-Styx-Origin-Id` indicates the origin where the request would
have been routed *should* it have been successful.

Note. I chose to reuse the existing `X-Styx-Origin-Id` header instead of inventing a new one. 

NOTE: we need to make sure it is still possible to differentiate between 5xx responses from styx and the origins. Previously, a lack of this header indicated that the response came from styx. A presence of this header indicated that the origin responded.
