### PR TITLE
Temporarily reinstate rxjava dependency into styx-api

### DIFF
--- a/components/api/pom.xml
+++ b/components/api/pom.xml
@@ -16,6 +16,13 @@
   </properties>
 
   <dependencies>
+
+    <!-- Temporary until dependency transferred to plugins that require it -->
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,9 @@
     <!-- Build defaults to linux platform: -->
     <netty-tcnative.classifier>linux-x86_64</netty-tcnative.classifier>
 
+    <!-- Temporary until dependency transferred to plugins that require it -->
+    <rxjava.version>1.1.6</rxjava.version>
+
     <!-- General Versions -->
     <guava.version>18.0</guava.version>
     <jackson.version>2.10.1</jackson.version>
@@ -250,6 +253,13 @@
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>${netty-tcnative.version}</version>
         <classifier>${netty-tcnative.classifier}</classifier>
+      </dependency>
+
+      <!-- Temporary until dependency transferred to plugins that require it -->
+      <dependency>
+        <groupId>io.reactivex</groupId>
+        <artifactId>rxjava</artifactId>
+        <version>${rxjava.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
To give some time for dependent projects, such as plugins that may rely on this dependency, to include this dependency themselves explicitly.