### PR TITLE
Custom Via Header Support

### DIFF
--- a/components/common/src/main/java/com/hotels/styx/common/Strings.java
+++ b/components/common/src/main/java/com/hotels/styx/common/Strings.java
@@ -25,6 +25,14 @@ public final class Strings {
         return !isNullOrEmpty(s);
     }
 
+    public static final boolean isBlank(final String s) {
+        return isNullOrEmpty(s) || isNullOrEmpty(s.trim());
+    }
+
+    public static final boolean isNotBlank(final String s) {
+        return !isBlank(s);
+    }
+
     private Strings() {
         // Not used.
     }

--- a/components/proxy/src/main/java/com/hotels/styx/BuiltInInterceptors.java
+++ b/components/proxy/src/main/java/com/hotels/styx/BuiltInInterceptors.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -50,10 +50,14 @@ final class BuiltInInterceptors {
             builder.add(new HttpMessageLoggingInterceptor(longFormatEnabled, httpMessageFormatter));
         }
 
+        final HttpInterceptor viaInterceptor = config.get("via")
+                .map(ViaHeaderAppendingInterceptor::new)
+                .orElseGet(ViaHeaderAppendingInterceptor::new);
+
         builder.add(new TcpTunnelRequestRejector())
                 .add(new ConfigurationContextResolverInterceptor(EMPTY_CONFIGURATION_CONTEXT_RESOLVER))
                 .add(new UnexpectedRequestContentLengthRemover())
-                .add(new ViaHeaderAppendingInterceptor())
+                .add(viaInterceptor)
                 .add(new HopByHopHeadersRemovingInterceptor())
                 .add(new RequestEnrichingInterceptor(config.styxHeaderConfig()));
 

--- a/components/proxy/src/main/java/com/hotels/styx/BuiltInInterceptors.java
+++ b/components/proxy/src/main/java/com/hotels/styx/BuiltInInterceptors.java
@@ -50,14 +50,12 @@ final class BuiltInInterceptors {
             builder.add(new HttpMessageLoggingInterceptor(longFormatEnabled, httpMessageFormatter));
         }
 
-        final HttpInterceptor viaInterceptor = config.get("via")
-                .map(ViaHeaderAppendingInterceptor::new)
-                .orElseGet(ViaHeaderAppendingInterceptor::new);
-
         builder.add(new TcpTunnelRequestRejector())
                 .add(new ConfigurationContextResolverInterceptor(EMPTY_CONFIGURATION_CONTEXT_RESOLVER))
                 .add(new UnexpectedRequestContentLengthRemover())
-                .add(viaInterceptor)
+                .add(config.proxyServerConfig().via()
+                        .map(ViaHeaderAppendingInterceptor::new)
+                        .orElseGet(ViaHeaderAppendingInterceptor::new))
                 .add(new HopByHopHeadersRemovingInterceptor())
                 .add(new RequestEnrichingInterceptor(config.styxHeaderConfig()));
 

