### PR TITLE
Reduction of Styx build log size by ~40%

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
@@ -54,7 +54,7 @@ public abstract class AbstractStyxService implements StyxService {
 
     public AbstractStyxService(String name) {
         this.name = name;
-        LOGGER.info("Created {}", name);
+        LOGGER.debug("Created {}", name);
     }
 
     public StyxServiceStatus status() {
@@ -72,14 +72,14 @@ public abstract class AbstractStyxService implements StyxService {
     @Override
     public CompletableFuture<Void> start() {
         boolean changed = status.compareAndSet(CREATED, STARTING);
-        LOGGER.info("Starting {}", name);
+        LOGGER.debug("Starting {}", name);
 
         if (changed) {
             return startService()
                     .exceptionally(failWithMessage("Service failed to start."))
                     .thenAccept(na -> {
                         status.compareAndSet(STARTING, RUNNING);
-                        LOGGER.info("Started {}", name);
+                        LOGGER.debug("Started {}", name);
                     });
         } else {
             throw new IllegalStateException(format("Start '%s' called in %s state", name, status.get()));
@@ -90,13 +90,13 @@ public abstract class AbstractStyxService implements StyxService {
     public CompletableFuture<Void> stop() {
         boolean changed = status.compareAndSet(RUNNING, STOPPING);
 
-        LOGGER.info("Stopping {}", name);
+        LOGGER.debug("Stopping {}", name);
         if (changed) {
             return stopService()
                     .exceptionally(failWithMessage("Service failed to stop."))
                     .thenAccept(na -> {
                         status.compareAndSet(STOPPING, STOPPED);
-                        LOGGER.info("Stopped {}", name);
+                        LOGGER.debug("Stopped {}", name);
                     });
         } else {
             throw new IllegalStateException(format("Service '%s' stopped in %s state", name, status.get()));

--- a/components/client/src/test/integration/resources/logback.xml
+++ b/components/client/src/test/integration/resources/logback.xml
@@ -16,7 +16,7 @@
 
   <logger name="Styx-Tests" level="INFO"/>
   <logger name="com.hotels.styx.client.OriginsInventory" level="INFO"/>
-  <logger name="com.hotels.styx.http-messages.inbound" level="INFO"/>
+  <logger name="com.hotels.styx.http-messages.inbound" level="WARN"/>
   <logger name="com.hotels.styx.http-messages.outbound" level="INFO"/>
   <logger name="com.hotels.styx.client.OriginRestrictionLoadBalancingStrategy" level="INFO"/>
   <logger name="com.hotels.styx.common.content.FlowControllingHttpContentProducer" level="INFO"/>

--- a/components/client/src/test/unit/resources/logback.xml
+++ b/components/client/src/test/unit/resources/logback.xml
@@ -15,7 +15,7 @@
 
   <logger name="Styx-Tests" level="INFO"/>
   <logger name="com.hotels.styx.client.OriginsInventory" level="INFO"/>
-  <logger name="com.hotels.styx.http-messages.inbound" level="INFO"/>
+  <logger name="com.hotels.styx.http-messages.inbound" level="WARN"/>
   <logger name="com.hotels.styx.http-messages.outbound" level="INFO"/>
   <logger name="com.hotels.styx.client.OriginRestrictionLoadBalancingStrategy" level="INFO"/>
 

--- a/components/common/src/main/java/com/hotels/styx/NettyExecutor.java
+++ b/components/common/src/main/java/com/hotels/styx/NettyExecutor.java
@@ -49,13 +49,13 @@ public class NettyExecutor {
      */
     public static NettyExecutor create(String name, int count) {
         if (Epoll.isAvailable()) {
-            LOG.info("Epoll is available. Using the native socket transport.");
+            LOG.debug("Epoll is available. Using the native socket transport.");
             return new NettyExecutor(
                     epollEventLoopGroup(count, name + "-%d-Thread"),
                     EpollServerSocketChannel.class,
                     EpollSocketChannel.class);
         } else {
-            LOG.info("Epoll not available. Using nio socket transport.");
+            LOG.debug("Epoll not available. Using nio socket transport.");
             return new NettyExecutor(
                     nioEventLoopGroup(count, name + "-%d-Thread"),
                     NioServerSocketChannel.class,

--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -396,7 +396,7 @@ public final class StyxServer extends AbstractService {
 
         @Override
         public void stopped() {
-            LOG.info("Stopped phase 2 services");
+            LOG.debug("Stopped phase 2 services");
         }
     }
 
@@ -409,7 +409,7 @@ public final class StyxServer extends AbstractService {
 
         @Override
         public void healthy() {
-            LOG.info("Started phase 1 services");
+            LOG.debug("Started phase 1 services");
         }
 
         @Override
@@ -420,7 +420,7 @@ public final class StyxServer extends AbstractService {
 
         @Override
         public void stopped() {
-            LOG.info("Stopped phase 1 services.");
+            LOG.debug("Stopped phase 1 services.");
             styxServer.notifyStopped();
         }
     }

--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -86,6 +86,7 @@ public final class StyxServer extends AbstractService {
     private final StyxServerComponents components;
     private NettyExecutor proxyBossExecutor;
     private NettyExecutor proxyWorkerExecutor;
+    private boolean showBanner;
 
     public static void main(String[] args) {
         try {
@@ -115,6 +116,7 @@ public final class StyxServer extends AbstractService {
                 .styxConfig(parseConfiguration(startupConfig))
                 .startupConfig(startupConfig)
                 .loggingSetUp(environment -> activateLogbackConfigurer(startupConfig))
+                .showBanner(true)
                 .build();
 
         return new StyxServer(components, stopwatch);
@@ -216,6 +218,7 @@ public final class StyxServer extends AbstractService {
         services2.add(toGuavaService(new ServiceProviderMonitor<>("Styx-Server-Monitor", components.serversDatabase())));
 
         this.phase2Services = new ServiceManager(services2);
+        this.showBanner = components.showBanner();
     }
 
     public InetSocketAddress serverAddress(String name) {
@@ -325,6 +328,10 @@ public final class StyxServer extends AbstractService {
     }
 
     private void printBanner() {
+        if (!showBanner) {
+            return;
+        }
+
         try {
             try (Reader reader = new InputStreamReader(getClass().getResourceAsStream("/banner.txt"))) {
                 LOG.info(format("Starting styx %n{}"), CharStreams.toString(reader));

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -118,7 +118,7 @@ public class AdminServerBuilder {
     }
 
     public InetServer build() {
-        LOG.info("event bus that will be used is {}", environment.eventBus());
+        LOG.debug("event bus that will be used is {}", environment.eventBus());
         StyxConfig styxConfig = environment.configuration();
         AdminServerConfig adminServerConfig = styxConfig.adminServerConfig();
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderRoutingHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderRoutingHandler.java
@@ -83,7 +83,7 @@ public class ProviderRoutingHandler implements WebServiceHandler {
     }
 
     private void refreshRoutes(ObjectStore<? extends StyxObjectRecord<? extends StyxService>> db) {
-        LOG.info("Refreshing provider admin endpoint routes");
+        LOG.debug("Refreshing provider admin endpoint routes");
         router = buildRouter(db);
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
@@ -88,6 +88,7 @@ public class StyxServerComponents {
     private final RoutingObjectFactory.Context routingObjectContext;
     private final StartupConfig startupConfig;
     private final NettyExecutor executor;
+    private final boolean showBanner;
 
     // CHECKSTYLE:OFF
     private StyxServerComponents(Builder builder) {
@@ -191,6 +192,8 @@ public class StyxServerComponents {
                     StyxObjectRecord<InetServer> record = new StyxObjectRecord<>(definition.type(), ImmutableSet.copyOf(definition.tags()), definition.config(), provider);
                     serverObjectStore.insert(name, record);
                 });
+
+        this.showBanner = builder.showBanner;
     }
     // CHECKSTYLE:ON
 
@@ -206,6 +209,10 @@ public class StyxServerComponents {
         );
 
         return handlers;
+    }
+
+    public boolean showBanner() {
+        return showBanner;
     }
 
     public Environment environment() {
@@ -291,6 +298,7 @@ public class StyxServerComponents {
         private ServicesLoader servicesLoader = SERVICES_FROM_CONFIG;
         private MetricRegistry metricRegistry = new CodaHaleMetricRegistry();
         private StartupConfig startupConfig;
+        private boolean showBanner;
 
         private final Map<String, RoutingObjectFactory> additionalRoutingObjectFactories = new HashMap<>();
         private final Map<String, StyxService> additionalServices = new HashMap<>();
@@ -334,6 +342,7 @@ public class StyxServerComponents {
             }).collect(toList());
         }
 
+
         public Builder pluginFactories(List<ConfiguredPluginFactory> configuredPluginFactories) {
             this.configuredPluginFactories = requireNonNull(configuredPluginFactories);
             return this;
@@ -359,6 +368,11 @@ public class StyxServerComponents {
         @VisibleForTesting
         public Builder additionalRoutingObjects(Map<String, RoutingObjectFactory> additionalRoutingObjectFactories) {
             this.additionalRoutingObjectFactories.putAll(additionalRoutingObjectFactories);
+            return this;
+        }
+
+        public Builder showBanner(boolean showBanner) {
+            this.showBanner = showBanner;
             return this;
         }
 

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/HttpMessageLoggingInterceptorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/interceptors/HttpMessageLoggingInterceptorTest.java
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx.proxy.interceptors;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpVersion;
@@ -22,6 +24,7 @@ import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.common.format.HttpMessageFormatter;
 import com.hotels.styx.support.matchers.LoggingTestSupport;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 import static ch.qos.logback.classic.Level.INFO;
@@ -57,11 +61,23 @@ public class HttpMessageLoggingInterceptorTest {
     @Mock
     private HttpMessageFormatter httpMessageFormatter;
 
+    private Runnable resetLevel;
+
     @BeforeAll
     public void setup() {
+        Logger logger = (Logger) LoggerFactory.getLogger("com.hotels.styx.http-messages.inbound");
+        Level previousLevel = logger.getLevel();
+        logger.setLevel(INFO);
+        resetLevel = () -> logger.setLevel(previousLevel);
+
         MockitoAnnotations.initMocks(this);
         when(httpMessageFormatter.formatRequest(any(LiveHttpRequest.class))).thenReturn(FORMATTED_REQUEST);
         when(httpMessageFormatter.formatResponse(any(LiveHttpResponse.class))).thenReturn(FORMATTED_RESPONSE);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        resetLevel.run();
     }
 
     @BeforeEach

--- a/components/proxy/src/test/resources/logback.xml
+++ b/components/proxy/src/test/resources/logback.xml
@@ -18,7 +18,7 @@
   <logger name="com.hotels.styx.startup.extensions.FailureHandling" level="INFO"/>
   <logger name="com.hotels.styx.proxy.HttpErrorStatusCauseLogger" level="INFO"/>
   <logger name="com.hotels.styx.startup.ProxyServerSetUp" level="INFO"/>
-  <logger name="com.hotels.styx.http-messages.inbound" level="INFO"/>
+  <logger name="com.hotels.styx.http-messages.inbound" level="WARN"/>
   <logger name="com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry" level="INFO"/>
   <logger name="com.hotels.styx.metrics.reporting.graphite.GraphiteReporterService" level="INFO"/>
   <logger name="com.hotels.styx.metrics.reporting.graphite.GraphiteReporter" level="INFO"/>

--- a/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/NettyServer.java
@@ -102,7 +102,7 @@ final class NettyServer extends AbstractStyxService implements InetServer {
 
     @Override
     protected CompletableFuture<Void> startService() {
-        LOGGER.info("starting services");
+        LOGGER.debug("starting services");
 
         CompletableFuture<Void> serviceFuture = new CompletableFuture<>();
 
@@ -132,7 +132,7 @@ final class NettyServer extends AbstractStyxService implements InetServer {
                         Channel channel = future.channel();
                         channelGroup.add(channel);
                         address = (InetSocketAddress) channel.localAddress();
-                        LOGGER.info("server connector {} bound successfully on port {} socket port {}", new Object[]{serverConnector.getClass(), port, address});
+                        LOGGER.debug("server connector {} bound successfully on port {} socket port {}", new Object[]{serverConnector.getClass(), port, address});
                         serviceFuture.complete(null);
                     } else {
                         LOGGER.warn("Failed to start service={} cause={}", this, future.cause());

--- a/system-tests/e2e-suite/src/test/resources/conf/logback/logback.xml
+++ b/system-tests/e2e-suite/src/test/resources/conf/logback/logback.xml
@@ -12,6 +12,7 @@
   <logger name="org.apache" level="WARN"/>
   <logger name="io.netty" level="WARN"/>
   <logger name="com.hotels.styx.proxy.backends.file.FileChangeMonitor" level="INFO"/>
+  <!-- TODO why do we have another logback config file? Do we need to include anything here? If not, leave a comment explaining -->
 
   <root level="OFF">
     <appender-ref ref="CONSOLE"/>

--- a/system-tests/e2e-suite/src/test/resources/conf/logback/logback.xml
+++ b/system-tests/e2e-suite/src/test/resources/conf/logback/logback.xml
@@ -12,7 +12,8 @@
   <logger name="org.apache" level="WARN"/>
   <logger name="io.netty" level="WARN"/>
   <logger name="com.hotels.styx.proxy.backends.file.FileChangeMonitor" level="INFO"/>
-  <!-- TODO why do we have another logback config file? Do we need to include anything here? If not, leave a comment explaining -->
+  <logger name="com.google.common.util.concurrent.ServiceManager" level="ERROR" />
+  <logger name="com.hotels.styx.NettyExecutor" level="ERROR" />
 
   <root level="OFF">
     <appender-ref ref="CONSOLE"/>

--- a/system-tests/e2e-suite/src/test/resources/logback.xml
+++ b/system-tests/e2e-suite/src/test/resources/logback.xml
@@ -15,7 +15,7 @@
   </root>
 
   <logger name="Styx-Tests" level="INFO"/>
-  <logger name="com.hotels.styx.http-messages.inbound" level="DEBUG"/>
+  <logger name="com.hotels.styx.http-messages.inbound" level="WARN"/>
   <logger name="com.hotels.styx.http-messages.outbound" level="INFO"/>
   <logger name="com.hotels.styx.proxy.backends.file.FileChangeMonitor" level="INFO"/>
   <logger name="com.hotels.styx.proxy.encoders.ConfigurableUnwiseCharsEncoder" level="INFO"/>

--- a/system-tests/e2e-suite/src/test/resources/logback.xml
+++ b/system-tests/e2e-suite/src/test/resources/logback.xml
@@ -15,12 +15,14 @@
   </root>
 
   <logger name="Styx-Tests" level="INFO"/>
-  <logger name="com.hotels.styx.http-messages.inbound" level="INFO"/>
+  <logger name="com.hotels.styx.http-messages.inbound" level="DEBUG"/>
   <logger name="com.hotels.styx.http-messages.outbound" level="INFO"/>
   <logger name="com.hotels.styx.proxy.backends.file.FileChangeMonitor" level="INFO"/>
   <logger name="com.hotels.styx.proxy.encoders.ConfigurableUnwiseCharsEncoder" level="INFO"/>
   <logger name="com.hotels.styx.server.netty.connectors.HttpPipelineHandler" level="INFO"/>
   <logger name="com.hotels.styx.proxy.HttpErrorStatusCauseLogger" level="INFO"/>
   <logger name="com.hotels.styx.server.netty.connectors.HttpPipelineHandler" level="INFO"/>
+  <logger name="com.hotels.styx.common.content.FlowControllingHttpContentProducer" level="ERROR" />
+  <logger name="com.google.common.util.concurrent.ServiceManager" level="ERROR" />
 
 </configuration>

--- a/system-tests/ft-suite/src/test/resources/conf/logback/logback.xml
+++ b/system-tests/ft-suite/src/test/resources/conf/logback/logback.xml
@@ -10,7 +10,7 @@
   </appender>
 
   <logger name="Styx-Tests" level="INFO"/>
-  <logger name="com.hotels.styx.http-messages.inbound" level="INFO"/>
+  <logger name="com.hotels.styx.http-messages.inbound" level="WARN"/>
   <logger name="com.hotels.styx.http-messages.outbound" level="INFO"/>
 
   <logger name="io.netty" level="WARN"/>

--- a/system-tests/ft-suite/src/test/resources/logback.xml
+++ b/system-tests/ft-suite/src/test/resources/logback.xml
@@ -15,7 +15,7 @@
   </root>
 
   <logger name="Styx-Tests" level="INFO"/>
-  <logger name="com.hotels.styx.http-messages.inbound" level="INFO"/>
+  <logger name="com.hotels.styx.http-messages.inbound" level="WARN"/>
   <logger name="com.hotels.styx.http-messages.outbound" level="INFO"/>
   <logger name="com.hotels.styx.StyxServer" level="ERROR"/>
   <logger name="com.hotels.styx.client.netty.connectionpool.HttpRequestOperation" level="WARN"/>


### PR DESCRIPTION
Styx builds produce very large logs, with one recent example failing its travis build because the log size limit was exceeded.
This PR aims to reduce the size of the log without hiding any important information.

Reduction of build log size was accomplished through two means:
* Changing the logback.xml settings in test resources to block output of info and warnings that do not matter for tests.
* Changing code that unnecessarily logs at "info" level when "debug" would be more appropriate.

Limitation of this change: as the PR mostly focuses on number of log entries rather than size of log entries, there will probably still be some lines cluttering the logs that are relatively few in number but have large stack traces.


The exact number of lines removed will vary from build to build, but in my local tests, it cut the log down from ~18800 to ~10900 lines, a reduction of about ~40%, however, building locally seems to skip some of the tests, which is a separate problem we need to look into. I realised this after naming the PR, but it can't be changed.