### PR TITLE
Clean up PathPrefixRouter and rewrite now broken tests.

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
@@ -83,7 +83,7 @@ public class PathPrefixRouter implements RoutingObject {
         return CompletableFuture.allOf(stopFutures);
     }
 
-    private static class PrefixRoute implements Comparable<PrefixRoute> {
+    static class PrefixRoute implements Comparable<PrefixRoute> {
         private final String prefix;
         private final RoutingObject routingObject;
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
@@ -31,14 +31,11 @@ import com.hotels.styx.routing.config.StyxObjectDefinition;
 import com.hotels.styx.server.NoServiceConfiguredException;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static com.hotels.styx.config.schema.SchemaDsl.field;
-import static com.hotels.styx.config.schema.SchemaDsl.list;
-import static com.hotels.styx.config.schema.SchemaDsl.object;
-import static com.hotels.styx.config.schema.SchemaDsl.routingObject;
-import static com.hotels.styx.config.schema.SchemaDsl.string;
+import static com.hotels.styx.config.schema.SchemaDsl.*;
 import static com.hotels.styx.routing.config.RoutingConfigParser.toRoutingConfigNode;
 import static com.hotels.styx.routing.config.RoutingSupport.missingAttributeError;
 import static java.lang.String.join;
@@ -47,7 +44,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Makes a routing decision based on a request path prefix.
- *
+ * <p>
  * Chooses a destination according to longest matching path prefix.
  * The destination can be a routing object reference or an inline definition.
  */
@@ -62,7 +59,7 @@ public class PathPrefixRouter implements RoutingObject {
     public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
         String path = request.path();
 
-        for(PrefixRoute route: routes) {
+        for (PrefixRoute route : routes) {
             if (path.startsWith(route.prefix)) {
                 return route.routingObject.handle(request, context);
             }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
@@ -24,12 +24,10 @@ import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.config.schema.Schema;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 import com.hotels.styx.routing.RoutingObject;
-import com.hotels.styx.routing.RoutingObjectReference;
 import com.hotels.styx.routing.config.Builtins;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
 import com.hotels.styx.routing.config.StyxObjectConfiguration;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
-import com.hotels.styx.routing.config.StyxObjectReference;
 import com.hotels.styx.server.NoServiceConfiguredException;
 import org.jetbrains.annotations.NotNull;
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
@@ -57,6 +57,7 @@ public class PathPrefixRouter implements RoutingObject {
 
     PathPrefixRouter(PrefixRoute[] routes) {
         this.routes = routes;
+        Arrays.sort(this.routes);
     }
 
     @Override
@@ -121,7 +122,6 @@ public class PathPrefixRouter implements RoutingObject {
                 RoutingObject route = Builtins.build(singletonList(""), context, routeConfig.destination());
                 routes[i++] = new PrefixRoute(prefix, route);
             }
-            Arrays.sort(routes);
 
             return new PathPrefixRouter(routes);
         }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
@@ -35,7 +35,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static com.hotels.styx.config.schema.SchemaDsl.*;
+import static com.hotels.styx.config.schema.SchemaDsl.field;
+import static com.hotels.styx.config.schema.SchemaDsl.list;
+import static com.hotels.styx.config.schema.SchemaDsl.object;
+import static com.hotels.styx.config.schema.SchemaDsl.routingObject;
+import static com.hotels.styx.config.schema.SchemaDsl.string;
 import static com.hotels.styx.routing.config.RoutingConfigParser.toRoutingConfigNode;
 import static com.hotels.styx.routing.config.RoutingSupport.missingAttributeError;
 import static java.lang.String.join;

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/PathPrefixRouter.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,12 +17,10 @@ package com.hotels.styx.routing.handlers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
-import com.hotels.styx.common.Pair;
 import com.hotels.styx.config.schema.Schema;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 import com.hotels.styx.routing.RoutingObject;
@@ -31,14 +29,11 @@ import com.hotels.styx.routing.config.RoutingObjectFactory;
 import com.hotels.styx.routing.config.StyxObjectConfiguration;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
 import com.hotels.styx.server.NoServiceConfiguredException;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentSkipListMap;
 
-import static com.hotels.styx.common.Pair.pair;
 import static com.hotels.styx.config.schema.SchemaDsl.field;
 import static com.hotels.styx.config.schema.SchemaDsl.list;
 import static com.hotels.styx.config.schema.SchemaDsl.object;
@@ -47,10 +42,8 @@ import static com.hotels.styx.config.schema.SchemaDsl.string;
 import static com.hotels.styx.routing.config.RoutingConfigParser.toRoutingConfigNode;
 import static com.hotels.styx.routing.config.RoutingSupport.missingAttributeError;
 import static java.lang.String.join;
-import static java.util.Comparator.comparingInt;
-import static java.util.Comparator.naturalOrder;
-import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.stream.Collectors.toList;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Makes a routing decision based on a request path prefix.
@@ -58,31 +51,52 @@ import static java.util.stream.Collectors.toList;
  * Chooses a destination according to longest matching path prefix.
  * The destination can be a routing object reference or an inline definition.
  */
-public class PathPrefixRouter {
-    public static final Schema.FieldType SCHEMA = object(
-            field("routes", list(object(
-                    field("prefix", string()),
-                    field("destination", routingObject()))
-            ))
-    );
+public class PathPrefixRouter implements RoutingObject {
+    private final Iterable<PrefixRoute> routes;
 
-    private final ConcurrentSkipListMap<String, RoutingObject> routes = new ConcurrentSkipListMap<>(
-                    comparingInt(String::length)
-                            .reversed()
-                            .thenComparing(naturalOrder())
-    );
-
-    PathPrefixRouter(List<Pair<String, RoutingObject>> routes) {
-        routes.forEach(entry -> this.routes.put(entry.key(), entry.value()));
+    PathPrefixRouter(Iterable<PrefixRoute> routes) {
+        this.routes = routes;
     }
 
-    public Optional<RoutingObject> route(LiveHttpRequest request) {
+    @Override
+    public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
         String path = request.path();
 
-        return routes.entrySet().stream()
-                .filter(entry -> path.startsWith(entry.getKey()))
-                .findFirst()
-                .map(Map.Entry::getValue);
+        for(PrefixRoute route: routes) {
+            if (path.startsWith(route.prefix)) {
+                return route.routingObject.handle(request, context);
+            }
+        }
+
+        return Eventual.error(new NoServiceConfiguredException(path));
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        List<CompletableFuture<Void>> stopFutures = new ArrayList<>();
+        routes.forEach(prefixRoute -> stopFutures.add(prefixRoute.routingObject.stop()));
+        return CompletableFuture.allOf(stopFutures.toArray(new CompletableFuture[stopFutures.size()]));
+    }
+
+    private static class PrefixRoute implements Comparable<PrefixRoute> {
+        private final String prefix;
+        private final RoutingObject routingObject;
+
+        PrefixRoute(String prefix, RoutingObject routingObject) {
+            this.prefix = requireNonNull(prefix);
+            this.routingObject = requireNonNull(routingObject);
+        }
+
+        @Override
+        public int compareTo(@NotNull PrefixRoute o) {
+            if (prefix.length() > o.prefix.length()) {
+                return -1;
+            } else if (prefix.length() < o.prefix.length()) {
+                return 1;
+            } else {
+                return prefix.compareTo(o.prefix);
+            }
+        }
     }
 
     /**
@@ -97,28 +111,24 @@ public class PathPrefixRouter {
                 throw missingAttributeError(configBlock, join(".", fullName), "routes");
             }
 
-            PathPrefixRouter pathPrefixRouter = new PathPrefixRouter(
-                    config.routes.stream()
-                            .map(route -> pair(route.prefix, Builtins.build(ImmutableList.of(""), context, route.destination)))
-                            .collect(toList())
-            );
+            List<PrefixRoute> routes = new ArrayList<>();
+            for (PathPrefixConfig routeConfig : config.routes()) {
+                String prefix = routeConfig.prefix();
+                RoutingObject route = Builtins.build(singletonList(""), context, routeConfig.destination());
+                routes.add(new PrefixRoute(prefix, route));
+            }
+            routes.sort(null);
 
-            return new RoutingObject() {
-                @Override
-                public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
-                    return pathPrefixRouter.route(request)
-                            .orElse((x, y) -> Eventual.error(new NoServiceConfiguredException(request.path())))
-                            .handle(request, context);
-                }
-
-                @Override
-                public CompletableFuture<Void> stop() {
-                    pathPrefixRouter.routes.forEach((route, routingObject) -> routingObject.stop());
-                    return completedFuture(null);
-                }
-            };
+            return new PathPrefixRouter(routes);
         }
     }
+
+    public static final Schema.FieldType SCHEMA = object(
+            field("routes", list(object(
+                    field("prefix", string()),
+                    field("destination", routingObject()))
+            ))
+    );
 
     /**
      * PathPrefixRouter configuration.

--- a/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
@@ -113,17 +113,15 @@ public class PathPrefixRouterTest {
     }
 
     private PathPrefixRouter buildRouter(Map<String, String> prefixRoutes) {
-        ArrayNode routes = mapper.createArrayNode();
-        prefixRoutes.forEach((path, route) -> routes.add(mapper.createObjectNode()
-                .put("prefix", path)
-                .put("destination", route)));
-        ObjectNode config = mapper.createObjectNode().set("routes", routes);
+        PathPrefixRouter.PrefixRoute[] routes = new PathPrefixRouter.PrefixRoute[prefixRoutes.size()];
+        int i = 0;
+        for (Map.Entry<String, String> entry : prefixRoutes.entrySet()) {
+            String path = entry.getKey();
+            String route = entry.getValue();
+            routes[i++] = new PathPrefixRouter.PrefixRoute(path, routingObjects.get(route));
+        }
 
-        StyxObjectDefinition configBlock = new StyxObjectDefinition("test", Builtins.PATH_PREFIX_ROUTER, config);
-
-        PathPrefixRouter router = (PathPrefixRouter) new PathPrefixRouter.Factory().build(singletonList("test"), routingContext, configBlock);
-
-        return router;
+        return new PathPrefixRouter(routes);
     }
 
     private void testRequestRoute(PathPrefixRouter router, String path, RoutingObject handler) {

--- a/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
@@ -1,3 +1,18 @@
+/*
+  Copyright (C) 2013-2020 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 package com.hotels.styx.routing.handlers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
@@ -46,13 +46,13 @@ public class PathPrefixRouterTest {
     private static final ObjectMapper mapper = new ObjectMapper();
 
     public Map<StyxObjectReference, RoutingObject> routingObjects = new HashMap<>();
-    public RoutingObjectFactory.Context Routingcontext;
+    public RoutingObjectFactory.Context routingContext;
     public HttpInterceptor.Context context = mock(HttpInterceptor.Context.class);
 
     @BeforeEach
     public void beforeEach() throws Exception {
-        Routingcontext = mock(RoutingObjectFactory.Context.class);
-        when(Routingcontext.refLookup()).thenReturn(ref -> routingObjects.get(ref));
+        routingContext = mock(RoutingObjectFactory.Context.class);
+        when(routingContext.refLookup()).thenReturn(ref -> routingObjects.get(ref));
     }
 
     @Test
@@ -121,7 +121,7 @@ public class PathPrefixRouterTest {
 
         StyxObjectDefinition configBlock = new StyxObjectDefinition("test", Builtins.PATH_PREFIX_ROUTER, config);
 
-        PathPrefixRouter router = (PathPrefixRouter) new PathPrefixRouter.Factory().build(singletonList("test"), Routingcontext, configBlock);
+        PathPrefixRouter router = (PathPrefixRouter) new PathPrefixRouter.Factory().build(singletonList("test"), routingContext, configBlock);
 
         return router;
     }

--- a/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
@@ -31,12 +31,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -118,7 +121,8 @@ public class PathPrefixRouterTest {
         for (Map.Entry<String, String> entry : prefixRoutes.entrySet()) {
             String path = entry.getKey();
             String route = entry.getValue();
-            routes[i++] = new PathPrefixRouter.PrefixRoute(path, routingObjects.get(route));
+            RoutingObject routingObject = requireNonNull(routingObjects.get(new StyxObjectReference(route)), "No reouting object for " + route);
+            routes[i++] = new PathPrefixRouter.PrefixRoute(path, routingObject);
         }
 
         return new PathPrefixRouter(routes);

--- a/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
@@ -1,0 +1,119 @@
+package com.hotels.styx.routing.handlers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import com.hotels.styx.api.HttpInterceptor;
+import com.hotels.styx.api.LiveHttpRequest;
+import com.hotels.styx.routing.RoutingObject;
+import com.hotels.styx.routing.config.Builtins;
+import com.hotels.styx.routing.config.RoutingObjectFactory;
+import com.hotels.styx.routing.config.StyxObjectDefinition;
+import com.hotels.styx.routing.config.StyxObjectReference;
+import com.hotels.styx.server.NoServiceConfiguredException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PathPrefixRouterTest {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public Map<StyxObjectReference, RoutingObject> routingObjects = new HashMap<>();
+    public RoutingObjectFactory.Context Routingcontext;
+    public HttpInterceptor.Context context = mock(HttpInterceptor.Context.class);
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        Routingcontext = mock(RoutingObjectFactory.Context.class);
+        when(Routingcontext.refLookup()).thenReturn(ref -> routingObjects.get(ref));
+    }
+
+    @Test
+    public void no_routes_always_throws_NoServiceConfiguredException() throws Exception {
+        PathPrefixRouter router = buildRouter(emptyMap());
+
+        assertThrows(NoServiceConfiguredException.class, () ->
+                Mono.from(router.handle(LiveHttpRequest.get("/").build(), null)).block()
+        );
+    }
+
+    @Test
+    public void root_handler_handles_sub_paths() throws Exception {
+        RoutingObject rootHandler = mock(RoutingObject.class);
+
+        routingObjects.put(new StyxObjectReference("rootHandler"), rootHandler);
+
+        PathPrefixRouter router = buildRouter(singletonMap("/", "rootHandler"));
+
+        testRequestRoute(router, "/", rootHandler);
+        testRequestRoute(router, "/foo/bar", rootHandler);
+    }
+
+    @Test
+    public void most_specific_path_is_chosen() throws Exception {
+        RoutingObject rootHandler = mock(RoutingObject.class);
+        RoutingObject fooFileHandler = mock(RoutingObject.class);
+        RoutingObject fooPathHandler = mock(RoutingObject.class);
+        RoutingObject fooBarFileHandler = mock(RoutingObject.class);
+        RoutingObject fooBarPathHandler = mock(RoutingObject.class);
+        RoutingObject fooBazFileHandler = mock(RoutingObject.class);
+
+        routingObjects.put(new StyxObjectReference("rootHandler"), rootHandler);
+        routingObjects.put(new StyxObjectReference("fooFileHandler"), fooFileHandler);
+        routingObjects.put(new StyxObjectReference("fooPathHandler"), fooPathHandler);
+        routingObjects.put(new StyxObjectReference("fooBarFileHandler"), fooBarFileHandler);
+        routingObjects.put(new StyxObjectReference("fooBarPathHandler"), fooBarPathHandler);
+        routingObjects.put(new StyxObjectReference("fooBazFileHandler"), fooBazFileHandler);
+
+        PathPrefixRouter router = buildRouter(ImmutableMap.<String, String>builder()
+                .put("/", "rootHandler")
+                .put("/foo", "fooFileHandler")
+                .put("/foo/", "fooPathHandler")
+                .put("/foo/bar", "fooBarFileHandler")
+                .put("/foo/bar/", "fooBarPathHandler")
+                .put("/foo/baz", "fooBazFileHandler")
+                .build());
+
+        testRequestRoute(router, "/", rootHandler);
+        testRequestRoute(router, "/foo", fooFileHandler);
+        testRequestRoute(router, "/foo/x", fooPathHandler);
+        testRequestRoute(router, "/foo/", fooPathHandler);
+        testRequestRoute(router, "/foo/bar", fooBarFileHandler);
+        testRequestRoute(router, "/foo/bar/x", fooBarPathHandler);
+        testRequestRoute(router, "/foo/bar/", fooBarPathHandler);
+        testRequestRoute(router, "/foo/baz/", fooBazFileHandler);
+        testRequestRoute(router, "/foo/baz/y", fooBazFileHandler);
+    }
+
+    private PathPrefixRouter buildRouter(Map<String, String> prefixRoutes) {
+        ArrayNode routes = mapper.createArrayNode();
+        prefixRoutes.forEach((path, route) -> routes.add(mapper.createObjectNode()
+                .put("prefix", path)
+                .put("destination", route)));
+        ObjectNode config = mapper.createObjectNode().set("routes", routes);
+
+        StyxObjectDefinition configBlock = new StyxObjectDefinition("test", Builtins.PATH_PREFIX_ROUTER, config);
+
+        PathPrefixRouter router = (PathPrefixRouter) new PathPrefixRouter.Factory().build(singletonList("test"), Routingcontext, configBlock);
+
+        return router;
+    }
+
+    private void testRequestRoute(PathPrefixRouter router, String path, RoutingObject handler) {
+        LiveHttpRequest request = LiveHttpRequest.get(path).build();
+        router.handle(request, context);
+        verify(handler).handle(request, context);
+    }
+}

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/PathPrefixRouterFactoryTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/PathPrefixRouterFactoryTest.kt
@@ -16,20 +16,16 @@
 package com.hotels.styx.routing.handlers
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.hotels.styx.api.HttpRequest
-import com.hotels.styx.api.LiveHttpRequest.get
-import com.hotels.styx.common.Pair.pair
-import com.hotels.styx.config.schema.SchemaValidationException
-import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig
 import com.hotels.styx.RoutingObjectFactoryContext
-import com.hotels.styx.routing.config.RoutingObjectFactory
-import com.hotels.styx.routing.config.Builtins
-import com.hotels.styx.routing.config.Builtins.BUILTIN_HANDLER_SCHEMAS
-import com.hotels.styx.routing.config.StyxObjectReference
+import com.hotels.styx.api.HttpRequest
+import com.hotels.styx.config.schema.SchemaValidationException
 import com.hotels.styx.handle
+import com.hotels.styx.infrastructure.configuration.yaml.YamlConfig
 import com.hotels.styx.mockObject
 import com.hotels.styx.ref
 import com.hotels.styx.routeLookup
+import com.hotels.styx.routing.config.Builtins.BUILTIN_HANDLER_SCHEMAS
+import com.hotels.styx.routing.config.RoutingObjectFactory
 import com.hotels.styx.routingObjectDef
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
@@ -37,56 +33,10 @@ import io.kotlintest.specs.FeatureSpec
 import io.mockk.verify
 import reactor.core.publisher.toMono
 import java.nio.charset.StandardCharsets.UTF_8
-import java.util.Optional
 
 class PathPrefixRouterFactoryTest : FeatureSpec({
 
     val context = RoutingObjectFactoryContext()
-
-
-    feature("PathPrefixRouter") {
-//        scenario("No path prefixes configured") {
-//            val router = PathPrefixRouter(listOf())
-//
-//            router.route(get("/").build()) shouldBe Optional.empty()
-//        }
-
-//        scenario("Root path") {
-//            val rootHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("root"))
-//            val router = PathPrefixRouter(listOf(PathPrefixRouter.PrefixRoute("/", rootHandler)))
-//
-//            router.route(get("/").build()) shouldBe Optional.of(rootHandler)
-//            router.route(get("/foo/bar").build()) shouldBe Optional.of(rootHandler)
-//            router.route(get("/foo/bar/").build()) shouldBe Optional.of(rootHandler)
-//            router.route(get("/foo").build()) shouldBe Optional.of(rootHandler)
-//        }
-
-//        scenario("Choice of most specific path") {
-//            val fooFileHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-file"))
-//            val fooPathHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-path"))
-//            val fooBarFileHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-bar-file"))
-//            val fooBarPathHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-bar-path"))
-//            val fooBazFileHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-baz-file"))
-//
-//            val router = PathPrefixRouter(listOf(
-//                    PathPrefixRouter.PrefixRoute("/foo", fooFileHandler),
-//                    PathPrefixRouter.PrefixRoute("/foo/", fooPathHandler),
-//                    PathPrefixRouter.PrefixRoute("/foo/bar", fooBarFileHandler),
-//                    PathPrefixRouter.PrefixRoute("/foo/bar/", fooBarPathHandler),
-//                    PathPrefixRouter.PrefixRoute("/foo/baz", fooBazFileHandler)
-//            ))
-//
-//            router.route(get("/").build()) shouldBe Optional.empty()
-//            router.route(get("/foo").build()) shouldBe Optional.of(fooFileHandler)
-//            router.route(get("/foo/x").build()) shouldBe Optional.of(fooPathHandler)
-//            router.route(get("/foo/").build()) shouldBe Optional.of(fooPathHandler)
-//            router.route(get("/foo/bar").build()) shouldBe Optional.of(fooBarFileHandler)
-//            router.route(get("/foo/bar/x").build()) shouldBe Optional.of(fooBarPathHandler)
-//            router.route(get("/foo/bar/").build()) shouldBe Optional.of(fooBarPathHandler)
-//            router.route(get("/foo/baz/").build()) shouldBe Optional.of(fooBazFileHandler)
-//            router.route(get("/foo/baz/y").build()) shouldBe Optional.of(fooBazFileHandler)
-//        }
-    }
 
     feature("PathPrefixRouterFactory") {
 

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/PathPrefixRouterFactoryTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/PathPrefixRouterFactoryTest.kt
@@ -39,7 +39,7 @@ import reactor.core.publisher.toMono
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Optional
 
-class PathPrefixRouterTest : FeatureSpec({
+class PathPrefixRouterFactoryTest : FeatureSpec({
 
     val context = RoutingObjectFactoryContext()
 

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/PathPrefixRouterTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/PathPrefixRouterTest.kt
@@ -45,47 +45,47 @@ class PathPrefixRouterTest : FeatureSpec({
 
 
     feature("PathPrefixRouter") {
-        scenario("No path prefixes configured") {
-            val router = PathPrefixRouter(listOf())
+//        scenario("No path prefixes configured") {
+//            val router = PathPrefixRouter(listOf())
+//
+//            router.route(get("/").build()) shouldBe Optional.empty()
+//        }
 
-            router.route(get("/").build()) shouldBe Optional.empty()
-        }
+//        scenario("Root path") {
+//            val rootHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("root"))
+//            val router = PathPrefixRouter(listOf(PathPrefixRouter.PrefixRoute("/", rootHandler)))
+//
+//            router.route(get("/").build()) shouldBe Optional.of(rootHandler)
+//            router.route(get("/foo/bar").build()) shouldBe Optional.of(rootHandler)
+//            router.route(get("/foo/bar/").build()) shouldBe Optional.of(rootHandler)
+//            router.route(get("/foo").build()) shouldBe Optional.of(rootHandler)
+//        }
 
-        scenario("Root path") {
-            val rootHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("root"))
-            val router = PathPrefixRouter(listOf(pair("/", rootHandler)))
-
-            router.route(get("/").build()) shouldBe Optional.of(rootHandler)
-            router.route(get("/foo/bar").build()) shouldBe Optional.of(rootHandler)
-            router.route(get("/foo/bar/").build()) shouldBe Optional.of(rootHandler)
-            router.route(get("/foo").build()) shouldBe Optional.of(rootHandler)
-        }
-
-        scenario("Choice of most specific path") {
-            val fooFileHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-file"))
-            val fooPathHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-path"))
-            val fooBarFileHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-bar-file"))
-            val fooBarPathHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-bar-path"))
-            val fooBazFileHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-baz-file"))
-
-            val router = PathPrefixRouter(listOf(
-                    pair("/foo", fooFileHandler),
-                    pair("/foo/", fooPathHandler),
-                    pair("/foo/bar", fooBarFileHandler),
-                    pair("/foo/bar/", fooBarPathHandler),
-                    pair("/foo/baz", fooBazFileHandler)
-            ))
-
-            router.route(get("/").build()) shouldBe Optional.empty()
-            router.route(get("/foo").build()) shouldBe Optional.of(fooFileHandler)
-            router.route(get("/foo/x").build()) shouldBe Optional.of(fooPathHandler)
-            router.route(get("/foo/").build()) shouldBe Optional.of(fooPathHandler)
-            router.route(get("/foo/bar").build()) shouldBe Optional.of(fooBarFileHandler)
-            router.route(get("/foo/bar/x").build()) shouldBe Optional.of(fooBarPathHandler)
-            router.route(get("/foo/bar/").build()) shouldBe Optional.of(fooBarPathHandler)
-            router.route(get("/foo/baz/").build()) shouldBe Optional.of(fooBazFileHandler)
-            router.route(get("/foo/baz/y").build()) shouldBe Optional.of(fooBazFileHandler)
-        }
+//        scenario("Choice of most specific path") {
+//            val fooFileHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-file"))
+//            val fooPathHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-path"))
+//            val fooBarFileHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-bar-file"))
+//            val fooBarPathHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-bar-path"))
+//            val fooBazFileHandler = Builtins.build(listOf(""), context.get(), StyxObjectReference("foo-baz-file"))
+//
+//            val router = PathPrefixRouter(listOf(
+//                    PathPrefixRouter.PrefixRoute("/foo", fooFileHandler),
+//                    PathPrefixRouter.PrefixRoute("/foo/", fooPathHandler),
+//                    PathPrefixRouter.PrefixRoute("/foo/bar", fooBarFileHandler),
+//                    PathPrefixRouter.PrefixRoute("/foo/bar/", fooBarPathHandler),
+//                    PathPrefixRouter.PrefixRoute("/foo/baz", fooBazFileHandler)
+//            ))
+//
+//            router.route(get("/").build()) shouldBe Optional.empty()
+//            router.route(get("/foo").build()) shouldBe Optional.of(fooFileHandler)
+//            router.route(get("/foo/x").build()) shouldBe Optional.of(fooPathHandler)
+//            router.route(get("/foo/").build()) shouldBe Optional.of(fooPathHandler)
+//            router.route(get("/foo/bar").build()) shouldBe Optional.of(fooBarFileHandler)
+//            router.route(get("/foo/bar/x").build()) shouldBe Optional.of(fooBarPathHandler)
+//            router.route(get("/foo/bar/").build()) shouldBe Optional.of(fooBarPathHandler)
+//            router.route(get("/foo/baz/").build()) shouldBe Optional.of(fooBazFileHandler)
+//            router.route(get("/foo/baz/y").build()) shouldBe Optional.of(fooBazFileHandler)
+//        }
     }
 
     feature("PathPrefixRouterFactory") {


### PR DESCRIPTION
Move the routing object code into a separate class.
Change the ConcurrentSkipList into an array.
