### PR TITLE
Store target origin in request context

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
@@ -397,7 +397,7 @@ public final class OriginsInventory
         return origins.values().stream()
                 .filter(origin -> origin.state().equals(state))
                 .map(origin -> {
-                    HttpHandler hostClient = (request, context) -> new Eventual<>(origin.hostClient.sendRequest(request));
+                    HttpHandler hostClient = (request, context) -> new Eventual<>(origin.hostClient.sendRequest(request, context));
                     return remoteHost(origin.origin, hostClient, origin.hostClient);
                 })
                 .collect(toList());

--- a/components/client/src/main/java/com/hotels/styx/client/StyxHostHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHostHttpClient.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.hotels.styx.client;
 
+import com.hotels.styx.api.HttpInterceptor.Context;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.ResponseEventListener;
@@ -30,6 +31,8 @@ import static java.util.Objects.requireNonNull;
  * A Styx HTTP Client for proxying to an individual origin host.
  */
 public class StyxHostHttpClient implements LoadBalancingMetricSupplier {
+    public static final String ORIGINID_CONTEXT_KEY = "styx.originid";
+
     private final ConnectionPool pool;
 
     StyxHostHttpClient(ConnectionPool pool) {
@@ -40,7 +43,10 @@ public class StyxHostHttpClient implements LoadBalancingMetricSupplier {
         return new StyxHostHttpClient(pool);
     }
 
-    public Publisher<LiveHttpResponse> sendRequest(LiveHttpRequest request) {
+    public Publisher<LiveHttpResponse> sendRequest(LiveHttpRequest request, Context context) {
+        if (context != null) {
+            context.add(ORIGINID_CONTEXT_KEY, pool.getOrigin().id());
+        }
         return Flux.from(pool.borrowConnection())
                 .flatMap(connection -> {
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/StyxHostHttpClientTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/StyxHostHttpClientTest.java
@@ -17,11 +17,17 @@ package com.hotels.styx.client;
 
 import com.hotels.styx.api.Buffer;
 import com.hotels.styx.api.ByteStream;
+import com.hotels.styx.api.HttpInterceptor;
+import com.hotels.styx.api.HttpInterceptor.Context;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
+import com.hotels.styx.api.Id;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
+import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.client.connectionpool.ConnectionPool;
+import com.hotels.styx.server.HttpInterceptorContext;
+import com.hotels.styx.support.Support;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
@@ -34,6 +40,8 @@ import reactor.test.publisher.TestPublisher;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static com.hotels.styx.client.StyxHostHttpClient.ORIGINID_CONTEXT_KEY;
+import static com.hotels.styx.support.Support.requestContext;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -62,10 +70,11 @@ public class StyxHostHttpClientTest {
     public void returnsConnectionBackToPool() {
         Connection connection = mockConnection(just(response));
         ConnectionPool pool = mockPool(connection);
+        Context context = mockContext();
 
         StyxHostHttpClient hostClient = new StyxHostHttpClient(pool);
 
-        StepVerifier.create(hostClient.sendRequest(request))
+        StepVerifier.create(hostClient.sendRequest(request, context))
                 .consumeNextWith(response -> response.consume())
                 .expectComplete()
                 .verify();
@@ -73,6 +82,7 @@ public class StyxHostHttpClientTest {
         verify(pool).borrowConnection();
         verify(connection).write(any(LiveHttpRequest.class));
         verify(pool).returnConnection(any(Connection.class));
+        verify(context).add(ORIGINID_CONTEXT_KEY, Id.id("mockorigin"));
     }
 
     @Test
@@ -82,13 +92,14 @@ public class StyxHostHttpClientTest {
         // been published.
         Connection connection = mockConnection(just(response));
         ConnectionPool pool = mockPool(connection);
+        Context context = mockContext();
         AtomicReference<LiveHttpResponse> transformedResponse = new AtomicReference<>();
 
         StyxHostHttpClient hostClient = new StyxHostHttpClient(pool);
 
         // The StepVerifier consumes the response event and then unsubscribes
         // from the response observable.
-        StepVerifier.create(hostClient.sendRequest(request))
+        StepVerifier.create(hostClient.sendRequest(request, context))
                 .consumeNextWith(transformedResponse::set)
                 .verifyComplete();
 
@@ -101,17 +112,20 @@ public class StyxHostHttpClientTest {
 
         // Finally, the connection is returned after the response body is fully consumed:
         verify(pool).returnConnection(any(Connection.class));
+
+        verify(context).add(ORIGINID_CONTEXT_KEY, Id.id("mockorigin"));
     }
 
     @Test
     public void releasesIfRequestIsCancelledBeforeHeaders() {
         Connection connection = mockConnection(EmitterProcessor.create());
         ConnectionPool pool = mockPool(connection);
+        Context context = mockContext();
 
         StyxHostHttpClient hostClient = new StyxHostHttpClient(pool);
         AtomicReference<Subscription> subscription = new AtomicReference<>();
 
-        Flux.from(hostClient.sendRequest(request))
+        Flux.from(hostClient.sendRequest(request, context))
                 .subscribe(new BaseSubscriber<LiveHttpResponse>() {
                     @Override
                     protected void hookOnSubscribe(Subscription s) {
@@ -123,17 +137,19 @@ public class StyxHostHttpClientTest {
 
         subscription.get().cancel();
         verify(pool).closeConnection(any(Connection.class));
+        verify(context).add(ORIGINID_CONTEXT_KEY, Id.id("mockorigin"));
     }
 
     @Test
     public void ignoresResponseObservableErrorsAfterHeaders() {
         Connection connection = mockConnection(responseProvider);
         ConnectionPool pool = mockPool(connection);
+        Context context = mockContext();
         AtomicReference<LiveHttpResponse> newResponse = new AtomicReference<>();
 
         StyxHostHttpClient hostClient = new StyxHostHttpClient(pool);
 
-        StepVerifier.create(hostClient.sendRequest(request))
+        StepVerifier.create(hostClient.sendRequest(request, context))
                 .then(() -> {
                     responseProvider.onNext(response);
                     responseProvider.onError(new RuntimeException("oh dear ..."));
@@ -145,6 +161,7 @@ public class StyxHostHttpClientTest {
         newResponse.get().consume();
 
         verify(pool).returnConnection(any(Connection.class));
+        verify(context).add(ORIGINID_CONTEXT_KEY, Id.id("mockorigin"));
     }
 
     @Test
@@ -152,31 +169,35 @@ public class StyxHostHttpClientTest {
         // A connection that yields no response:
         Connection connection = mockConnection(Flux.empty());
         ConnectionPool pool = mockPool(connection);
+        Context context = mockContext();
 
         StyxHostHttpClient hostClient = new StyxHostHttpClient(pool);
 
-        StepVerifier.create(hostClient.sendRequest(request))
+        StepVerifier.create(hostClient.sendRequest(request, context))
                 .expectNextCount(0)
                 .expectComplete()
                 .log()
                 .verify();
 
         verify(pool).closeConnection(any(Connection.class));
+        verify(context).add(ORIGINID_CONTEXT_KEY, Id.id("mockorigin"));
     }
 
     @Test
     public void releasesConnectionWhenResponseFailsBeforeHeaders() {
         Connection connection = mockConnection(Flux.error(new RuntimeException()));
         ConnectionPool pool = mockPool(connection);
+        Context context = mockContext();
 
         StyxHostHttpClient hostClient = new StyxHostHttpClient(pool);
 
-        StepVerifier.create(hostClient.sendRequest(request))
+        StepVerifier.create(hostClient.sendRequest(request, context))
                 .expectNextCount(0)
                 .expectError()
                 .verify();
 
         verify(pool).closeConnection(any(Connection.class));
+        verify(context).add(ORIGINID_CONTEXT_KEY, Id.id("mockorigin"));
     }
 
     @Test
@@ -184,11 +205,12 @@ public class StyxHostHttpClientTest {
         TestPublisher<Buffer> testPublisher = TestPublisher.create();
         Connection connection = mockConnection(just(LiveHttpResponse.response(OK).body(new ByteStream(testPublisher)).build()));
         ConnectionPool pool = mockPool(connection);
+        Context context = mockContext();
         AtomicReference<LiveHttpResponse> receivedResponse = new AtomicReference<>();
 
         StyxHostHttpClient hostClient = new StyxHostHttpClient(pool);
 
-        StepVerifier.create(hostClient.sendRequest(request))
+        StepVerifier.create(hostClient.sendRequest(request, context))
                 .consumeNextWith(receivedResponse::set)
                 .expectComplete()
                 .verify();
@@ -198,6 +220,7 @@ public class StyxHostHttpClientTest {
                 .verify();
 
         verify(pool).closeConnection(any(Connection.class));
+        verify(context).add(ORIGINID_CONTEXT_KEY, Id.id("mockorigin"));
     }
 
     @Test
@@ -219,6 +242,18 @@ public class StyxHostHttpClientTest {
     ConnectionPool mockPool(Connection connection) {
         ConnectionPool pool = mock(ConnectionPool.class);
         when(pool.borrowConnection()).thenReturn(Flux.just(connection));
+        Origin origin = mockOrigin("mockorigin");
+        when(pool.getOrigin()).thenReturn(origin);
         return pool;
+    }
+
+    Origin mockOrigin(String id) {
+        Origin origin = mock(Origin.class);
+        when(origin.id()).thenReturn(Id.id(id));
+        return origin;
+    }
+
+    HttpInterceptor.Context mockContext() {
+        return mock(HttpInterceptor.Context.class);
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
@@ -134,7 +134,7 @@ public class HostProxy implements RoutingObject {
     public Eventual<LiveHttpResponse> handle(LiveHttpRequest request, HttpInterceptor.Context context) {
         if (active) {
             return new Eventual<>(
-                    ResponseEventListener.from(client.sendRequest(request))
+                    ResponseEventListener.from(client.sendRequest(request, context))
                             .whenCancelled(originMetrics::requestCancelled)
                             .apply());
         } else {

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/StyxBackendServiceClientFactoryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/StyxBackendServiceClientFactoryTest.java
@@ -17,6 +17,7 @@ package com.hotels.styx.proxy;
 
 import com.hotels.styx.Environment;
 import com.hotels.styx.StyxConfig;
+import com.hotels.styx.api.HttpInterceptor.Context;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.configuration.Configuration.MapBackedConfiguration;
@@ -186,7 +187,7 @@ public class StyxBackendServiceClientFactoryTest {
 
     private StyxHostHttpClient hostClient(LiveHttpResponse response) {
         StyxHostHttpClient mockClient = mock(StyxHostHttpClient.class);
-        when(mockClient.sendRequest(any(LiveHttpRequest.class))).thenReturn(Flux.just(response));
+        when(mockClient.sendRequest(any(LiveHttpRequest.class), any(Context.class))).thenReturn(Flux.just(response));
         when(mockClient.loadBalancingMetric()).thenReturn(new LoadBalancingMetric(1));
         return mockClient;
     }

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/HostProxyTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/handlers/HostProxyTest.kt
@@ -26,6 +26,7 @@ import com.hotels.styx.api.LiveHttpResponse
 import com.hotels.styx.client.StyxHostHttpClient
 import com.hotels.styx.client.applications.metrics.OriginMetrics
 import com.hotels.styx.RoutingObjectFactoryContext
+import com.hotels.styx.api.HttpInterceptor.Context
 import com.hotels.styx.handle
 import com.hotels.styx.requestContext
 import com.hotels.styx.routingObjectDef
@@ -51,7 +52,7 @@ class HostProxyTest : FeatureSpec() {
                 HostProxy("localhost", 80, client, mockk()).handle(request.stream(), mockk())
 
                 verify {
-                    client!!.sendRequest(ofType(LiveHttpRequest::class))
+                    client!!.sendRequest(ofType(LiveHttpRequest::class), ofType(Context::class))
                 }
             }
 
@@ -69,7 +70,7 @@ class HostProxyTest : FeatureSpec() {
                 exception.message shouldBe ("HostProxy localhost:80 is stopped but received traffic.")
 
                 verify(exactly = 0) {
-                    client!!.sendRequest(any())
+                    client!!.sendRequest(any(), any())
                 }
             }
 
@@ -77,7 +78,7 @@ class HostProxyTest : FeatureSpec() {
                 val client = mockk<StyxHostHttpClient>()
                 val originMetrics = mockk<OriginMetrics>()
 
-                every { client.sendRequest(any()) } returns Eventual(Mono.never())
+                every { client.sendRequest(any(), any()) } returns Eventual(Mono.never())
 
                 val hostProxy = HostProxy("abc", 80, client, originMetrics)
 
@@ -93,7 +94,7 @@ class HostProxyTest : FeatureSpec() {
                 val client = mockk<StyxHostHttpClient>()
                 val originMetrics = mockk<OriginMetrics>()
 
-                every { client.sendRequest(any()) } returns Eventual.of(
+                every { client.sendRequest(any(), any()) } returns Eventual.of(
                         LiveHttpResponse
                                 .response()
                                 .body(ByteStream(Flux.never()))
@@ -164,7 +165,7 @@ class HostProxyTest : FeatureSpec() {
 
     override fun beforeTest(testCase: TestCase) {
         client = mockk(relaxed = true) {
-            every { sendRequest(any()) } returns Eventual.of(HttpResponse.response(OK).build().stream())
+            every { sendRequest(any(), any()) } returns Eventual.of(HttpResponse.response(OK).build().stream())
         }
     }
 

--- a/system-tests/e2e-suite/src/test/java/com/hotels/styx/plugins/OnCompleteErrorPlugin.java
+++ b/system-tests/e2e-suite/src/test/java/com/hotels/styx/plugins/OnCompleteErrorPlugin.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
See Issue #657 
The ID of the origin to which the request has been routed is stored in the request context, under the key `styx.originid`. The type of the ID is `com.hotels.styx.api.Id`.