### PR TITLE
Fix toxiproxy configuration in test environment.

### DIFF
--- a/system-tests/docker-test-env/README.md
+++ b/system-tests/docker-test-env/README.md
@@ -53,7 +53,7 @@ $ curl http://localhost:8474/proxies | jq
 Applying toxics:
 
 ```bash
-$ curl -v -X POST -H "Content-Type: application/json" -d @system-tests/docker-test-env/toxiproxy/origin-latency.json http://localhost:8474/proxies/httpd-01/toxics
+$ curl -v -X POST -H "Content-Type: application/json" -d @system-tests/docker-test-env/toxiproxy/origin-latency.json http://localhost:8474/proxies/origin-01/toxics
 ```
 
 Removing toxics:

--- a/system-tests/docker-test-env/styx-config/origins.yml
+++ b/system-tests/docker-test-env/styx-config/origins.yml
@@ -37,13 +37,14 @@
 
 - id: "toxiproxy"
   path: "/toxi"
-  healthCheck:
-    uri: /hello.txt
   connectionPool:
     maxConnectionsPerHost: 45
     maxPendingConnectionsPerHost: 15
     connectTimeoutMillis: 1000
     pendingConnectionTimeoutMillis: 8000
   responseTimeoutMillis: 60000
+  rewrites:
+    - urlPattern: "/toxi/(.*)"
+      replacement: "/$1"
   origins:
     - { id: "toxiproxy-01", host: "toxiproxy:8080" }


### PR DESCRIPTION
Strip the `/toxi/` prefix away from the request URL, so that nginx origin will find the correct static asset.

Add a correct origin-id to the toxi-proxy usage examples.

Disable health checking from toxi-proxy endpoint. Otherwise the toxics will probably take the origin out of rotation.
