### PR TITLE
Provide control of Graphite metrics tags support

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteConfig.java
@@ -28,25 +28,20 @@ public class GraphiteConfig {
     private final String host;
     private final int port;
     private final long intervalMillis;
-    private final String prefix;
     private final boolean enabled;
+    private final boolean tagsEnabled;
 
     @JsonCreator
     GraphiteConfig(@JsonProperty("host") String host,
                    @JsonProperty("port") Integer port,
                    @JsonProperty("intervalMillis") Long intervalMillis,
-                   @JsonProperty("prefix") String prefix,
-                   @JsonProperty("enabled") Boolean enabled) {
+                   @JsonProperty("enabled") Boolean enabled,
+                   @JsonProperty("tagsEnabled") Boolean tagsEnabled) {
         this.host = host;
         this.port = ofNullable(port).orElse(9090);
         this.intervalMillis = ofNullable(intervalMillis).orElse(SECONDS.toMillis(5));
-        this.prefix = ofNullable(prefix).orElse("");
         this.enabled = ofNullable(enabled).orElse(true);
-    }
-
-    @JsonProperty("prefix")
-    public String prefix() {
-        return prefix;
+        this.tagsEnabled = ofNullable(tagsEnabled).orElse(false);
     }
 
     @JsonProperty("host")
@@ -69,6 +64,11 @@ public class GraphiteConfig {
         return enabled;
     }
 
+    @JsonProperty("tagsEnabled")
+    public boolean tagsEnabled() {
+        return tagsEnabled;
+    }
+
     @Override
     public String toString() {
         return this.getClass().getSimpleName()
@@ -77,6 +77,7 @@ public class GraphiteConfig {
                 + "port=" + port + ","
                 + "intervalMillis=" + intervalMillis + ","
                 + "enabled=" + enabled + ","
+                + "tagsEnabled=" + tagsEnabled
                 + "}";
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterService.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterService.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
+import static io.micrometer.core.instrument.config.validate.PropertyValidator.getBoolean;
 import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -72,9 +73,9 @@ public final class GraphiteReporterService extends AbstractStyxService {
         private String serviceName;
         private String host;
         private int port;
-        private String prefix;
         private long reportingIntervalMillis;
         private boolean enabled;
+        private boolean tagsEnabled;
 
         public Builder meterRegistry(@NotNull MeterRegistry meterRegistry) {
             this.meterRegistry = meterRegistry;
@@ -96,11 +97,6 @@ public final class GraphiteReporterService extends AbstractStyxService {
             return this;
         }
 
-        public Builder prefix(String prefix) {
-            this.prefix = prefix;
-            return this;
-        }
-
         public Builder reportingIntervalMillis(long reportingIntervalMillis) {
             this.reportingIntervalMillis = reportingIntervalMillis;
             return this;
@@ -108,6 +104,11 @@ public final class GraphiteReporterService extends AbstractStyxService {
 
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
+            return this;
+        }
+
+        public Builder tagsEnabled(boolean tagsEnabled) {
+            this.tagsEnabled = tagsEnabled;
             return this;
         }
 
@@ -128,10 +129,9 @@ public final class GraphiteReporterService extends AbstractStyxService {
             return null;
         }
 
-        @NotNull
         @Override
-        public String prefix() {
-            return builder.prefix;
+        public boolean graphiteTagsEnabled() {
+            return builder.tagsEnabled;
         }
 
         @NotNull

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterService.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterService.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import static io.micrometer.core.instrument.config.validate.PropertyValidator.getBoolean;
 import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -37,8 +36,8 @@ import static org.slf4j.LoggerFactory.getLogger;
 public final class GraphiteReporterService extends AbstractStyxService {
     private static final Logger LOGGER = getLogger(GraphiteReporterService.class);
     private final MeterRegistry meterRegistry;
+    private final MicrometerGraphiteConfig graphiteConfig;
     private GraphiteMeterRegistry graphiteMeterRegistry;
-    private MicrometerGraphiteConfig graphiteConfig;
 
     private GraphiteReporterService(Builder builder) {
         super(builder.serviceName);
@@ -120,7 +119,7 @@ public final class GraphiteReporterService extends AbstractStyxService {
     private static final class MicrometerGraphiteConfig implements GraphiteConfig {
         private final Builder builder;
 
-        public MicrometerGraphiteConfig(final Builder builder) {
+        public MicrometerGraphiteConfig(Builder builder) {
             this.builder = builder;
         }
 

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterServiceFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterServiceFactory.java
@@ -38,9 +38,9 @@ public class GraphiteReporterServiceFactory implements ServiceFactory<StyxServic
                 .serviceName(format("Graphite-Reporter-%s:%d", host, port))
                 .host(host)
                 .port(port)
-                .prefix(graphiteConfig.prefix())
                 .reportingIntervalMillis(graphiteConfig.intervalMillis())
                 .enabled(graphiteConfig.enabled())
+                .tagsEnabled(graphiteConfig.tagsEnabled())
                 .build();
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterServiceTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterServiceTest.java
@@ -17,10 +17,7 @@ package com.hotels.styx.metrics.reporting.graphite;
 
 import com.hotels.styx.common.StyxFutures;
 import com.hotels.styx.support.matchers.LoggingTestSupport;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.graphite.GraphiteConfig;
 import io.micrometer.graphite.GraphiteDimensionalNamingConvention;
 import io.micrometer.graphite.GraphiteHierarchicalNamingConvention;
 import io.micrometer.graphite.GraphiteMeterRegistry;

--- a/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterServiceTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterServiceTest.java
@@ -78,7 +78,6 @@ public class GraphiteReporterServiceTest {
         } finally {
             StyxFutures.await(service.stop());
         }
-
     }
 
     @Test
@@ -92,7 +91,6 @@ public class GraphiteReporterServiceTest {
         } finally {
             StyxFutures.await(service.stop());
         }
-
     }
 
     @Test
@@ -106,9 +104,5 @@ public class GraphiteReporterServiceTest {
         } finally {
             StyxFutures.await(service.stop());
         }
-
     }
-
-
-
 }


### PR DESCRIPTION
By default, the Graphite reporter assumes that Graphite does not support tags on metrics. The reporter configuration can be changed to `tagsEnabled: true` to send tags to Graphite.

Also removed the `prefix` configuration item from the Graphite config. This prefix feature does not exist in the micrometer graphite integration.