### PR TITLE
Reduce CI logging

### DIFF
--- a/components/api/src/test/resources/conf/logback/logback.xml
+++ b/components/api/src/test/resources/conf/logback/logback.xml
@@ -3,7 +3,10 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/components/api/src/test/resources/conf/logback/logback.xml
+++ b/components/api/src/test/resources/conf/logback/logback.xml
@@ -10,7 +10,7 @@
     </encoder>
   </appender>
 
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>
 </configuration>

--- a/components/client/src/test/integration/resources/logback.xml
+++ b/components/client/src/test/integration/resources/logback.xml
@@ -3,7 +3,10 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/components/client/src/test/unit/resources/logback.xml
+++ b/components/client/src/test/unit/resources/logback.xml
@@ -3,7 +3,9 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}</pattern>
     </encoder>
   </appender>
 

--- a/components/proxy/src/test/resources/conf/logback.xml
+++ b/components/proxy/src/test/resources/conf/logback.xml
@@ -3,7 +3,10 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/components/proxy/src/test/resources/conf/logback.xml
+++ b/components/proxy/src/test/resources/conf/logback.xml
@@ -10,7 +10,7 @@
     </encoder>
   </appender>
 
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>
 </configuration>

--- a/components/proxy/src/test/resources/logback.xml
+++ b/components/proxy/src/test/resources/logback.xml
@@ -3,7 +3,10 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/components/server/src/test/resources/conf/logback/logback.xml
+++ b/components/server/src/test/resources/conf/logback/logback.xml
@@ -3,7 +3,10 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/components/server/src/test/resources/conf/logback/logback.xml
+++ b/components/server/src/test/resources/conf/logback/logback.xml
@@ -10,7 +10,7 @@
     </encoder>
   </appender>
 
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>
 </configuration>

--- a/components/server/src/test/resources/logback.xml
+++ b/components/server/src/test/resources/logback.xml
@@ -3,7 +3,10 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <java-uuid-generator.version>3.1.5</java-uuid-generator.version>
 
     <!-- Logging Versions -->
-    <logback.version>1.1.2</logback.version>
+    <logback.version>1.1.10</logback.version>
     <slf4j.version>1.7.30</slf4j.version>
 
     <scala.version>2.12</scala.version>

--- a/support/testsupport/src/test/resources/logback.xml
+++ b/support/testsupport/src/test/resources/logback.xml
@@ -10,12 +10,7 @@
     </encoder>
   </appender>
 
-  <root level="OFF">
+  <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>
-
-  <logger name="Styx-Tests" level="INFO"/>
-  <logger name="com.hotels.styx.common.FsmEventProcessor" level="INFO"/>
-  <logger name="com.hotels.styx.common.content.FlowControllingHttpContentProducer" level="INFO"/>
-
 </configuration>

--- a/system-tests/e2e-suite/src/test/resources/conf/logback/logback-debug-stdout.xml
+++ b/system-tests/e2e-suite/src/test/resources/conf/logback/logback-debug-stdout.xml
@@ -2,7 +2,10 @@
 <configuration scan="true" scanPeriod="10000">
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/system-tests/e2e-suite/src/test/resources/conf/logback/logback-suppress-errors.xml
+++ b/system-tests/e2e-suite/src/test/resources/conf/logback/logback-suppress-errors.xml
@@ -2,7 +2,10 @@
 <configuration scan="true" scanPeriod="10000">
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/system-tests/e2e-suite/src/test/resources/conf/logback/logback.xml
+++ b/system-tests/e2e-suite/src/test/resources/conf/logback/logback.xml
@@ -2,7 +2,10 @@
 <configuration scan="true" scanPeriod="10000">
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/system-tests/e2e-suite/src/test/resources/logback.xml
+++ b/system-tests/e2e-suite/src/test/resources/logback.xml
@@ -3,7 +3,10 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/system-tests/ft-suite/src/test/resources/conf/logback/logback.xml
+++ b/system-tests/ft-suite/src/test/resources/conf/logback/logback.xml
@@ -2,7 +2,10 @@
 <configuration scan="true" scanPeriod="10000">
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/system-tests/ft-suite/src/test/resources/logback.xml
+++ b/system-tests/ft-suite/src/test/resources/logback.xml
@@ -3,7 +3,10 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full,
+        org.junit,
+        org.apache.maven.surefire}
+      </pattern>
     </encoder>
   </appender>
 

--- a/travis/deploy.sh
+++ b/travis/deploy.sh
@@ -48,7 +48,7 @@ mvn install -B -U -P macosx,release -DskipTests=true -Dmaven.test.skip=true -Dgp
 
 function deploySnapshot() {
   echo "Deploying snapshot to sonatype"
-  mvn deploy --settings travis/mvn-settings.xml -B -U -P sonatype-oss-release,linux -DskipTests=true -Dmaven.test.skip=true -Dgpg.skip=true
+  mvn deploy --settings travis/mvn-settings.xml -B -U -P sonatype-oss-release,linux -DskipTests=true -Dmaven.test.skip=true -Dgpg.skip=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 }
 
 if [[ -n "$TRAVIS_TAG" ]]; then


### PR DESCRIPTION
* Update logback to 1.1.10 and filter CI stacktraces
* Reduce DEBUG logging
* Filter Maven Downloading/Downloaded messages (mainly during deploy to Sonatype)

The first two changes result in a reduction of about 5000 lines in a CI build.