--- a/components/proxy/src/main/java/com/hotels/styx/ServerConfigSchema.java
+++ b/components/proxy/src/main/java/com/hotels/styx/ServerConfigSchema.java
@@ -90,7 +90,8 @@ final class ServerConfigSchema {
                                     optional("maxContentLength", integer()),
                                     optional("requestTimeoutMillis", integer()),
                                     optional("keepAliveTimeoutMillis", integer()),
-                                    optional("maxConnectionsCount", integer())
+                                    optional("maxConnectionsCount", integer()),
+                                    optional("via", string())
                             )),
                             field("admin", object(
                                     field("connectors", serverConnectorsSchema),

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyServerConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/ProxyServerConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -22,15 +22,19 @@ import com.hotels.styx.server.HttpConnectorConfig;
 import com.hotels.styx.server.HttpsConnectorConfig;
 import com.hotels.styx.server.netty.NettyServerConfig;
 
+import java.util.Optional;
+
 /**
  * Configuration for proxy server.
  */
 @JsonDeserialize(builder = ProxyServerConfig.Builder.class)
 public class ProxyServerConfig extends NettyServerConfig {
     private final int clientWorkerThreadsCount;
+    private final String via;
 
     public ProxyServerConfig() {
         this.clientWorkerThreadsCount = HALF_OF_AVAILABLE_PROCESSORS;
+        this.via = null;
     }
 
     private ProxyServerConfig(Builder builder) {
@@ -39,10 +43,15 @@ public class ProxyServerConfig extends NettyServerConfig {
         Integer clientThreads = builder.clientWorkerThreadsCount;
 
         this.clientWorkerThreadsCount = clientThreads == null || clientThreads == 0 ? HALF_OF_AVAILABLE_PROCESSORS : clientThreads;
+        this.via = builder.via;
     }
 
     public int clientWorkerThreadsCount() {
         return clientWorkerThreadsCount;
+    }
+
+    public Optional<String> via() {
+        return Optional.ofNullable(via);
     }
 
     /**
@@ -52,6 +61,7 @@ public class ProxyServerConfig extends NettyServerConfig {
     public static class Builder {
         private final NettyServerConfig.Builder builder = new NettyServerConfig.Builder();
         private Integer clientWorkerThreadsCount;
+        private String via;
 
         @JsonProperty("bossThreadsCount")
         public Builder setBossThreadsCount(Integer bossThreadsCount) {
@@ -132,6 +142,12 @@ public class ProxyServerConfig extends NettyServerConfig {
         @JsonProperty("compressResponses")
         public Builder setCompressResponses(boolean compressResponses) {
             builder.setCompressResponses(compressResponses);
+            return this;
+        }
+
+        @JsonProperty("via")
+        public Builder setVia(final String via) {
+            this.via = via;
             return this;
         }
 

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/interceptors/ViaHeaderAppendingInterceptor.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/interceptors/ViaHeaderAppendingInterceptor.java
@@ -16,53 +16,65 @@
 package com.hotels.styx.proxy.interceptors;
 
 import com.hotels.styx.api.Eventual;
+import com.hotels.styx.api.HttpHeaderNames;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpVersion;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
+import io.netty.util.AsciiString;
 
-import static com.hotels.styx.api.HttpHeaderNames.VIA;
 import static com.hotels.styx.api.HttpVersion.HTTP_1_0;
+import static com.hotels.styx.common.Strings.isBlank;
 import static com.hotels.styx.common.Strings.isNotEmpty;
-import static io.netty.handler.codec.http.HttpHeaders.newEntity;
 
 /**
  * Add support for "Via" header as per described in Chapter 9.9 in the HTTP/1.1 specification.
  *
  */
 public class ViaHeaderAppendingInterceptor implements HttpInterceptor {
-    private static final CharSequence VIA_STYX_1_0 = newEntity("1.0 styx");
-    private static final CharSequence VIA_STYX_1_1 = newEntity("1.1 styx");
+    private static final String VIA = "styx";
+    private final CharSequence via_1_0;
+    private final CharSequence via_1_1;
+
+    public ViaHeaderAppendingInterceptor() {
+        this(VIA);
+    }
+
+    public ViaHeaderAppendingInterceptor(final String via) {
+        final String value = isBlank(via) ? VIA : via;
+        via_1_0 = AsciiString.of("1.0 " + value);
+        via_1_1 = AsciiString.of("1.1 " + value);
+    }
 
     @Override
     public Eventual<LiveHttpResponse> intercept(LiveHttpRequest request, Chain chain) {
         LiveHttpRequest newRequest = request.newBuilder()
-                .header(VIA, viaHeader(request))
+                .header(HttpHeaderNames.VIA, viaHeader(request))
                 .build();
 
         return chain.proceed(newRequest)
                 .map(response -> response.newBuilder()
-                        .header(VIA, viaHeader(response))
+                        .header(HttpHeaderNames.VIA, viaHeader(response))
                         .build());
     }
 
-    private static CharSequence viaHeader(LiveHttpRequest httpMessage) {
+    private CharSequence viaHeader(LiveHttpRequest httpMessage) {
         CharSequence styxViaEntry = styxViaEntry(httpMessage.version());
 
-        return httpMessage.headers().get(VIA)
+        return httpMessage.headers().get(HttpHeaderNames.VIA)
                 .map(viaHeader -> isNotEmpty(viaHeader) ? viaHeader + ", " + styxViaEntry : styxViaEntry)
                 .orElse(styxViaEntry);
     }
 
-    private static CharSequence viaHeader(LiveHttpResponse httpMessage) {
+    private CharSequence viaHeader(LiveHttpResponse httpMessage) {
         CharSequence styxViaEntry = styxViaEntry(httpMessage.version());
 
-        return httpMessage.headers().get(VIA)
+        return httpMessage.headers().get(HttpHeaderNames.VIA)
                 .map(viaHeader -> isNotEmpty(viaHeader) ? viaHeader + ", " + styxViaEntry : styxViaEntry)
                 .orElse(styxViaEntry);
     }
 
-    private static CharSequence styxViaEntry(HttpVersion httpVersion) {
-        return httpVersion.equals(HTTP_1_0) ? VIA_STYX_1_0 : VIA_STYX_1_1;
+    private CharSequence styxViaEntry(HttpVersion httpVersion) {
+        return httpVersion.equals(HTTP_1_0) ? via_1_0 : via_1_1;
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ViaHeaderAppendingInterceptorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ViaHeaderAppendingInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,10 +33,10 @@ import static com.hotels.styx.support.matchers.IsOptional.isValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ViaHeaderAppendingInterceptorTest {
-    final ReturnResponseChain ANY_RESPONSE_HANDLER = returnsResponse(response().build());
-    final HttpInterceptor interceptor = new ViaHeaderAppendingInterceptor();
+    private final ReturnResponseChain ANY_RESPONSE_HANDLER = returnsResponse(response().build());
+    private final HttpInterceptor interceptor = new ViaHeaderAppendingInterceptor();
 
-    private LiveHttpRequest interceptRequest(LiveHttpRequest request) {
+    private LiveHttpRequest interceptRequest(final HttpInterceptor interceptor, final LiveHttpRequest request) {
         RequestRecordingChain recording = requestRecordingChain(ANY_RESPONSE_HANDLER);
         interceptor.intercept(request, recording);
         return recording.recordedRequest();
@@ -48,7 +48,7 @@ public class ViaHeaderAppendingInterceptorTest {
                 .header(HOST, "www.example.com:8000")
                 .build();
 
-        LiveHttpRequest interceptedRequest = interceptRequest(request);
+        LiveHttpRequest interceptedRequest = interceptRequest(interceptor, request);
         assertThat(interceptedRequest.headers().get(VIA), isValue("1.1 styx"));
     }
 
@@ -58,7 +58,7 @@ public class ViaHeaderAppendingInterceptorTest {
                 .header(VIA, "")
                 .build();
 
-        LiveHttpRequest interceptedRequest = interceptRequest(request);
+        LiveHttpRequest interceptedRequest = interceptRequest(interceptor, request);
         assertThat(interceptedRequest.headers().get(VIA), isValue("1.1 styx"));
     }
 
@@ -69,7 +69,7 @@ public class ViaHeaderAppendingInterceptorTest {
                 .header(VIA, "")
                 .build();
 
-        LiveHttpRequest interceptedRequest = interceptRequest(request);
+        LiveHttpRequest interceptedRequest = interceptRequest(interceptor, request);
         assertThat(interceptedRequest.headers().get(VIA), isValue("1.0 styx"));
     }
 
@@ -85,7 +85,7 @@ public class ViaHeaderAppendingInterceptorTest {
                 .header(VIA, "1.0 ricky, 1.1 mertz, 1.0 lucy")
                 .build();
 
-        LiveHttpRequest interceptedRequest = interceptRequest(request);
+        LiveHttpRequest interceptedRequest = interceptRequest(interceptor, request);
         assertThat(interceptedRequest.headers().get(VIA), isValue("1.0 ricky, 1.1 mertz, 1.0 lucy, 1.1 styx"));
     }
 
@@ -96,5 +96,18 @@ public class ViaHeaderAppendingInterceptorTest {
                         .build()))).block();
 
         assertThat(response.headers().get(VIA), isValue("1.0 ricky, 1.1 mertz, 1.0 lucy, 1.1 styx"));
+    }
+
+    @Test
+    public void addsCustomViaHeader() throws Exception {
+        final String customVia = "MyAwesomeProxy";
+        final ViaHeaderAppendingInterceptor localInterceptor = new ViaHeaderAppendingInterceptor(customVia);
+        final LiveHttpRequest request = post("/foo")
+                .header(HOST, "www.example.com:8000")
+                .build();
+
+        final LiveHttpRequest interceptedRequest = interceptRequest(localInterceptor, request);
+
+        assertThat(interceptedRequest.headers().get(VIA), isValue("1.1 " + customVia));
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ViaHeaderAppendingInterceptorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/ViaHeaderAppendingInterceptorTest.java
@@ -101,12 +101,11 @@ public class ViaHeaderAppendingInterceptorTest {
     @Test
     public void addsCustomViaHeader() throws Exception {
         final String customVia = "MyAwesomeProxy";
-        final ViaHeaderAppendingInterceptor localInterceptor = new ViaHeaderAppendingInterceptor(customVia);
-        final LiveHttpRequest request = post("/foo")
-                .header(HOST, "www.example.com:8000")
-                .build();
 
-        final LiveHttpRequest interceptedRequest = interceptRequest(localInterceptor, request);
+        final LiveHttpRequest interceptedRequest = interceptRequest(new ViaHeaderAppendingInterceptor(customVia),
+                post("/foo")
+                        .header(HOST, "www.example.com:8000")
+                        .build());
 
         assertThat(interceptedRequest.headers().get(VIA), isValue("1.1 " + customVia));
     }


### PR DESCRIPTION
Adds ability to configure a custom `via` header value for Styx server.

Sample configuration:

```
proxy:
  via: myStyxApp
```
