### PR TITLE
Update maven-javadoc-plugin from 3.1.1 to 3.2.0 and disable for proxy module

### DIFF
--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -186,6 +186,18 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven-javadoc-plugin.version}</version>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <resources>
       <resource>
         <directory>src/main/resources</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
     <maven-pmd-plugin.version>3.5</maven-pmd-plugin.version>
-    <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
     <maven-project-info-reports-plugin.version>2.6</maven-project-info-reports-plugin.version>
     <maven-release-plugin.version>2.4</maven-release-plugin.version>
     <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
@@ -1008,7 +1008,6 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
 
   </build>


### PR DESCRIPTION
The main Styx build was [failing](https://travis-ci.org/github/HotelsDotCom/styx/builds/766896976?utm_source=github_status&utm_medium=notification) because of the `maven-javadoc-plugin` being unable to process Java files with references to classes/packages defined in Kotlin source.

Updating the plugin does not fix this, unfortunately, which is why the configuration for the `proxy` module has been set to skip it. It should be noted that the plugin is not able to process Kotlin code anyway, so even if it was working, it would still be missing information.

In future, we should find a solution for documenting the APIs that will work for both languages, but for now, this PR should get the build passing again.