### PR TITLE
Update outdated dependencies

### DIFF
--- a/components/common/src/main/java/com/hotels/styx/common/io/FileResourceIterator.java
+++ b/components/common/src/main/java/com/hotels/styx/common/io/FileResourceIterator.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2018 Expedia Inc.
+  Copyright (C) 2013-2021 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static com.google.common.io.Files.fileTreeTraverser;
+import static com.google.common.io.Files.fileTraverser;
 import static java.util.stream.StreamSupport.stream;
 
 /**
@@ -33,7 +33,7 @@ public class FileResourceIterator implements Iterator<Resource> {
 
     public FileResourceIterator(File root, File file, String suffix) {
         File absolutePath = root.toPath().resolve(file.toPath()).toFile();
-        Iterable<File> children = fileTreeTraverser().postOrderTraversal(absolutePath);
+        Iterable<File> children = fileTraverser().depthFirstPostOrder(absolutePath);
         this.resourceIterator = stream(children.spliterator(), false)
                 .filter(hasSuffix(suffix).or(sameFile(file)))
                 .map(fileToResource(file))

--- a/components/proxy/src/test/java/com/hotels/styx/applications/yaml/YamlApplicationsProviderTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/applications/yaml/YamlApplicationsProviderTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2021 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -225,7 +225,7 @@ public class YamlApplicationsProviderTest {
     public void cannotLoadWithSyntaxErrors() throws IOException {
         Exception e = assertThrows(RuntimeException.class,
                 () -> loadFromPath("classpath:/conf/origins/origins-with-syntax-error-for-configtest.yml"));
-        assertThat(e.getMessage(), matchesPattern("Invalid YAML from classpath:conf/origins/origins-with-syntax-error-for-configtest.yml: Cannot deserialize instance of `java.util.ArrayList<com.hotels.styx.api.extension.service.BackendService>` out of VALUE_STRING token\n at \\[Source: .*\\]"));
+        assertThat(e.getMessage(), matchesPattern("Invalid YAML from classpath:conf/origins/origins-with-syntax-error-for-configtest.yml: Cannot deserialize value of type `java.util.ArrayList<com.hotels.styx.api.extension.service.BackendService>` from String value \\(token `JsonToken.VALUE_STRING`\\)\n at \\[Source: .*]"));
     }
 
     private static BackendService applicationFor(YamlApplicationsProvider provider, String appName) {

--- a/components/proxy/src/test/java/com/hotels/styx/infrastructure/logging/ExceptionConverterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/infrastructure/logging/ExceptionConverterTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2019 Expedia Inc.
+  Copyright (C) 2013-2020 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/test/java/com/hotels/styx/infrastructure/logging/ExceptionConverterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/infrastructure/logging/ExceptionConverterTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2020 Expedia Inc.
+  Copyright (C) 2013-2021 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <bytebuddy.version>1.10.6</bytebuddy.version>
 
     <!--Kotlin -->
-    <kotlin.version>1.3.61</kotlin.version>
+    <kotlin.version>1.4.32</kotlin.version>
     <kotlintest.version>3.4.2</kotlintest.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     <kotlinx.html.version>0.6.12</kotlinx.html.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
     <antlr.version>4.5.1-1</antlr.version>
     <netty.version>4.1.49.Final</netty.version>
     <netty-tcnative.version>2.0.26.Final</netty-tcnative.version>
-    <reactive-streams.version>1.0.2</reactive-streams.version>
-    <reactor.version>3.3.0.RELEASE</reactor.version>
+    <reactive-streams.version>1.0.3</reactive-streams.version>
+    <reactor.version>3.4.4</reactor.version>
     <pcollections.version>3.0.3</pcollections.version>
     <bytebuddy.version>1.10.6</bytebuddy.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <netty-tcnative.classifier>linux-x86_64</netty-tcnative.classifier>
 
     <!-- General Versions -->
-    <guava.version>24.1.1-jre</guava.version>
+    <guava.version>29.0-jre</guava.version>
     <jackson.version>2.12.1</jackson.version>
     <jackson.dataformat.version>${jackson.version}</jackson.dataformat.version>
     <jackson.module.scala.version>${jackson.version}</jackson.module.scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,10 +106,10 @@
 
     <!-- General Versions -->
     <guava.version>24.1.1-jre</guava.version>
-    <jackson.version>2.10.5</jackson.version>
-    <jackson.dataformat.version>2.10.5</jackson.dataformat.version>
-    <jackson.module.scala.version>2.10.5</jackson.module.scala.version>
-    <jackson-module-kotlin.version>2.10.5</jackson-module-kotlin.version>
+    <jackson.version>2.12.1</jackson.version>
+    <jackson.dataformat.version>${jackson.version}</jackson.dataformat.version>
+    <jackson.module.scala.version>${jackson.version}</jackson.module.scala.version>
+    <jackson-module-kotlin.version>${jackson.version}</jackson-module-kotlin.version>
     <metrics.version>4.0.5</metrics.version>
     <antlr.version>4.5.1-1</antlr.version>
     <netty.version>4.1.49.Final</netty.version>


### PR DESCRIPTION
This PR updates a few dependencies. Two of the updates; guava and jackson; were marked for us as security vulnerabilities by GitHub's dependabot. I also included some other updates at the same time.

A java code file had to be changed due to the guava update. This is because the previously used API was removed and replaced (it seems this part of guava is considered "beta" and thus more subject to breaking changes).