### PR TITLE
Update build version to java11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: trusty
 language: java
 jdk:
-  - openjdk8
   - openjdk11
 script: mvn verify -Pquality,linux
 cache:
@@ -13,14 +12,14 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
-    jdk: openjdk8
+    jdk: openjdk11
     repo: HotelsDotCom/styx
 - provider: script
   script: chmod +x travis/deploy.sh && travis/deploy.sh
   skip_cleanup: true
   on:
     tags: true
-    jdk: openjdk8
+    jdk: openjdk11
     repo: HotelsDotCom/styx
 - provider: releases
   api_key: $GIT_TOKEN
@@ -29,5 +28,5 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    jdk: openjdk8
+    jdk: openjdk11
     repo: HotelsDotCom/styx

--- a/docker/styx-build/Dockerfile
+++ b/docker/styx-build/Dockerfile
@@ -8,7 +8,7 @@ ENV MVN_INSTALL_DIR=/opt/mvn
 
 WORKDIR ${APP_HOME}
 
-RUN yum install -y java-1.8.0-openjdk-devel \
+RUN yum install -y java-11-openjdk-devel \
     && yum install -y git \
     && yum install -y bash-completion \
     && yum install -y docker \

--- a/pom.xml
+++ b/pom.xml
@@ -96,10 +96,10 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.source>1.8</java.source>
-    <java.target>1.8</java.target>
-    <java.testSource>1.8</java.testSource>
-    <java.testTarget>1.8</java.testTarget>
+    <java.source>11</java.source>
+    <java.target>11</java.target>
+    <java.testSource>11</java.testSource>
+    <java.testTarget>11</java.testTarget>
 
     <!-- Build defaults to linux platform: -->
     <netty-tcnative.classifier>linux-x86_64</netty-tcnative.classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
-    <maven-compiler-plugin.version>3.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>1.2</maven-enforcer-plugin.version>
@@ -628,7 +628,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.3</version>
+          <version>${maven-compiler-plugin.version}</version>
           <configuration>
             <source>${java.source}</source>
             <target>${java.target}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
   <properties>
 
-    <!-- common build properties -->
+    <!-- common build properties  -->
     <wiki.url>${project.url}</wiki.url>
     <maven.build.timestamp.format>yyyy-MM-dd|HH\:mm\:ss</maven.build.timestamp.format>
     <timestamp>${maven.build.timestamp}</timestamp>


### PR DESCRIPTION
Currently Styx is built with Java 8, the previous long-term-support version from 2014.
This PR will update it to build with Java 11, which is the latest long-term-support version (from 2018).

See also https://en.wikipedia.org/wiki/Java_version_history