### PR TITLE
Fix nullability mistake

### DIFF
--- a/components/proxy/src/main/kotlin/com/hotels/styx/proxy/plugin/NamedPlugin.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/proxy/plugin/NamedPlugin.kt
@@ -22,7 +22,7 @@ interface NamedPlugin : Plugin {
     @VisibleForTesting
     fun originalPlugin(): Plugin
 
-    fun name(): String?
+    fun name(): String
 
     fun setEnabled(enabled: Boolean)
 


### PR DESCRIPTION
This PR only removes a single character, but it is necessary to prevent a return type from being incorrectly nullable.