### PR TITLE
Correct parent module for test-api

### DIFF
--- a/components/test-api/pom.xml
+++ b/components/test-api/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>styx-support</artifactId>
     <groupId>com.hotels.styx</groupId>
+    <artifactId>styx-components</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
The parent module for `test-api` was incorrectly left as `support` after moving it. This corrects it to `components`.