### PR TITLE
Extend timeouts in tests (for machines with slower connection establishment)

### DIFF
--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/ConnectionPools.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/ConnectionPools.java
@@ -75,7 +75,10 @@ public final class ConnectionPools {
                         .build());
     }
 
-    private static ConnectionPool poolForOrigin(ConnectionPoolSettings connectionPoolSettings, Origin origin, MetricRegistry metricRegistry, NettyConnectionFactory connectionFactory) {
+    private static ConnectionPool poolForOrigin(ConnectionPoolSettings connectionPoolSettings,
+                                                Origin origin,
+                                                MetricRegistry metricRegistry,
+                                                NettyConnectionFactory connectionFactory) {
         return new StatsReportingConnectionPool(
                 new SimpleConnectionPool(
                         origin,

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/ConnectionPools.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/ConnectionPools.java
@@ -75,11 +75,11 @@ public final class ConnectionPools {
                         .build());
     }
 
-    private static ConnectionPool poolForOrigin(Origin origin, MetricRegistry metricRegistry, NettyConnectionFactory connectionFactory) {
+    private static ConnectionPool poolForOrigin(ConnectionPoolSettings connectionPoolSettings, Origin origin, MetricRegistry metricRegistry, NettyConnectionFactory connectionFactory) {
         return new StatsReportingConnectionPool(
                 new SimpleConnectionPool(
                         origin,
-                        defaultConnectionPoolSettings(),
+                        connectionPoolSettings,
                         connectionFactory),
                 metricRegistry
         );
@@ -98,6 +98,6 @@ public final class ConnectionPools {
                                 .build())
                 .build();
 
-        return origin -> poolForOrigin(origin, metricRegistry, connectionFactory);
+        return origin -> poolForOrigin(backendService.connectionPoolConfig(), origin, metricRegistry, connectionFactory);
     }
 }

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/RetryHandlingSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/RetryHandlingSpec.scala
@@ -16,6 +16,7 @@
 package com.hotels.styx.client
 
 import java.nio.charset.Charset
+import java.util.concurrent.TimeUnit.SECONDS
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -25,6 +26,7 @@ import com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH
 import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.LiveHttpRequest
 import com.hotels.styx.api.LiveHttpRequest.get
+import com.hotels.styx.api.`extension`.service.ConnectionPoolSettings
 import com.hotels.styx.api.extension.Origin._
 import com.hotels.styx.api.extension.service.{BackendService, StickySessionConfig}
 import com.hotels.styx.api.extension.{ActiveOrigins, Origin}
@@ -127,6 +129,11 @@ class RetryHandlingSpec extends FunSuite with BeforeAndAfterAll with Matchers wi
   test("retries the next available origin on failure") {
     val backendService = new BackendService.Builder()
       .origins(unhealthyOriginOne, unhealthyOriginTwo, unhealthyOriginThree, healthyOriginTwo)
+      .connectionPoolConfig(
+        new ConnectionPoolSettings.Builder()
+          .pendingConnectionTimeout(10, SECONDS)
+          .build()
+      )
       .build()
 
     val client: StyxBackendServiceClient = newHttpClientBuilder(backendService.id)

--- a/components/proxy/src/test/java/com/hotels/styx/StyxServerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/StyxServerTest.java
@@ -324,7 +324,8 @@ public class StyxServerTest {
     private static void eventually(Runnable block) {
         long startTime = currentTimeMillis();
         Throwable lastError = null;
-        while (currentTimeMillis() - startTime < 3000) {
+        // Note: since this returns as soon as it completes the task without error, it will only hit the maximum time if the test fails.
+        while (currentTimeMillis() - startTime < 30000) {
             try {
                 block.run();
                 return;


### PR DESCRIPTION
These changes will only increase the duration of failures of the particular tests altered. 
For passing builds, and builds whose failures are unrelated to these tests, nothing will change.