### PR TITLE
Update guava to 30.0 jre

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -18,7 +18,6 @@ package com.hotels.styx;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.CharStreams;
 import com.google.common.util.concurrent.AbstractService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
 import com.hotels.styx.admin.AdminServerBuilder;

--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2020 Expedia Inc.
+  Copyright (C) 2013-2021 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.hotels.styx;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.CharStreams;
 import com.google.common.util.concurrent.AbstractService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
 import com.hotels.styx.admin.AdminServerBuilder;
@@ -47,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.hotels.styx.StyxServers.toGuavaService;
 import static com.hotels.styx.infrastructure.logging.LOGBackConfigurer.initLogging;
 import static com.hotels.styx.infrastructure.logging.LOGBackConfigurer.shutdownLogging;
@@ -304,10 +306,10 @@ public final class StyxServer extends AbstractService {
         printBanner();
         CompletableFuture.runAsync(() -> {
             // doStart should return quicly. Therefore offload waiting on a separate thread:
-            this.phase1Services.addListener(new Phase1ServerStatusListener(this));
+            this.phase1Services.addListener(new Phase1ServerStatusListener(this), directExecutor());
             this.phase1Services.startAsync().awaitHealthy();
 
-            this.phase2Services.addListener(new Phase2ServerStatusListener(this));
+            this.phase2Services.addListener(new Phase2ServerStatusListener(this), directExecutor());
             this.phase2Services.startAsync();
         });
     }

--- a/components/proxy/src/main/kotlin/com/hotels/styx/ServiceProviderMonitor.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/ServiceProviderMonitor.kt
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx;
 
-import com.google.common.util.concurrent.MoreExecutors
 import com.google.common.util.concurrent.MoreExecutors.directExecutor
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
@@ -25,7 +24,6 @@ import com.hotels.styx.api.extension.service.spi.AbstractStyxService
 import com.hotels.styx.api.extension.service.spi.StyxService
 import com.hotels.styx.routing.db.StyxObjectStore
 import org.slf4j.LoggerFactory.getLogger
-import java.lang.IllegalStateException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicReference
 

--- a/components/proxy/src/main/kotlin/com/hotels/styx/ServiceProviderMonitor.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/ServiceProviderMonitor.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2020 Expedia Inc.
+  Copyright (C) 2013-2021 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package com.hotels.styx;
 
+import com.google.common.util.concurrent.MoreExecutors
+import com.google.common.util.concurrent.MoreExecutors.directExecutor
 import com.google.common.util.concurrent.Service
 import com.google.common.util.concurrent.ServiceManager
 import com.google.common.util.concurrent.ServiceManager.Listener
@@ -53,7 +55,7 @@ internal class ServiceProviderMonitor<T : StyxObjectRecord<out StyxService>>(nam
             override fun failure(service: Service) {
                 future.completeExceptionally(service.failureCause())
             }
-        })
+        }, directExecutor())
 
         manager.get().startAsync()
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <netty-tcnative.classifier>linux-x86_64</netty-tcnative.classifier>
 
     <!-- General Versions -->
-    <guava.version>29.0-jre</guava.version>
+    <guava.version>30.0-jre</guava.version>
     <jackson.version>2.12.1</jackson.version>
     <jackson.dataformat.version>${jackson.version}</jackson.dataformat.version>
     <jackson.module.scala.version>${jackson.version}</jackson.module.scala.version>


### PR DESCRIPTION
GitHub's Dependabot is a little unclear on this. It says 
> We found potential security vulnerabilities in your dependencies.

But after clicking through it says
>  No security update is needed as com.google.guava:guava is no longer vulnerable 

Regardless, it's a very small change, so I made a PR anyway.